### PR TITLE
fix arn for preproduction to point to dev gateway

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -24,7 +24,7 @@
       "front_certificate_domain_name": "front.preproduction.lpa.opg.service.justice.gov.uk",
       "admin_certificate_domain_name": "admin.preproduction.lpa.opg.service.justice.gov.uk",
       "sirius_api_gateway_endpoint": "https://api.dev.sirius.opg.digital/v1/lpa-online-tool/lpas/",
-      "sirius_api_gateway_arn": "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/lpa-online-tool/*",
+      "sirius_api_gateway_arn": "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/lpa-online-tool/*",
       "prevent_db_destroy": "false"
     },
     "production": {


### PR DESCRIPTION
## Purpose
The preproduction environment could not talk to the development of the Sirius API gateway.

Fixes LPA-3620

## Approach

The preproduction environment was pointed at the development Sirius API gateway, but the ARN for the access policy was incorrect.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
