### PR TITLE
update cpu and memory allocation to match old prod

### DIFF
--- a/terraform/terraform_environment/ecs_admin.tf
+++ b/terraform/terraform_environment/ecs_admin.tf
@@ -59,8 +59,8 @@ resource "aws_ecs_task_definition" "admin" {
   family                   = "${local.environment}-admin"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 2048
-  memory                   = 4096
+  cpu                      = 512
+  memory                   = 1024
   container_definitions    = "[${local.admin_web}, ${local.admin_app}]"
   task_role_arn            = aws_iam_role.admin_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn

--- a/terraform/terraform_environment/ecs_admin.tf
+++ b/terraform/terraform_environment/ecs_admin.tf
@@ -59,8 +59,8 @@ resource "aws_ecs_task_definition" "admin" {
   family                   = "${local.environment}-admin"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 512
-  memory                   = 1024
+  cpu                      = 2048
+  memory                   = 4096
   container_definitions    = "[${local.admin_web}, ${local.admin_app}]"
   task_role_arn            = aws_iam_role.admin_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn

--- a/terraform/terraform_environment/ecs_api.tf
+++ b/terraform/terraform_environment/ecs_api.tf
@@ -100,8 +100,8 @@ resource "aws_ecs_task_definition" "api" {
   family                   = "${terraform.workspace}-api"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 512
-  memory                   = 1024
+  cpu                      = 2048
+  memory                   = 4096
   container_definitions    = "[${local.api_web}, ${local.api_app}]"
   task_role_arn            = "${aws_iam_role.api_task_role.arn}"
   execution_role_arn       = "${aws_iam_role.execution_role.arn}"

--- a/terraform/terraform_environment/ecs_front.tf
+++ b/terraform/terraform_environment/ecs_front.tf
@@ -59,8 +59,8 @@ resource "aws_ecs_task_definition" "front" {
   family                   = "${local.environment}-front"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 512
-  memory                   = 1024
+  cpu                      = 2048
+  memory                   = 4096
   container_definitions    = "[${local.front_web}, ${local.front_app}]"
   task_role_arn            = aws_iam_role.front_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn

--- a/terraform/terraform_environment/ecs_pdf.tf
+++ b/terraform/terraform_environment/ecs_pdf.tf
@@ -45,7 +45,7 @@ resource "aws_ecs_task_definition" "pdf" {
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 1024
-  memory                   = 4096
+  memory                   = 2048
   container_definitions    = "[${local.pdf_app}]"
   task_role_arn            = aws_iam_role.pdf_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn


### PR DESCRIPTION
Old production assigned the following instances to each part of the service

Service | EC2 Instance
-- | --
admin | T2.medium
api | T2.medium
front | T2.medium
pdf | T2.small


Instance Type | vCPUs | Memory | ECS CPU | ECS Memory
-- | -- | -- | -- | --
T2.medium | 2 | 4GB | 2048 | 4096
T2.small | 1 | 2GB | 1024 | 2048

Update ECS task definitions to match
