### PR TITLE
Lpa 3576

### DIFF
--- a/pipeline_scripts/ecs_start_seeding_task.py
+++ b/pipeline_scripts/ecs_start_seeding_task.py
@@ -47,11 +47,6 @@ class ECSMonitor:
         self.get_seeding_task_definition()
         self.get_subnet_id()
 
-        # self.db_client_security_group = self.get_security_group_id('rds-client-{}'.format(
-        #     self.environment))
-        # self.seeding_security_group = self.get_security_group_id('{}-seeding-ecs-service'.format(
-        #     self.environment))
-
     def read_parameters_from_file(self, config_file):
         with open(config_file) as json_file:
             parameters = json.load(json_file)
@@ -90,20 +85,6 @@ class ECSMonitor:
             DurationSeconds=900
         )
         self.aws_iam_session = session
-
-    def get_security_group_id(self, security_group_name):
-      # get security group ids by security group name
-      # returns security group id
-        security_group_id = self.aws_ec2_client.describe_security_groups(
-            Filters=[
-                {
-                    'Name': 'group-name',
-                    'Values': [security_group_name + "*"]
-                },
-            ],
-            MaxResults=50
-        )['SecurityGroups'][0]['GroupId']
-        return security_group_id
 
     def get_subnet_id(self):
       # get ids for private subnets

--- a/pipeline_scripts/ecs_start_seeding_task.py
+++ b/pipeline_scripts/ecs_start_seeding_task.py
@@ -47,10 +47,10 @@ class ECSMonitor:
         self.get_seeding_task_definition()
         self.get_subnet_id()
 
-        self.db_client_security_group = self.get_security_group_id('rds-client-{}'.format(
-            self.environment))
-        self.seeding_security_group = self.get_security_group_id('{}-seeding-ecs-service'.format(
-            self.environment))
+        # self.db_client_security_group = self.get_security_group_id('rds-client-{}'.format(
+        #     self.environment))
+        # self.seeding_security_group = self.get_security_group_id('{}-seeding-ecs-service'.format(
+        #     self.environment))
 
     def read_parameters_from_file(self, config_file):
         with open(config_file) as json_file:
@@ -58,6 +58,8 @@ class ECSMonitor:
             self.aws_account_id = parameters['account_id']
             self.aws_ecs_cluster = parameters['cluster_name']
             self.environment = parameters['environment']
+            self.db_client_security_group = parameters['db_client_security_group_id']
+            self.seeding_security_group = parameters['seeding_security_group_id']
 
     def get_seeding_task_definition(self):
       # get the latest task definition for seeding

--- a/terraform/terraform_environment/config_file.tf
+++ b/terraform/terraform_environment/config_file.tf
@@ -1,5 +1,5 @@
 resource "local_file" "environment_pipeline_tasks_config" {
-  content  = "${jsonencode(local.environment_pipeline_tasks_config)}"
+  content  = jsonencode(local.environment_pipeline_tasks_config)
   filename = "/tmp/environment_pipeline_tasks_config.json"
 }
 
@@ -7,11 +7,13 @@ locals {
   front_fqdn = local.account_name == "production" ? "www.lastingpowerofattorney.service.gov.uk" : aws_route53_record.front.fqdn
 
   environment_pipeline_tasks_config = {
-    account_id   = local.account_id
-    cluster_name = aws_ecs_cluster.online-lpa.name
-    environment  = local.environment
-    front_fqdn   = local.front_fqdn
-    admin_fqdn   = aws_route53_record.admin.fqdn
-    tag          = var.container_version
+    account_id                  = local.account_id
+    cluster_name                = aws_ecs_cluster.online-lpa.name
+    environment                 = local.environment
+    front_fqdn                  = local.front_fqdn
+    admin_fqdn                  = aws_route53_record.admin.fqdn
+    tag                         = var.container_version
+    db_client_security_group_id = aws_security_group.rds-client.id
+    seeding_security_group_id   = aws_security_group.seeding_ecs_service.id
   }
 }


### PR DESCRIPTION
## Purpose
The python script to run the ecs seeding task failed to olook up security group IDs correctly.

Fixes LPA-3576

## Approach

Add the security group IDs to the pipeline config file instead and read them in.

## Learning

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
