### PR TITLE
LPA- 3743 Changed permission for gateway access

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -40,7 +40,7 @@
       "front_certificate_domain_name": "*.front.lpa.opg.service.justice.gov.uk",
       "admin_certificate_domain_name": "*.admin.lpa.opg.service.justice.gov.uk",
       "sirius_api_gateway_endpoint": "https://api.dev.sirius.opg.digital/v1/lpa-online-tool/lpas/",
-      "sirius_api_gateway_arn": "arn:aws:execute-api:eu-west-1:649098267436:*/*/GET/lpa-online-tool/*",
+      "sirius_api_gateway_arn": "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/lpa-online-tool/*",
       "prevent_db_destroy": false,
       "backup_retention_period": 0,
       "skip_final_snapshot" : true,


### PR DESCRIPTION
LPA- 3743
https://opgtransform.atlassian.net/browse/LPA-3743

Fixes LPA-3743
The proprod environment now points to right gateway. 

_Explain how your code addresses the purpose of the change_

The proprod environment now points to right gateway. This should now enable receiving responses from Sirius and updating the LPA db and would would then reflect right status on dashboard and status pages for applications.


_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
