### PR TITLE
create an autoscaling role for ecs autoscaling

### DIFF
--- a/terraform/account/autoscaling_role.tf
+++ b/terraform/account/autoscaling_role.tf
@@ -1,0 +1,3 @@
+resource "aws_iam_service_linked_role" "ecs_autoscaling_service_role" {
+  aws_service_name = "ecs.application-autoscaling.amazonaws.com"
+}


### PR DESCRIPTION
## Purpose
ECS autoscaling requires a Service Role for autoscaling permissions.

This is an account level shared resource.

Fixes LPA-3420

## Approach

The PR will bring the role under Terraform management so that further development can continue on PR https://github.com/ministryofjustice/opg-lpa/pull/96

## Learning

https://docs.aws.amazon.com/IAM/latest/UserGuide/using-service-linked-roles.html

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [x] The product team have tested these changes
