### PR TITLE
LPA: Check status return from sirius irrespective of what's status is stor…

### DIFF
--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="SqlDialectMappings">
-    <file url="file://$PROJECT_DIR$/scripts/non_live_seeding/seed_test_users.sql" dialect="PostgreSQL" />
-  </component>
-</project>

--- a/service-api/module/Application/src/Controller/StatusController.php
+++ b/service-api/module/Application/src/Controller/StatusController.php
@@ -220,15 +220,13 @@ class StatusController extends AbstractRestfulController
 
                         $currentResult = $results[$lpaId];
                         $currentProcessingStatus = $currentResult['found'] ? $currentResult['status'] : null;
-                       // var_dump($currentProcessingStatus);
-
 
                         $receiptDate = isset($lpaDetail['receiptDate']) ? $lpaDetail['receiptDate'] : null;
                         $registrationDate = isset($lpaDetail['registrationDate']) ? $lpaDetail['registrationDate'] : null;
                         $rejectDate = isset($lpaDetail['rejectedDate']) ? $lpaDetail['rejectedDate'] : null;
 
                         // If it doesn't match what we already have update the database
-                        if (!is_null($lpaDetail['status']) && $lpaDetail['status']){
+                        if (!is_null($lpaDetail['status']) && $lpaDetail['status'] && $lpaDetail['status'] != $currentProcessingStatus){
                             $this->updateMetadata($lpaId, $lpaDetail['status'],$receiptDate,$registrationDate,$rejectDate);
                             $results[$lpaId] = ['found' => true, 'status' => $lpaDetail['status'], 'receiptDate' => $receiptDate, 'registrationDate' => $registrationDate, 'rejectedDate' => $rejectDate];
                         }

--- a/service-api/module/Application/src/Controller/StatusController.php
+++ b/service-api/module/Application/src/Controller/StatusController.php
@@ -206,7 +206,6 @@ class StatusController extends AbstractRestfulController
         if (!empty($allIdsToCheckStatusInSirius)) {
             $this->getLogger()->info('All application ids to check in Sirius :' .implode("','",$allIdsToCheckStatusInSirius)."'");
             $this->getLogger()->info('Count of all application ids to check in Sirius :' . count($allIdsToCheckStatusInSirius));
-            // }
 
             // Get status update from Sirius
             $siriusResponseArray = $this->processingStatusService->getStatuses($allIdsToCheckStatusInSirius);
@@ -241,8 +240,6 @@ class StatusController extends AbstractRestfulController
                         }
                     }
                 }
-                die;
-
             }
         }
         return new Json($results);

--- a/service-api/module/Application/src/Controller/StatusController.php
+++ b/service-api/module/Application/src/Controller/StatusController.php
@@ -224,13 +224,13 @@ class StatusController extends AbstractRestfulController
                         $receiptDate = isset($lpaDetail['receiptDate']) ? $lpaDetail['receiptDate'] : null;
                         $registrationDate = isset($lpaDetail['registrationDate']) ? $lpaDetail['registrationDate'] : null;
                         $rejectDate = isset($lpaDetail['rejectedDate']) ? $lpaDetail['rejectedDate'] : null;
-
+                        
                         // If it doesn't match what we already have update the database
-                        if (!is_null($lpaDetail['status']) && $lpaDetail['status'] && $lpaDetail['status'] != $currentProcessingStatus){
+                        if (isset($lpaDetail['status']) && $lpaDetail['status'] !== $currentProcessingStatus) {
                             $this->updateMetadata($lpaId, $lpaDetail['status'],$receiptDate,$registrationDate,$rejectDate);
                             $results[$lpaId] = ['found' => true, 'status' => $lpaDetail['status'], 'receiptDate' => $receiptDate, 'registrationDate' => $registrationDate, 'rejectedDate' => $rejectDate];
                         }
-                        else if (!is_null($lpaDetail['status']) && $lpaDetail['status'] == $currentProcessingStatus){
+                        else if (isset($lpaDetail['status']) && $lpaDetail['status'] == $currentProcessingStatus) {
                             $results[$lpaId] = ['found' => true, 'status' => $currentProcessingStatus,'receiptDate' => $receiptDate, 'registrationDate' => $registrationDate, 'rejectedDate' => $rejectDate];
                         }
                         else if(is_null($lpaDetail['status']) && !is_null($currentProcessingStatus) && is_null($rejectDate)){
@@ -241,6 +241,8 @@ class StatusController extends AbstractRestfulController
                         }
                     }
                 }
