### PR TITLE
LPA-3711 Script naming of Terraform Workspace and Docker Image Tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,30 +261,32 @@ orbs:
           - run:
               name: Push web container
               command: |
+                export IMAGE_TAG=$(bash ~/project/pipeline_scripts/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+                echo $IMAGE_TAG
                 if << parameters.build_web >> ; then
-                  export SHORT_HASH=${CIRCLE_SHA1:0:7} >> $BASH_ENV
-                  docker tag << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web:$CIRCLE_BRANCH-$SHORT_HASH
+                  docker tag << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web:${IMAGE_TAG}
                   if [ "${CIRCLE_BRANCH}" == "master" ]; then
                     # If master, push branch tag and latest
-                    docker tag << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web:$CIRCLE_BRANCH-$SHORT_HASH << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web:latest
+                    docker tag << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web:${IMAGE_TAG} << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web:latest
                     docker push << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web
                   else
                     # Else, push branch tag only
-                    docker push << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web:$CIRCLE_BRANCH-$SHORT_HASH
+                    docker push << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web:${IMAGE_TAG}
                   fi
                 fi
           - run:
               name: Push app container
               command: |
-                export SHORT_HASH=${CIRCLE_SHA1:0:7} >> $BASH_ENV
-                docker tag << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app:$CIRCLE_BRANCH-$SHORT_HASH
+                export IMAGE_TAG=$(bash ~/project/pipeline_scripts/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+                echo $IMAGE_TAG
+                docker tag << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app:${IMAGE_TAG}
                 if [ "${CIRCLE_BRANCH}" == "master" ]; then
                   # If master, push branch tag and latest
-                  docker tag << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app:$CIRCLE_BRANCH-$SHORT_HASH << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app:latest
+                  docker tag << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app:${IMAGE_TAG} << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app:latest
                   docker push << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app
                 else
                   # Else, push branch tag only
-                  docker push << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app:$CIRCLE_BRANCH-$SHORT_HASH
+                  docker push << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app:${IMAGE_TAG}
                 fi
 
   infrastructure_and_deployment:
@@ -356,13 +358,13 @@ orbs:
           - run:
               name: Lint Environment Terraform
               command: |
-                export SHORT_HASH=${CIRCLE_SHA1:0:7} >> $BASH_ENV
-                echo $SHORT_HASH
+                export IMAGE_TAG=$(bash ~/project/pipeline_scripts/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+                echo $IMAGE_TAG
                 cd ~/project/terraform/environment
                 terraform init -lock-timeout=300s
-                export TF_WORKSPACE=${ENV_NAME:0:13} >> $BASH_ENV
+                export TF_WORKSPACE=$(~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
-                terraform validate -var container_version=$CIRCLE_BRANCH-$SHORT_HASH
+                terraform validate -var container_version=${IMAGE_TAG}
 
       apply_email_terraform:
         #
@@ -382,7 +384,7 @@ orbs:
               command: |
                 cd ~/project/terraform/email
                 terraform init -lock-timeout=300s
-                export TF_WORKSPACE=<<parameters.workspace>>
+                export TF_WORKSPACE=$(~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 terraform apply -lock-timeout=300s --auto-approve
 
@@ -404,7 +406,7 @@ orbs:
               command: |
                 cd ~/project/terraform/account
                 terraform init -lock-timeout=300s
-                export TF_WORKSPACE=<<parameters.workspace>>
+                export TF_WORKSPACE=$(~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 terraform apply -lock-timeout=300s --auto-approve
 
@@ -425,14 +427,13 @@ orbs:
           - run:
               name: Apply Environment Terraform
               command: |
-                ENV_NAME=<<parameters.workspace>>
-                export SHORT_HASH=${CIRCLE_SHA1:0:7} >> $BASH_ENV
-                echo $SHORT_HASH
+                export IMAGE_TAG=$(bash ~/project/pipeline_scripts/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+                echo $IMAGE_TAG
                 cd ~/project/terraform/environment
                 terraform init -lock-timeout=300s
-                export TF_WORKSPACE=${ENV_NAME:0:13} >> $BASH_ENV
+                export TF_WORKSPACE=$(~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
-                terraform apply -lock-timeout=300s -auto-approve -parallelism=15 -var container_version=$CIRCLE_BRANCH-$SHORT_HASH
+                terraform apply -lock-timeout=300s -auto-approve -parallelism=15 -var container_version=${IMAGE_TAG}
                 export ENV_DOMAINS="$(terraform output)" >> $BASH_ENV
           - persist_to_workspace:
               root: /tmp
@@ -455,13 +456,12 @@ orbs:
           - run:
               name: Destroy Development Environment
               command: |
-                ENV_NAME=<<parameters.workspace>>
-                export TF_WORKSPACE=${ENV_NAME:0:13} >> $BASH_ENV
+                export TF_WORKSPACE=$(~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 if [ "${CIRCLE_BRANCH}" != "master" ]; then
                   cd ~/project/terraform/environment
                   terraform init -lock-timeout=300s
-                  export TF_WORKSPACE=${ENV_NAME:0:13} >> $BASH_ENV
+                  export TF_WORKSPACE=$(~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                   echo $TF_WORKSPACE
                   terraform destroy -lock-timeout=300s -auto-approve
                 fi
@@ -486,7 +486,7 @@ orbs:
           - run:
               name: Wait for new tasks in services to be running
               command: |
-                export TF_WORKSPACE=${ENV_NAME:0:13} >> $BASH_ENV
+                export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 python scripts/pipeline/ecs_monitor/ecs_monitor.py
           - run:
@@ -516,17 +516,16 @@ orbs:
           - run:
               name: Wait for new tasks in services to be running
               command: |
-                export TF_WORKSPACE=${ENV_NAME:0:13} >> $BASH_ENV
+                export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 python scripts/pipeline/ecs_monitor/ecs_monitor.py
           - run:
               name: Add CircleCI ingress to environment
               command: |
                 if [ <<parameters.workspace>> != "production" ]; then
-                  ENV_NAME=<<parameters.workspace>>
                   cd ~/project/terraform/account_ingress
                   terraform init -lock-timeout=300s
-                  export TF_WORKSPACE=${ENV_NAME:0:13} >> $BASH_ENV
+                  export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                   echo $TF_WORKSPACE
                   terraform apply -lock-timeout=300s -auto-approve
                 fi
@@ -538,10 +537,9 @@ orbs:
               name: Remove CircleCI ingress to environment
               command: |
                 if [ <<parameters.workspace>> != "production" ]; then
-                  ENV_NAME=<<parameters.workspace>>
                   cd ~/project/terraform/account_ingress
                   terraform init -lock-timeout=300s
-                  export TF_WORKSPACE=${ENV_NAME:0:13} >> $BASH_ENV
+                  export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                   echo $TF_WORKSPACE
                   terraform destroy -lock-timeout=300s -auto-approve
                 fi
@@ -579,24 +577,22 @@ orbs:
           - run:
               name: Get URLs
               command: |
-                ENV_NAME=<<parameters.workspace>>
-                echo 'export TF_WORKSPACE=${ENV_NAME:0:13}' >> $BASH_ENV
+                export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
-                echo 'export FRONT_DOMAIN="$(jq -r .front_fqdn /tmp/environment_pipeline_tasks_config.json)"' >> $BASH_ENV
+                scripts/pipeline/set_environment_variables/set_slack_env_vars.sh >> $BASH_ENV
           - run:
               name: Wait for new tasks in services to be running
               command: |
-                export TF_WORKSPACE=${ENV_NAME:0:13} >> $BASH_ENV
+                export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 python scripts/pipeline/ecs_monitor/ecs_monitor.py
           - run:
               name: Add CircleCI ingress to environment
               command: |
                 if [ <<parameters.workspace>> != "production" ]; then
-                  ENV_NAME=<<parameters.workspace>>
                   cd ~/project/terraform/account_ingress
                   terraform init -lock-timeout=300s
-                  export TF_WORKSPACE=${ENV_NAME:0:13} >> $BASH_ENV
+                  export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                   echo $TF_WORKSPACE
                   terraform apply -lock-timeout=300s -auto-approve -var docker_remote_ip=$DOCKER_REMOTE_IP
                 fi
@@ -609,10 +605,9 @@ orbs:
               name: Remove CircleCI ingress to environment
               command: |
                 if [ <<parameters.workspace>> != "production" ]; then
-                  ENV_NAME=<<parameters.workspace>>
                   cd ~/project/terraform/account_ingress
                   terraform init -lock-timeout=300s
-                  export TF_WORKSPACE=${ENV_NAME:0:13} >> $BASH_ENV
+                  export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                   echo $TF_WORKSPACE
                   terraform destroy -lock-timeout=300s -auto-approve
                 fi
@@ -634,8 +629,7 @@ jobs:
       - run:
           name: Get URLs
           command: |
-            ENV_NAME=<<parameters.workspace>>
-            scripts/pipeline/set_environment_variables/set_terraform_workspace_name.sh >> $BASH_ENV
+            export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
             echo $TF_WORKSPACE
             scripts/pipeline/set_environment_variables/set_slack_env_vars.sh >> $BASH_ENV
       - slack/notify:
@@ -658,8 +652,7 @@ jobs:
       - run:
           name: Get URLs
           command: |
-            ENV_NAME=<<parameters.workspace>>
-            echo 'export TF_WORKSPACE=${ENV_NAME:0:13}' >> $BASH_ENV
+            export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
             echo $TF_WORKSPACE
             scripts/pipeline/set_environment_variables/set_slack_env_vars.sh >> $BASH_ENV
       - slack/notify:
@@ -678,5 +671,6 @@ jobs:
           name: Check ECR Scan Results
           command: |
             sudo pip3 install -r scripts/pipeline/requirements.txt
-            export SHORT_HASH=${CIRCLE_SHA1:0:7} >> $BASH_ENV
-            python scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py --search online-lpa --tag $CIRCLE_BRANCH-$SHORT_HASH
+            export IMAGE_TAG=$(bash ~/project/pipeline_scripts/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+                echo $IMAGE_TAG
+            python scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py --search online-lpa --tag ${IMAGE_TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,54 +1,60 @@
 version: 2.1
 
 workflows:
-  pr-build-and-test:
+  pr_build:
     jobs:
       - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
           name: front_docker_build
           ecr_repository_name_prefix: online-lpa/front
           service_path: service-front
+          filters: { branches: { ignore: [master] } }
+
       - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
           name: admin_docker_build
           ecr_repository_name_prefix: online-lpa/admin
           service_path: service-admin
+          filters: { branches: { ignore: [master] } }
+
       - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
           name: api_docker_build
           ecr_repository_name_prefix: online-lpa/api
           service_path: service-api
+          filters: { branches: { ignore: [master] } }
+
       - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
           name: pdf_docker_build
           ecr_repository_name_prefix: online-lpa/pdf
           service_path: service-pdf
           build_web: false
+          filters: { branches: { ignore: [master] } }
+
       - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
           name: seeding_docker_build
           ecr_repository_name_prefix: online-lpa/seeding
           service_path: service-seeding
           build_web: false
           unit_test: false
+          filters: { branches: { ignore: [master] } }
 
       - infrastructure_and_deployment/lint_and_validate_terraform:
           name: lint_and_validate_terraform
-          filters:
-            branches:
-              ignore: master
+          filters: { branches: { ignore: [master] } }
 
       - infrastructure_and_deployment/apply_account_terraform:
           name: dev_account_apply_terraform
           workspace: development
+          filters: { branches: { ignore: [master] } }
           requires: [lint_and_validate_terraform]
-          filters:
-            branches:
-              ignore: master
+
       - infrastructure_and_deployment/apply_email_terraform:
           name: email_apply_terraform
           workspace: development
+          filters: { branches: { ignore: [master] } }
           requires: [lint_and_validate_terraform]
-          filters:
-            branches:
-              ignore: master
+
       - infrastructure_and_deployment/apply_environment_terraform:
           name: dev_environment_apply_terraform
+          filters: { branches: { ignore: [master] } }
           requires:
             [
               dev_account_apply_terraform,
@@ -58,9 +64,6 @@ workflows:
               pdf_docker_build,
               seeding_docker_build,
             ]
-          filters:
-            branches:
-              ignore: master
 
       - ecr_scan_results:
           name: ecr_scan_results_development
@@ -77,45 +80,74 @@ workflows:
 
       - infrastructure_and_deployment/seed_environment_databases:
           name: dev_seed_environment_databases
-          requires: [dev_environment_apply_terraform]
           filters: { branches: { ignore: [master] } }
+          requires: [dev_environment_apply_terraform]
 
       - infrastructure_and_deployment/run_functional_test:
           name: run_functional_test
+          filters: { branches: { ignore: [master] } }
           requires: [dev_seed_environment_databases]
-          filters:
-            branches:
-              ignore: master
 
       - slack_notify_domain:
           name: post_environment_domains
+          filters: { branches: { ignore: [master] } }
           requires: [run_functional_test]
-          filters:
-            branches:
-              ignore: master
 
       - hold-for-destruction:
           name: hold_env_for_destruction
           type: approval
+          filters: { branches: { ignore: [master] } }
           requires: [post_environment_domains]
-          filters:
-            branches:
-              ignore: master
+
       - infrastructure_and_deployment/destroy_dev_environment:
           name: dev_destroy_environment
+          filters: { branches: { ignore: [master] } }
           requires: [hold_env_for_destruction]
-          filters:
-            branches:
-              ignore: master
+
+  path_to_live:
+    jobs:
+      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+          name: front_docker_build
+          ecr_repository_name_prefix: online-lpa/front
+          service_path: service-front
+          filters: { branches: { only: [master] } }
+
+      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+          name: admin_docker_build
+          ecr_repository_name_prefix: online-lpa/admin
+          service_path: service-admin
+          filters: { branches: { only: [master] } }
+
+      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+          name: api_docker_build
+          ecr_repository_name_prefix: online-lpa/api
+          service_path: service-api
+          filters: { branches: { only: [master] } }
+
+      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+          name: pdf_docker_build
+          ecr_repository_name_prefix: online-lpa/pdf
+          service_path: service-pdf
+          build_web: false
+          filters: { branches: { only: [master] } }
+
+      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+          name: seeding_docker_build
+          ecr_repository_name_prefix: online-lpa/seeding
+          service_path: service-seeding
+          build_web: false
+          unit_test: false
+          filters: { branches: { only: [master] } }
 
       - infrastructure_and_deployment/apply_account_terraform:
           name: preprod_account_apply_terraform
           workspace: preproduction
-          filters:
-            branches:
-              only: master
+          filters: { branches: { only: [master] } }
+
       - infrastructure_and_deployment/apply_environment_terraform:
           name: preprod_environment_apply_terraform
+          workspace: preproduction
+          filters: { branches: { only: [master] } }
           requires:
             [
               preprod_account_apply_terraform,
@@ -124,10 +156,6 @@ workflows:
               api_docker_build,
               pdf_docker_build,
             ]
-          workspace: preproduction
-          filters:
-            branches:
-              only: master
 
       - ecr_scan_results:
           name: ecr_scan_results_master
@@ -144,46 +172,37 @@ workflows:
       - infrastructure_and_deployment/seed_environment_databases:
           name: preprod_seed_environment_databases
           workspace: preproduction
-          requires: [preprod_environment_apply_terraform]
           filters: { branches: { only: [master] } }
+          requires: [preprod_environment_apply_terraform]
 
       - infrastructure_and_deployment/run_functional_test:
           name: preprod_test_functional
-          requires: [preprod_seed_environment_databases]
           workspace: preproduction
-          filters:
-            branches:
-              only: master
+          filters: { branches: { only: [master] } }
+          requires: [preprod_seed_environment_databases]
 
       - infrastructure_and_deployment/apply_account_terraform:
           name: prod_account_apply_terraform
           workspace: production
+          filters: { branches: { only: [master] } }
           requires: [preprod_test_functional]
-          filters:
-            branches:
-              only: master
 
       - infrastructure_and_deployment/apply_environment_terraform:
           name: prod_environment_apply_terraform
           requires: [prod_account_apply_terraform]
+          filters: { branches: { only: [master] } }
           workspace: production
-          filters:
-            branches:
-              only: master
 
       - infrastructure_and_deployment/run_healthcheck_test:
           name: test_healthcheck_prod
           requires: [prod_environment_apply_terraform]
+          filters: { branches: { only: [master] } }
           workspace: production
-          filters:
-            branches:
-              only: master
+
       - slack_notify_production_release:
           name: post_production_release_message
+          filters: { branches: { only: [master] } }
           requires: [test_healthcheck_prod]
-          filters:
-            branches:
-              only: master
 
 orbs:
   slack: circleci/slack@3.3.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ orbs:
           - run:
               name: Lint Environment Terraform
               command: |
-                export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+                export IMAGE_TAG=$(~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
                 echo $IMAGE_TAG
                 cd ~/project/terraform/environment
                 terraform init -lock-timeout=300s
@@ -446,7 +446,7 @@ orbs:
           - run:
               name: Apply Environment Terraform
               command: |
-                export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+                export IMAGE_TAG=$(~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
                 echo $IMAGE_TAG
                 cd ~/project/terraform/environment
                 terraform init -lock-timeout=300s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ orbs:
           - run:
               name: Push web container
               command: |
-                export IMAGE_TAG=$(bash ~/project/pipeline_scripts/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+                export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
                 echo $IMAGE_TAG
                 if << parameters.build_web >> ; then
                   docker tag << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_web:${IMAGE_TAG}
@@ -277,7 +277,7 @@ orbs:
           - run:
               name: Push app container
               command: |
-                export IMAGE_TAG=$(bash ~/project/pipeline_scripts/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+                export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
                 echo $IMAGE_TAG
                 docker tag << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app:${IMAGE_TAG}
                 if [ "${CIRCLE_BRANCH}" == "master" ]; then
@@ -358,11 +358,11 @@ orbs:
           - run:
               name: Lint Environment Terraform
               command: |
-                export IMAGE_TAG=$(bash ~/project/pipeline_scripts/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+                export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
                 echo $IMAGE_TAG
                 cd ~/project/terraform/environment
                 terraform init -lock-timeout=300s
-                export TF_WORKSPACE=$(~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                export TF_WORKSPACE=$(~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 terraform validate -var container_version=${IMAGE_TAG}
 
@@ -384,7 +384,7 @@ orbs:
               command: |
                 cd ~/project/terraform/email
                 terraform init -lock-timeout=300s
-                export TF_WORKSPACE=$(~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                export TF_WORKSPACE=$(~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 terraform apply -lock-timeout=300s --auto-approve
 
@@ -406,7 +406,7 @@ orbs:
               command: |
                 cd ~/project/terraform/account
                 terraform init -lock-timeout=300s
-                export TF_WORKSPACE=$(~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                export TF_WORKSPACE=$(~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 terraform apply -lock-timeout=300s --auto-approve
 
@@ -427,11 +427,11 @@ orbs:
           - run:
               name: Apply Environment Terraform
               command: |
-                export IMAGE_TAG=$(bash ~/project/pipeline_scripts/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+                export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
                 echo $IMAGE_TAG
                 cd ~/project/terraform/environment
                 terraform init -lock-timeout=300s
-                export TF_WORKSPACE=$(~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                export TF_WORKSPACE=$(~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 terraform apply -lock-timeout=300s -auto-approve -parallelism=15 -var container_version=${IMAGE_TAG}
                 export ENV_DOMAINS="$(terraform output)" >> $BASH_ENV
@@ -456,12 +456,12 @@ orbs:
           - run:
               name: Destroy Development Environment
               command: |
-                export TF_WORKSPACE=$(~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                export TF_WORKSPACE=$(~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 if [ "${CIRCLE_BRANCH}" != "master" ]; then
                   cd ~/project/terraform/environment
                   terraform init -lock-timeout=300s
-                  export TF_WORKSPACE=$(~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                  export TF_WORKSPACE=$(~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                   echo $TF_WORKSPACE
                   terraform destroy -lock-timeout=300s -auto-approve
                 fi
@@ -486,7 +486,7 @@ orbs:
           - run:
               name: Wait for new tasks in services to be running
               command: |
-                export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 python scripts/pipeline/ecs_monitor/ecs_monitor.py
           - run:
@@ -516,7 +516,7 @@ orbs:
           - run:
               name: Wait for new tasks in services to be running
               command: |
-                export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 python scripts/pipeline/ecs_monitor/ecs_monitor.py
           - run:
@@ -525,7 +525,7 @@ orbs:
                 if [ <<parameters.workspace>> != "production" ]; then
                   cd ~/project/terraform/account_ingress
                   terraform init -lock-timeout=300s
-                  export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                  export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                   echo $TF_WORKSPACE
                   terraform apply -lock-timeout=300s -auto-approve
                 fi
@@ -539,7 +539,7 @@ orbs:
                 if [ <<parameters.workspace>> != "production" ]; then
                   cd ~/project/terraform/account_ingress
                   terraform init -lock-timeout=300s
-                  export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                  export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                   echo $TF_WORKSPACE
                   terraform destroy -lock-timeout=300s -auto-approve
                 fi
@@ -577,13 +577,13 @@ orbs:
           - run:
               name: Get URLs
               command: |
-                export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 scripts/pipeline/set_environment_variables/set_slack_env_vars.sh >> $BASH_ENV
           - run:
               name: Wait for new tasks in services to be running
               command: |
-                export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 python scripts/pipeline/ecs_monitor/ecs_monitor.py
           - run:
@@ -592,7 +592,7 @@ orbs:
                 if [ <<parameters.workspace>> != "production" ]; then
                   cd ~/project/terraform/account_ingress
                   terraform init -lock-timeout=300s
-                  export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                  export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                   echo $TF_WORKSPACE
                   terraform apply -lock-timeout=300s -auto-approve -var docker_remote_ip=$DOCKER_REMOTE_IP
                 fi
@@ -607,7 +607,7 @@ orbs:
                 if [ <<parameters.workspace>> != "production" ]; then
                   cd ~/project/terraform/account_ingress
                   terraform init -lock-timeout=300s
-                  export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+                  export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                   echo $TF_WORKSPACE
                   terraform destroy -lock-timeout=300s -auto-approve
                 fi
@@ -629,7 +629,7 @@ jobs:
       - run:
           name: Get URLs
           command: |
-            export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+            export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
             echo $TF_WORKSPACE
             scripts/pipeline/set_environment_variables/set_slack_env_vars.sh >> $BASH_ENV
       - slack/notify:
@@ -652,7 +652,7 @@ jobs:
       - run:
           name: Get URLs
           command: |
-            export TF_WORKSPACE=$(bash ~/project/pipeline_scripts/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+            export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
             echo $TF_WORKSPACE
             scripts/pipeline/set_environment_variables/set_slack_env_vars.sh >> $BASH_ENV
       - slack/notify:
@@ -671,6 +671,6 @@ jobs:
           name: Check ECR Scan Results
           command: |
             sudo pip3 install -r scripts/pipeline/requirements.txt
-            export IMAGE_TAG=$(bash ~/project/pipeline_scripts/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+            export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
                 echo $IMAGE_TAG
             python scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py --search online-lpa --tag ${IMAGE_TAG}

--- a/scripts/pipeline/set_environment_variables/set_image_tag.sh
+++ b/scripts/pipeline/set_environment_variables/set_image_tag.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+name_tag()
+{
+  branch=$1
+  branch=${branch//-}
+  branch=${branch//_}
+  branch=${branch//\/}
+  branch=${branch:0:13}
+  branch=$(echo $branch | tr '[:upper:]' '[:lower:]')
+  short_hash=${2:0:7}
+  echo "$branch-$short_hash"
+}
+
+echo $(name_tag $1 $2)

--- a/scripts/pipeline/set_environment_variables/set_terraform_workspace_name.sh
+++ b/scripts/pipeline/set_environment_variables/set_terraform_workspace_name.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-echo "export TF_WORKSPACE=${ENV_NAME:0:13}  | tr '[:upper:]' '[:lower:]'"

--- a/scripts/pipeline/set_environment_variables/set_workspace.sh
+++ b/scripts/pipeline/set_environment_variables/set_workspace.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+function name_workspace() {
+  workspace=$1
+  workspace=${workspace//-}
+  workspace=${workspace//_}
+  workspace=${workspace//\/}
+  workspace=${workspace:0:13}
+  workspace=$(echo $workspace | tr '[:upper:]' '[:lower:]')
+  echo $workspace
+}
+workspace_name=$(name_workspace $1)
+  if [ -z "$workspace_name" ]
+    then
+          exit 1
+    else
+          echo $workspace_name
+    fi


### PR DESCRIPTION
## Purpose
Make the naming of environments and Docker images standard.
Let the pipeline support Dependabot PRs.

Fixes LPA-3711

## Approach

Use the scripts from UAL and Refunds to produce clean workspace and Docker image names.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
