### PR TITLE
Auto cancel builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,10 @@ version: 2.1
 workflows:
   pr_build:
     jobs:
+      - cancel_redundant_builds:
+          name: cancel_previous_jobs
+          filters: { branches: { ignore: [master] } }
+
       - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
           name: front_docker_build
           ecr_repository_name_prefix: online-lpa/front
@@ -44,19 +48,20 @@ workflows:
           name: dev_account_apply_terraform
           workspace: development
           filters: { branches: { ignore: [master] } }
-          requires: [lint_and_validate_terraform]
+          requires: [cancel_previous_jobs, lint_and_validate_terraform]
 
       - infrastructure_and_deployment/apply_email_terraform:
           name: email_apply_terraform
           workspace: development
           filters: { branches: { ignore: [master] } }
-          requires: [lint_and_validate_terraform]
+          requires: [cancel_previous_jobs, lint_and_validate_terraform]
 
       - infrastructure_and_deployment/apply_environment_terraform:
           name: dev_environment_apply_terraform
           filters: { branches: { ignore: [master] } }
           requires:
             [
+              cancel_previous_jobs,
               dev_account_apply_terraform,
               front_docker_build,
               admin_docker_build,
@@ -632,6 +637,21 @@ orbs:
               when: always
 
 jobs:
+  cancel_redundant_builds:
+    docker:
+      - image: circleci/python
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Cancel Redundant Builds
+          command: |
+            python scripts/pipeline/cancel_previous_jobs/cancel_redundant_builds.py \
+            --circle_project_username ${CIRCLE_PROJECT_USERNAME} \
+            --circle_project_reponame ${CIRCLE_PROJECT_REPONAME} \
+            --circle_branch ${CIRCLE_BRANCH} \
+            --circle_builds_token ${CIRCLECI_API_KEY} \
+            --terms_to_waitfor "dev_account_apply_terraform,dev_environment_apply_terraform,apply_email_terraform"
   slack_notify_domain:
     docker:
       - image: circleci/python

--- a/scripts/pipeline/cancel_previous_jobs/README.md
+++ b/scripts/pipeline/cancel_previous_jobs/README.md
@@ -1,0 +1,22 @@
+# Cancel Redundant CircleCI Builds
+
+This script will cancel redundant builds when new ones are started. If jobs matching the `terms_to_waitfor` argument are running, the script will wait for them to end first, then cancel the build.
+
+## Run script
+
+The script uses a CircleCI Personal API Token to authorise the requests against the API. Information about creating a token can be found at <https://circleci.com/docs/2.0/managing-api-tokens/>.
+
+The token should be added as an Environment Variable to the CircleCI project settings. Information about setting Environment Variables can be found at <https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-shell-command/>.
+
+All arguments are required, and are available in CircleCI as built-in Environment Variables. <https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables>
+
+Example command to run script.
+
+``` bash
+python scripts/pipeline/cancel_previous_jobs/cancel_redundant_builds.py \
+--circle_project_username ${CIRCLE_PROJECT_USERNAME} \
+--circle_project_reponame ${CIRCLE_PROJECT_REPONAME} \
+--circle_branch ${CIRCLE_BRANCH} \
+--circle_builds_token ${CIRCLECI_API_KEY} \
+--terms_to_waitfor "dev_account_apply_terraform,dev_environment_apply_terraform,apply_email_terraform"
+```

--- a/scripts/pipeline/cancel_previous_jobs/cancel_redundant_builds.py
+++ b/scripts/pipeline/cancel_previous_jobs/cancel_redundant_builds.py
@@ -1,0 +1,175 @@
+import requests
+import os
+import json
+from time import sleep
+import argparse
+
+
+class CancelPreviousWorkflows:
+    def __init__(
+        self,
+        circle_project_username,
+        circle_project_reponame,
+        circle_branch,
+        circle_builds_token,
+        terms_to_waitfor,
+    ):
+
+        self.circle_project_username = circle_project_username
+        self.circle_project_reponame = circle_project_reponame
+        self.circle_branch = circle_branch
+        self.circle_builds_token = circle_builds_token
+        self.terms_to_waitfor = terms_to_waitfor.split(",")
+        self.delay = 10
+        if "CIRCLE_WORKFLOW_ID" in os.environ:
+            self.current_workflow_id = os.environ["CIRCLE_WORKFLOW_ID"]
+        else:
+            self.current_workflow_id = "None"
+
+        for term in self.terms_to_waitfor:
+            print(f"Term to wait for: {term}")
+
+    def get_running_jobs(self):
+        running_jobs_url = f"https://circleci.com/api/v1.1/project/github/{self.circle_project_username}/{self.circle_project_reponame}/tree/{self.circle_branch}?circle-token={self.circle_builds_token}"
+        response = requests.get(running_jobs_url)
+        running_jobs = []
+        if response.status_code == 200:
+            running_jobs_json = json.loads(response.text)
+            for job in running_jobs_json:
+                if job['status'] == "queued" or job['status'] == "running":
+                    if job['workflows']['workflow_id'] != self.current_workflow_id:
+                        running_jobs.append(job['workflows'])
+                        print(
+                            f"Other Job: \"{job['workflows']['job_name']}\", Status: \"{job['status']}\"")
+            return running_jobs
+        else:
+            print(
+                f"API call to circle failed with status code: {response.status_code}")
+            return running_jobs
+
+    def tf_job_running(self, running_jobs):
+        if len(running_jobs) > 0:
+            for job in running_jobs:
+                if any(term_to_ignore in job['job_name'] for term_to_ignore in self.terms_to_waitfor):
+                    print(f"Found terraform job \"{job['job_name']}\"")
+                    return True
+            print(f"Found non terraform job \"{job['job_name']}\"")
+            return False
+        else:
+            print("Found no jobs running")
+            return False
+
+    def cancel_workflows(self):
+        workflow_ids = []
+        running_jobs = self.get_running_jobs()
+        for job in running_jobs:
+            print(f"Will attempt to cancel workflow: {job['workflow_id']}")
+            workflow_ids.append(str(job['workflow_id']))
+
+        unique_workflow_ids = list(set(workflow_ids))
+
+        for workflow_id in unique_workflow_ids:
+            print(f"Cancelling workflow: {workflow_id}")
+            headers = {"Accept": "application/json"}
+            url = f"https://circleci.com/api/v2/workflow/{workflow_id}/cancel?circle-token={self.circle_builds_token}"
+
+            response = requests.post(url, None, headers=headers)
+            if response.text == "{\"message\":\"Accepted.\"}":
+                print(f"Successfully cancelled workflow: {workflow_id}")
+            else:
+                print(f"Failed to cancel workflow: {workflow_id}")
+
+    def wait_for_terraform_jobs(self):
+        tf_job_exists = False
+        tf_running = self.tf_job_running(self.get_running_jobs())
+        count = 0
+
+        while tf_running:
+            tf_job_exists = True
+            sleep(self.delay)
+            count = count + 1
+            tf_running_jobs = self.get_running_jobs()
+            tf_running = self.tf_job_running(tf_running_jobs)
+            print(
+                f"Waiting for terraform job \"{tf_running_jobs[0]['job_name']}\" to finish. Waiting {count * self.delay} seconds")
+
+        if tf_job_exists:
+            running_jobs = self.get_running_jobs()
+            count = 0
+            while len(running_jobs) < 1 and count < 12:
+                count = count + 1
+                print(
+                    f"Terraform job finished. Waiting for next job to start so we can cancel it. Waiting {count * self.delay} seconds")
+                sleep(self.delay)
+                success, running_jobs = self.get_running_jobs()
+            if len(running_jobs) < 1:
+                print(
+                    "No further jobs running or left to run (or they are taking too long to start")
+            else:
+                print(
+                    "Terraform job finished, new job started. Checking if it's another terraform job")
+                if self.tf_job_running(self.get_running_jobs()):
+                    self.wait_for_terraform_jobs()
+                else:
+                    print("New job(s) aren't terraform jobs. Returning jobs to cancel")
+
+        return self.get_running_jobs()
+
+    @staticmethod
+    def exiting():
+        print("No workflows to cancel from Circle API. Continuing build")
+        exit(0)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Cancel all previous workflows with ignore list.")
+
+    parser.add_argument(
+        "--circle_project_username",
+        default="ministryofjustice",
+        help="Circle username for the workflow.",
+    )
+    parser.add_argument(
+        "--circle_project_reponame",
+        default="myproject",
+        help="The project for the workflow.",
+    )
+    parser.add_argument(
+        "--circle_branch",
+        default="None",
+        help="Name of the branch to check for the workflow.",
+    )
+    parser.add_argument(
+        "--circle_builds_token",
+        default="notarealtoken",
+        help="Personal API token for circle.",
+    )
+    parser.add_argument(
+        "--terms_to_waitfor",
+        default="term one, term two",
+        help="Strings representing job names separated by commas to 'wait for'.",
+    )
+
+    args = parser.parse_args()
+
+    cancel_workflows = CancelPreviousWorkflows(
+        args.circle_project_username,
+        args.circle_project_reponame,
+        args.circle_branch,
+        args.circle_builds_token,
+        args.terms_to_waitfor,
+    )
+
+    running_jobs = cancel_workflows.get_running_jobs()
+
+    if cancel_workflows.tf_job_running(running_jobs):
+        running_jobs = cancel_workflows.wait_for_terraform_jobs()
+    if len(running_jobs) > 0:
+        cancel_workflows.cancel_workflows()
+    else:
+        cancel_workflows.exiting()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose
To improve pipeline by cancelling running builds of the same type instead of allowing to complete for pr builds

## Approach

Updated pipeline to cancel job unless its a terraform step


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