+                die;
+
             }
         }
         return new Json($results);

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/StatusControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/StatusControllerTest.php
@@ -83,7 +83,11 @@ class StatusControllerTest extends AbstractControllerTest
         $this->assertEquals(new Json(
             [
                 98765 => [
-                    'found' => true, 'status' => 'Returned','receiptDate' => null, 'registrationDate' => null, 'rejectedDate'  => new DateTime('2019-02-11')
+                    'found' => true,
+                    'status' => 'Returned',
+                    'receiptDate' => null,
+                    'registrationDate' => null,
+                    'rejectedDate'  => new DateTime('2019-02-11')
                 ]
             ]
         ), $result);
@@ -122,7 +126,10 @@ class StatusControllerTest extends AbstractControllerTest
         $this->assertEquals(new Json(
             [
                 98765 => [
-                    'found' => true, 'status' => 'Checking', 'receiptDate' => new DateTime('2019-02-11'), 'registrationDate' => null,'rejectedDate'  => null
+                    'found' => true,
+                    'status' => 'Checking',
+                    'receiptDate' => new DateTime('2019-02-11'),
+                    'registrationDate' => null,'rejectedDate'  => null
                 ]
             ]
         ), $result);
@@ -153,7 +160,11 @@ class StatusControllerTest extends AbstractControllerTest
         $this->assertEquals(new Json(
             [
                 98765 => [
-                    'found' => true, 'status' => 'Received', 'receiptDate'  => new DateTime('2019-02-11'), 'registrationDate' => null, 'rejectedDate' => null
+                    'found' => true,
+                    'status' => 'Received',
+                    'receiptDate'  => new DateTime('2019-02-11'),
+                    'registrationDate' => null,
+                    'rejectedDate' => null
                 ]
             ]
         ), $result);
@@ -196,7 +207,11 @@ class StatusControllerTest extends AbstractControllerTest
         $this->assertEquals(new Json(
             [
                 98765 => [
-                    'found' => true, 'status' => 'Checking','receiptDate' => null,'registrationDate'  => new DateTime('2019-02-11'), 'rejectedDate' => null
+                    'found' => true,
+                    'status' => 'Checking',
+                    'receiptDate' => null,
+                    'registrationDate'  => new DateTime('2019-02-11'),
+                    'rejectedDate' => null
                 ]
             ]
         ), $result);
@@ -207,7 +222,11 @@ class StatusControllerTest extends AbstractControllerTest
         $this->statusController->onDispatch($this->mvcEvent);
 
         $lpa = new Lpa(['completedAt' => new DateTime('2019-02-01'),
-            'metadata' => [Lpa::SIRIUS_PROCESSING_STATUS => 'Waiting', Lpa::APPLICATION_REJECTED_DATE => null, Lpa::APPLICATION_REGISTRATION_DATE => null ]]);
+            'metadata' => [
+                Lpa::SIRIUS_PROCESSING_STATUS => 'Waiting',
+                Lpa::APPLICATION_REJECTED_DATE => null,
+                Lpa::APPLICATION_REGISTRATION_DATE => null
+            ]]);
 
         $dataModel = new DataModelEntity($lpa);
 
