### PR TITLE
LPA-3572 change LPA reference number to online LPA ID

### DIFF
--- a/service-front/module/Application/view/application/authenticated/lpa/complete/complete.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/complete/complete.twig
@@ -38,7 +38,7 @@
 
     {% endif %}
 
-    <p>Your LPA reference number is <strong class="bold-small">{{ formatLpaId(lpa.id) }}</strong></p>
+    <p>Your online LPA ID is <strong class="bold-small">{{ formatLpaId(lpa.id) }}</strong></p>
 
     <p>You're now ready to print and sign the {{ lpa.document.type == 'property-and-financial' ? 'property and financial affairs' : 'health and welfare' }} LPA for {{ lpa.document.donor.name }}, then post it to the Office of the Public Guardian.</p>
 

--- a/service-front/module/Application/view/application/authenticated/lpa/complete/view-docs.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/complete/view-docs.twig
@@ -25,7 +25,7 @@
 
 <div class="text">
 
-    <p>Your LPA reference number is <strong class="bold-small">{{ formatLpaId(lpa.id) }}</strong></p>
+    <p>Your online LPA ID is <strong class="bold-small">{{ formatLpaId(lpa.id) }}</strong></p>
 
     <p>You're now ready to print and sign the {{ lpa.document.type == 'property-and-financial' ? 'property and financial affairs' : 'health and welfare' }} LPA for {{ lpa.document.donor.name }}, then post it to the Office of the Public Guardian – if you have not already done so.</p>
 

--- a/service-front/module/Application/view/email/lpa-registration.twig
+++ b/service-front/module/Application/view/email/lpa-registration.twig
@@ -14,7 +14,7 @@
 </p>
 
 <p style="font-size: 19px; line-height: 1.315; margin: 0 0 20px 0; color: #0b0c0c">
-	LPA reference number: {{ formatLpaId(lpa.id) }}
+	Online LPA ID: {{ formatLpaId(lpa.id) }}
 </p>
 
 {% if lpa.payment.reference != null %}
@@ -29,7 +29,7 @@
 
 
 <p style="font-size: 19px; line-height: 1.315; margin: 0 0 20px 0; color: #0b0c0c">
-	If you have not already you should print off the LPA and sign before sending it to OPG. Instructions on the order people must sign are on the cover sheet of the LPA.
+	If you have not already, you should print off the LPA and sign before sending it to OPG. Instructions on the order people must sign are on the cover sheet of the LPA.
 </p>
 
 {% set viewDocsUrl = url('lpa/view-docs', {'lpa-id': lpa.id}, {'force_canonical': true}) %}


### PR DESCRIPTION
## Purpose

The 'online LPA ID' number (begins with 'A') is called the 'LPA reference number' in the service. This is incorrect, so I'm amending all references.


