### PR TITLE
Bump PDF's CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # opg-lpa
-The Office of the Public Guardian Lasting Power of Attorney online service: Managed by opg-org-infra &amp; Terraform
+The Office of the Public Guardian Lasting Power of Attorney online service: Managed by opg-org-infra &amp; Terraform.

--- a/terraform/terraform_environment/ecs_pdf.tf
+++ b/terraform/terraform_environment/ecs_pdf.tf
@@ -44,8 +44,8 @@ resource "aws_ecs_task_definition" "pdf" {
   family                   = "${local.environment}-pdf"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 1024
-  memory                   = 2048
+  cpu                      = 2048
+  memory                   = 4096
   container_definitions    = "[${local.pdf_app}]"
   task_role_arn            = aws_iam_role.pdf_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn


### PR DESCRIPTION
I've run metrics on PDF generation with sizes 1 vCPU, 2 vCPU & 4 vCPU. 2 vCPU consistently demonstrates a much faster generation time than 1 vCPU, and - oddly - is often faster than 4 vCPU too.

This comes off the back of PDFs taking significantly longer to generation on ECS than EC2. 