@@ -239,7 +258,11 @@ class StatusControllerTest extends AbstractControllerTest
         $this->assertEquals(new Json(
             [
                 98765 => [
-                    'found' => true, 'status' => 'Returned','receiptDate' => null, 'registrationDate' => null,  'rejectedDate'  => new DateTime('2019-02-11')
+                    'found' => true,
+                    'status' => 'Returned',
+                    'receiptDate' => null,
+                    'registrationDate' => null,
+                    'rejectedDate'  => new DateTime('2019-02-11')
                 ]
             ]
         ), $result);
@@ -250,7 +273,11 @@ class StatusControllerTest extends AbstractControllerTest
         $this->statusController->onDispatch($this->mvcEvent);
 
         $lpa = new Lpa(['completedAt' => new DateTime('2019-02-01'),
-            'metadata' => [Lpa::SIRIUS_PROCESSING_STATUS => 'Returned', Lpa::APPLICATION_REJECTED_DATE => null, Lpa::APPLICATION_REGISTRATION_DATE => null ]]);
+            'metadata' => [
+                Lpa::SIRIUS_PROCESSING_STATUS => 'Returned',
+                Lpa::APPLICATION_REJECTED_DATE => null,
+                Lpa::APPLICATION_REGISTRATION_DATE => null
+            ]]);
 
         $dataModel = new DataModelEntity($lpa);
 
@@ -282,7 +309,11 @@ class StatusControllerTest extends AbstractControllerTest
         $this->assertEquals(new Json(
             [
                 98765 => [
-                    'found' => true, 'status' => 'Checking','receiptDate' => new DateTime('2019-02-11'), 'registrationDate' => null,  'rejectedDate'  => null
+                    'found' => true,
+                    'status' => 'Checking',
+                    'receiptDate' => new DateTime('2019-02-11'),
+                    'registrationDate' => null,
+                    'rejectedDate'  => null
                 ]
             ]
         ), $result);
@@ -309,7 +340,12 @@ class StatusControllerTest extends AbstractControllerTest
 
         $result = $this->statusController->get('98765');
 
-        $this->assertEquals(new Json(['98765' => ['found' => true, 'status' => 'Checking', 'rejectedDate'  => null ]]), $result);
+        $this->assertEquals(new Json([
+            '98765' => [
+            'found' => true,
+                'status' => 'Checking',
+                'rejectedDate'  => null
+            ]]), $result);
     }
 
     public function testGetWithNoUpdateOnValidCaseWithNoPreviousStatus()
@@ -359,7 +395,14 @@ class StatusControllerTest extends AbstractControllerTest
 
         $result = $this->statusController->get('98765');
 
-        $this->assertEquals(new Json(['98765' => ['found' => true, 'status' => 'Checking', 'receiptDate' => null,'registrationDate' => new DateTime('2019-02-11'), 'rejectedDate' => null ]]), $result);
+        $this->assertEquals(new Json([
+            '98765' => [
+                'found' => true,
+                'status' => 'Checking',
+                'receiptDate' => null,
+                'registrationDate' => new DateTime('2019-02-11'),
+                'rejectedDate' => null
+            ]]), $result);
     }
 
     public function testGetNotFoundInDB()
@@ -385,7 +428,14 @@ class StatusControllerTest extends AbstractControllerTest
 
         $result = $this->statusController->get('98765');
 
-        $this->assertEquals(new Json(['98765' => ['found' => true, 'status' => 'Checking', 'receiptDate' => null,'registrationDate' => new DateTime('2019-02-11'), 'rejectedDate' => null ]]), $result);
+        $this->assertEquals(new Json([
+            '98765' => [
+                'found' => true,
+                'status' => 'Checking',
+                'receiptDate' => null,
+                'registrationDate' => new DateTime('2019-02-11'),
+                'rejectedDate' => null
+            ]]), $result);
     }
 
     public function testGetLpaAlreadyReturnedWithRegistrationDateSet()
