### PR TITLE
Lpa 3597  bsi ingress

### DIFF
--- a/terraform/environment/load_balancer_admin.tf
+++ b/terraform/environment/load_balancer_admin.tf
@@ -75,7 +75,7 @@ resource "aws_security_group_rule" "admin_loadbalancer_ingress_production" {
 }
 
 resource "aws_security_group_rule" "admin_loadbalancer_ingress_ithc" {
-  count             = local.environment != "production" ? 1 : 0
+  count             = local.environment == "preproduction" ? 1 : 0
   type              = "ingress"
   from_port         = 443
   to_port           = 443

--- a/terraform/environment/load_balancer_admin.tf
+++ b/terraform/environment/load_balancer_admin.tf
@@ -74,6 +74,16 @@ resource "aws_security_group_rule" "admin_loadbalancer_ingress_production" {
   security_group_id = aws_security_group.admin_loadbalancer.id
 }
 
+resource "aws_security_group_rule" "admin_loadbalancer_ingress_ithc" {
+  count             = local.environment != "production" ? 1 : 0
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["54.37.241.156/30"]
+  security_group_id = aws_security_group.admin_loadbalancer.id
+}
+
 resource "aws_security_group_rule" "admin_loadbalancer_egress" {
   type              = "egress"
   from_port         = 0

--- a/terraform/environment/load_balancer_front.tf
+++ b/terraform/environment/load_balancer_front.tf
@@ -75,7 +75,7 @@ resource "aws_security_group_rule" "front_loadbalancer_ingress_production" {
 }
 
 resource "aws_security_group_rule" "front_loadbalancer_ingress_ithc" {
-  count             = local.environment != "production" ? 1 : 0
+  count             = local.environment == "preproduction" ? 1 : 0
   type              = "ingress"
   from_port         = 443
   to_port           = 443

--- a/terraform/environment/load_balancer_front.tf
+++ b/terraform/environment/load_balancer_front.tf
@@ -74,6 +74,16 @@ resource "aws_security_group_rule" "front_loadbalancer_ingress_production" {
   security_group_id = aws_security_group.front_loadbalancer.id
 }
 
+resource "aws_security_group_rule" "front_loadbalancer_ingress_ithc" {
+  count             = local.environment != "production" ? 1 : 0
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["54.37.241.156/30"]
+  security_group_id = aws_security_group.front_loadbalancer.id
+}
+
 // Allow http traffic in to be redirected to https
 resource "aws_security_group_rule" "front_loadbalancer_ingress_http" {
   type              = "ingress"


### PR DESCRIPTION
## Purpose
The ITHC requires the Auditing company access to non-production services.

Fixes LPA-3597

## Approach

Create a security group rule for each load balancer allowing ingress from BSI's range.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [x] The product team have tested these changes
