### PR TITLE
Allow admin to check records for a user when searching via admin app

### DIFF
--- a/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
@@ -53,7 +53,7 @@ class ApplicationController extends AbstractLpaController
      */
     public function getList()
     {
-        $this->checkAccess();
+       // $this->checkAccess();
 
         $query = $this->params()->fromQuery();
 

--- a/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
@@ -53,8 +53,6 @@ class ApplicationController extends AbstractLpaController
      */
     public function getList()
     {
-       // $this->checkAccess();
-
         $query = $this->params()->fromQuery();
 
         //  If appropriate numeric values have been provided then get the correct page

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/ApplicationControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/ApplicationControllerTest.php
@@ -151,20 +151,7 @@ class ApplicationControllerTest extends AbstractControllerTest
         $this->assertNotNull($response);
         $this->assertInstanceOf(NoContent::class, $response);
     }
-
-    /**
-     * @expectedException ZfcRbac\Exception\UnauthorizedException
-     * @expectedExceptionMessage You do not have permission to access this service
-     */
-    public function testGetListUnauthorised()
-    {
-        $this->setAuthorised(false);
-
-        $controller = $this->getController();
-
-        $controller->getList();
-    }
-
+    
     public function testCreateSuccess()
     {
         $controller = $this->getController();

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/ApplicationControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/ApplicationControllerTest.php
@@ -151,7 +151,7 @@ class ApplicationControllerTest extends AbstractControllerTest
         $this->assertNotNull($response);
         $this->assertInstanceOf(NoContent::class, $response);
     }
-    
+
     public function testCreateSuccess()
     {
         $controller = $this->getController();


### PR DESCRIPTION
## Purpose
https://opgtransform.atlassian.net/browse/LPA-3571

Fixes LPA-3571

## Approach

Access permission was denying users application list to be searched by service call from admin app. Removed the access permission check to test.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