@@ -393,7 +443,10 @@ class StatusControllerTest extends AbstractControllerTest
         $this->statusController->onDispatch($this->mvcEvent);
 
         $lpa = new Lpa(['completedAt' => new DateTime('2019-02-01'),
-            'metadata' => [Lpa::SIRIUS_PROCESSING_STATUS => 'Returned', Lpa::APPLICATION_REJECTED_DATE => new DateTime('2019-02-10')]]);
+            'metadata' => [
+                Lpa::SIRIUS_PROCESSING_STATUS => 'Returned',
+                Lpa::APPLICATION_REJECTED_DATE => new DateTime('2019-02-10')
+            ]]);
 
         $dataModel = new DataModelEntity($lpa);
 
@@ -422,7 +475,14 @@ class StatusControllerTest extends AbstractControllerTest
 
         $result = $this->statusController->get('98765');
 
-        $this->assertEquals(new Json(['98765' => ['found' => true, 'status' => 'Checking', 'receiptDate' => null,'registrationDate' => new DateTime('2019-02-11'), 'rejectedDate' => null ]]), $result);
+        $this->assertEquals(new Json([
+            '98765' => [
+                'found' => true,
+                'status' => 'Checking',
+                'receiptDate' => null,
+                'registrationDate' => new DateTime('2019-02-11'),
+                'rejectedDate' => null
+            ]]), $result);
     }
 
     public function testGetLpaAlreadyReturnedWithRejectedDateSet()
@@ -430,7 +490,10 @@ class StatusControllerTest extends AbstractControllerTest
         $this->statusController->onDispatch($this->mvcEvent);
 
         $lpa = new Lpa(['completedAt' => new DateTime('2019-02-01'),
-            'metadata' => [Lpa::SIRIUS_PROCESSING_STATUS => 'Returned', Lpa::APPLICATION_REJECTED_DATE => new DateTime('2019-02-10')]]);
+            'metadata' => [
+                Lpa::SIRIUS_PROCESSING_STATUS => 'Returned',
+                Lpa::APPLICATION_REJECTED_DATE => new DateTime('2019-02-10')
+            ]]);
 
         $dataModel = new DataModelEntity($lpa);
 
@@ -447,7 +510,14 @@ class StatusControllerTest extends AbstractControllerTest
 
         $result = $this->statusController->get('98765');
 
-        $this->assertEquals(new Json(['98765' => ['found' => true, 'status' => 'Returned', 'receiptDate' => null,'registrationDate' => null, 'rejectedDate' => new DateTime('2019-02-10') ]]), $result);
+        $this->assertEquals(new Json([
+            '98765' => [
+                'found' => true,
+                'status' => 'Returned',
+                'receiptDate' => null,
+                'registrationDate' => null,
+                'rejectedDate' => new DateTime('2019-02-10')
+            ]]), $result);
     }
 
     /**
@@ -510,8 +580,18 @@ class StatusControllerTest extends AbstractControllerTest
         $result = $this->statusController->get('98765,98766');
 
         $this->assertEquals(new Json([
-            98765 => ['found' => true, 'status' => 'Returned', 'receiptDate' => null, 'registrationDate' => null, 'rejectedDate' => new DateTime('2019-02-11')],
-            98766 => ['found' => true, 'status' => 'Received', 'receiptDate' => new DateTime('2019-02-11'), 'registrationDate' => null,'rejectedDate' => null]
+            98765 => [
+                'found' => true,
+                'status' => 'Returned',
+                'receiptDate' => null,
+                'registrationDate' => null,
+                'rejectedDate' => new DateTime('2019-02-11')],
+            98766 => [
+                'found' => true,
+                'status' => 'Received',
+                'receiptDate' => new DateTime('2019-02-11'),
+                'registrationDate' => null,
+                'rejectedDate' => null]
         ]), $result);
     }
 }


### PR DESCRIPTION
…ed in LPA db

## Purpose
https://opgtransform.atlassian.net/browse/LPA-3740

Fixes LPA-3740

## Approach

Removed condition and send requests to Sirius to check status for all LPA's irrespective of their current status in LPA database. Based on the response received from gateway if the status differs from what is in lpa db, update database.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] The product team have tested these changes
