### PR TITLE
LPA-3752 accessibility page

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ However, sometimes e:g when working on Track My LPA, you'll also require the Sir
 git clone git@github.com:ministryofjustice/opg-sirius-api-gateway.git
 ```
 
-then return to the opg-lpa directory, and now instead of a simple docker-compose up , you'll need to also bring up with sirius api gateway, like this:
+Then return to the opg-lpa directory, and now instead of a simple docker-compose up , you'll need to bring the sirius api gateway too, like this:
 ```bash
 docker-compose -f docker-compose.yml \
 -f ../opg-sirius-api-gateway/docker-compose.yml \

--- a/README.md
+++ b/README.md
@@ -26,10 +26,24 @@ The Admin service will be available via https://localhost:7003
 
 The API service will be available (direct) via http://localhost:7001
 
-After the first time, you bring up the environment with:
+After the first time, normally you bring up the environment with:
 ```
 docker-compose up
 ```
+
+However, sometimes e:g when working on Track My LPA, you'll also require the Sirius API Gateway running locally. To achieve this you should clone the repo, in the same directory as opg-lpa was cloned into, so that the 2 repos are sibling directories.
+
+```
+git clone git@github.com:ministryofjustice/opg-sirius-api-gateway.git
+```
+
+then return to the opg-lpa directory, and now instead of a simple docker-compose up , you'll need to also bring up with sirius api gateway, like this:
+```bash
+docker-compose -f docker-compose.yml \
+-f ../opg-sirius-api-gateway/docker-compose.yml \
+-f ../opg-sirius-api-gateway/docker-compose-integration.yml up
+```
+
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -3,22 +3,22 @@ The Office of the Public Guardian Lasting Power of Attorney online service: Mana
 
 
 ## Local Development Setup
-The first time you bring up the environment:
+
+Intially, download the repo via:
 
 ```
 git clone git@github.com:ministryofjustice/opg-lpa.git
 cd opg-lpa
-
-docker-compose run front-composer
-docker-compose run admin-composer
-docker-compose run api-composer
-docker-compose run pdf-composer
-
-docker-compose up
 ```
 
-You will also need a copy of the local config file `service-front/config/autoload/local.php`. Any developer on the team
-should be able to provide you with this.
+Within `opg-lpa` directory to *run* the project for the first time use the following:
+
+```
+make dc-run
+make
+```
+
+The `Makefile` will fetch secrets using `aws secretsmanager` and `docker-compose` commands together to pass along environment variables removing the need for local configuration files.
 
 
 The LPA Tool service will be available via https://localhost:7002/home
@@ -26,33 +26,16 @@ The Admin service will be available via https://localhost:7003
 
 The API service will be available (direct) via http://localhost:7001
 
-After the first time, normally you bring up the environment with:
+After the first time, you can *run* the project by:
 ```
-docker-compose up
+make
 ```
-
-However, sometimes e:g when working on Track My LPA, you'll also require the Sirius API Gateway running locally. To achieve this you should clone the repo, in the same directory as opg-lpa was cloned into, so that the 2 repos are sibling directories.
-
-```
-git clone git@github.com:ministryofjustice/opg-sirius-api-gateway.git
-```
-
-Then return to the opg-lpa directory, and now instead of a simple docker-compose up , you'll need to bring the sirius api gateway too, like this:
-```bash
-docker-compose -f docker-compose.yml \
--f ../opg-sirius-api-gateway/docker-compose.yml \
--f ../opg-sirius-api-gateway/docker-compose-integration.yml up
-```
-
 
 ### Tests
 
 To run the unit tests
 ```bash
-docker-compose run front-app /app/vendor/bin/phpunit
-docker-compose run admin-app /app/vendor/bin/phpunit
-docker-compose run api-app /app/vendor/bin/phpunit
-docker-compose run pdf-app /app/vendor/bin/phpunit
+make dc-unit-tests
 ```
 
 ### Updating composer dependencies

--- a/service-front/module/Application/config/module.routes.php
+++ b/service-front/module/Application/config/module.routes.php
@@ -41,6 +41,17 @@ return [
                 ],
             ], // terms
 
+            'accessibility' => [
+                'type' => 'Zend\Router\Http\Literal',
+                'options' => [
+                    'route'    => '/accessibility',
+                    'defaults' => [
+                        'controller' => 'General\HomeController',
+                        'action'     => 'accessibility',
+                    ],
+                ],
+            ], // terms
+
             'privacy' => [
                 'type' => 'Zend\Router\Http\Literal',
                 'options' => [

--- a/service-front/module/Application/src/Controller/General/HomeController.php
+++ b/service-front/module/Application/src/Controller/General/HomeController.php
@@ -31,6 +31,10 @@ class HomeController extends AbstractBaseController
         return new ViewModel();
     }
 
+    public function accessibilityAction(){
+        return new ViewModel();
+    }
+
     public function privacyAction(){
         return new ViewModel();
     }

--- a/service-front/module/Application/tests/Controller/General/HomeControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/HomeControllerTest.php
@@ -48,6 +48,18 @@ class HomeControllerTest extends AbstractControllerTest
         $this->assertEquals('', $result->getTemplate());
     }
 
+    public function testAccessibilityAction()
+    {
+        /** @var HomeController $controller */
+        $controller = $this->getController(HomeController::class);
+
+        /** @var ViewModel $result */
+        $result = $controller->accessibilityAction();
+
+        $this->assertInstanceOf(ViewModel::class, $result);
+        $this->assertEquals('', $result->getTemplate());
+    }
+
     public function testTermsAction()
     {
         /** @var HomeController $controller */

--- a/service-front/module/Application/view/application/general/home/accessibility.twig
+++ b/service-front/module/Application/view/application/general/home/accessibility.twig
@@ -6,7 +6,7 @@
 {% block content %}
 
 <p>This online service is run by the <a href="https://www.gov.uk/government/organisations/office-of-the-public-guardian">Office of the Public Guardian</a>. We want as many people as possible to be able to use this service. For example, that means you should be able to:</p>
-<ul><li>change colours, contrast levels and fonts</li></ul>
+<li>change colours, contrast levels and fonts</li>
 <li>zoom in up to 300% without the text spilling off the screen</li>
 <li>navigate most of the website using just a keyboard</li>
 <li>navigate most of the website using speech recognition software</li>
@@ -14,7 +14,7 @@
 <p>We’ve also made the website text as simple as possible to understand.</p>
 <h2 class="heading-medium">Get help</h2>
 <p><a href="https://mcmw.abilitynet.org.uk">AbilityNet</a> has guidance about how to:</p>
-<ul><li>make your mouse easier to use</li></ul>
+<li>make your mouse easier to use</li>
 <li>use your keyboard instead of a mouse</li>
 <li>talk to your device</li>
 <li>make your device talk to you</li>
@@ -23,7 +23,7 @@
 <li>magnify the screen</li>
 <h2 class="heading-medium">How accessible this website is</h2>
 <p>We know some parts of this website are not fully accessible:</p>
-<ul><li>the text will not reflow in a single column when you change the size of the browser window</li></ul>
+<li>the text will not reflow in a single column when you change the size of the browser window</li>
 <li>you cannot modify the line height or spacing of text</li>
 <li>most older PDF documents are not fully accessible to screen reader software</li>
 <li>live video streams do not have captions</li>
@@ -32,7 +32,7 @@
 <h2 class="heading-medium">What to do if you cannot access parts of this service</h2>
 <p>If you cannot use this service, you can use the <a href="https://www.gov.uk/government/publications/make-a-lasting-power-of-attorney">paper version of the LPA</a>. </p>
 <p>You can email <a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a> to get the paper LPA in an alternative format, such as:</p>
-<ul><li>large print</li></ul>
+<li>large print</li>
 <li>braille</li>
 <li>audio</li>
 <p>Include your address, the title of the document you need and the format you need it in.</p>

--- a/service-front/module/Application/view/application/general/home/accessibility.twig
+++ b/service-front/module/Application/view/application/general/home/accessibility.twig
@@ -87,7 +87,7 @@
     <p>Not applicable</p>
     <h2 class="heading-medium">Preparation of this accessibility statement</h2>
     <p>This statement was prepared on [date]. It was last reviewed on <sup>[date]</sup>.</p>
-    <p>This service was last tested on [date]. The test was carried out by Digital Accessibility Centre (DAC).</p></font></div>
+    <p>This service was last tested on [date]. The test was carried out by Digital Accessibility Centre (DAC).</p></font>
 </div>
             
 {% endblock content %}

--- a/service-front/module/Application/view/application/general/home/accessibility.twig
+++ b/service-front/module/Application/view/application/general/home/accessibility.twig
@@ -80,7 +80,7 @@
         <li>users are not restricted to using certain input modalities - for example, keyboard, mouse, touchscreen, voice input - and they can switch between them</li>
         <li>status messages are shown in a way that assistive technologies understand without losing focus</li>
     </ul>
-    <p>This work will be completed by xxxxxxx.</p>
+    <p>This work will be completed by 28 Feb 2021.</p>
     <h3 class="heading-medium">Disproportionate burden</h3>
     <p>Not applicable</p>
     <h3 class="heading-medium">Content that’s not within the scope of the accessibility regulations</h3>

--- a/service-front/module/Application/view/application/general/home/accessibility.twig
+++ b/service-front/module/Application/view/application/general/home/accessibility.twig
@@ -1,0 +1,65 @@
+{% extends 'layout/twig/layout.twig' %}
+
+{% block htmlTitle %}Accessibility statement - {% endblock %}
+{% block pageTitle %}Accessibility statement{% endblock %}
+
+{% block supportTitleBottom %}
+	<span class="heading-secondary">Telephone, email, post or fax</span>
+{% endblock %}
+
+{% block content %}
+
+<div class="text">
+	<p class="lede"><strong>If you have a query about using the online service or completing your LPA and cannot find the answer in the online help, then please contact us.</strong></p>
+
+	<h2 class="heading-medium">
+		<i class="icon icon-phone"></i>
+		Telephone
+	</h2>
+
+	<p class="lede">0300 456 0300</p>
+
+	<p class="bold">Call centre opening times:</p>
+
+	<p>
+		Monday, Tuesday, Thursday, Friday 9.30am to 5pm<br>
+		Wednesday 10am to 5pm
+	</p>
+
+	<h2 class="heading-medium">
+		<i class="icon icon-email"></i>
+		Email
+	</h2>
+
+	<p class="lede"><a href="mailto:customerservices@publicguardian.gov.uk">customerservices@publicguardian.gov.uk</a></p>
+
+	<p>Our target is to respond to emails within 10 working days</p>
+
+	<h2 class="heading-medium">
+		<i class="icon icon-fax"></i>
+		Fax
+	</h2>
+
+	<p class="lede">0870 739 5780</p>
+
+	<h2 id="postal-address" class="heading-medium">
+		<i class="icon icon-post"></i>
+		Post your LPA documents for registration to:
+	</h2>
+
+	<p class="lede">
+	    Office of the Public Guardian<br>
+	    PO Box 16185<br>
+	    Birmingham<br>
+	    B2 2WH
+    </p>
+</div>
+
+{% endblock content %}
+
+
+
+
+
+
+

--- a/service-front/module/Application/view/application/general/home/accessibility.twig
+++ b/service-front/module/Application/view/application/general/home/accessibility.twig
@@ -6,90 +6,90 @@
 {% block content %}
 
 <div class="text">
-<p>This online service is run by the <a href="https://www.gov.uk/government/organisations/office-of-the-public-guardian">Office of the Public Guardian</a>. We want as many people as possible to be able to use this service. For example, that means you should be able to:</p>
-<ul class="list list-bullet">
-<li>change colours, contrast levels and fonts</li>
-<li>zoom in up to 300% without the text spilling off the screen</li>
-<li>navigate most of the website using just a keyboard</li>
-<li>navigate most of the website using speech recognition software</li>
-<li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
-</ul>
-<p>We’ve also made the website text as simple as possible to understand.</p>
-<h2 class="heading-medium">Get help</h2>
-<p><a href="https://mcmw.abilitynet.org.uk">AbilityNet</a> has guidance about how to:</p>
-<ul class="list list-bullet">
-<li><a href="https://mcmw.abilitynet.org.uk/impairment/making-your-mouse-easier-to-use">make your mouse easier to use</a></li>
-<li><a href="https://mcmw.abilitynet.org.uk/category/keyboard-shortcuts">use your keyboard instead of a mouse</a></li>
-<li><a href="https://mcmw.abilitynet.org.uk/impairment/talking-to-your-device">talk to your device</a></li>
-<li><a href="https://mcmw.abilitynet.org.uk/impairment/make-your-device-talk-to-you">make your device talk to you</a></li>
-<li><a href="https://mcmw.abilitynet.org.uk/impairment/making-text-larger">make text larger</a></li>
-<li><a href="https://mcmw.abilitynet.org.uk/impairment/changing-your-colours">change your colours</a></li>
-<li><a href="https://mcmw.abilitynet.org.uk/impairment/magnifying-the-screen">magnify the screen</a></li>
-</ul>
-<h2 class="heading-medium">How accessible this website is</h2>
-<p>We know some parts of this website are not fully accessible:</p>
-<ul class="list list-bullet">
-<li>the text will not reflow in a single column when you change the size of the browser window</li>
-<li>you cannot modify the line height or spacing of text</li>
-<li>the PDF document produced by the service is not fully accessible to screen reader software</li>
-<li>some of our online forms are difficult to navigate using just a keyboard</li>
-<li>you cannot skip to the main content when using a screen reader</li>
-</ul>
-<h2 class="heading-medium">What to do if you cannot access parts of this service</h2>
-<p>If you cannot use this service, you can use the <a href="https://www.gov.uk/government/publications/make-a-lasting-power-of-attorney">paper version of the LPA</a>. </p>
-<p>You can email <a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a> to get the paper LPA in an alternative format, such as:</p>
-<ul class="list list-bullet">
-<li>large print</li>
-<li>braille</li>
-<li>audio</li>
-</ul>
-<p>Include your address, the title of the document you need and the format you need it in.</p>
-<h2 class="heading-medium">Reporting accessibility problems with this service</h2>
-<p>We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please contact us. </p>
-<h3 class="heading-small">Email</h4>
-<p><a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a></p>
-<h3 class="heading-small">Telephone</h3>
-<p>0300 456 0300</p>
-<p>Monday to Friday 9:30am to 5pm, except Wednesday.</p>
-<p>Wednesday 10am to 5pm</p>
-<p><a href="https://www.gov.uk/call-charges">Find out about call charges</a></p>
-<h3 class="heading-small">Textphone</h3>
-0115 934 2778</h4>
-<h2 class="heading-medium">Enforcement procedure</h2>
-<p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <a href="https://www.equalityadvisoryservice.com" target="_blank">contact the Equality Advisory and Support Service (EASS)</a>.</p>
-<h2 class="heading-medium">Technical information about this website’s accessibility</h2>
-<p>The Office of the Public Guardian is committed to making its online services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
-<h3 class="heading-medium">Compliance status</h3>
-<p>This website is partially compliant with the <a href="https://www.w3.org/TR/WCAG21" target="_blank">Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliances listed below.</p>
-<h2 class="heading-medium">Non-accessible content</h2>
-<p>This service was fully compliant with Web Content Accessibility Guidelines (WCAG) 2.0.</p>
-<p>However, we’re currently checking that the service is compliant with Web Content Accessibility Guidelines (WCAG) 2.1.</p>
-<p>The content listed below may be non-accessible. We need to check:</p>
-<ul class="list list-bullet">
-<li>users can zoom in on content without needing to scroll or without causing poor experience</li>
-<li>non-text content has enough contrast with the background</li>
-<li>text spacing can be changed</li>
-<li>any additional content - for example, pop-ups, submenus - can be dismissed </li>
-<li>users can turn off or change keyboard shortcut</li>
-<li>users are warned when their session will timeout and lose any data they’ve entered</li>
-<li>users can use touchscreens with simple actions, like taps, double taps, and long presses</li>
-<li>users can cancel the trigger when they click down on a mouse or press down with their finger</li>
-<li>accessible labels are the same as the visual text for components</li>
-<li>any function can be activated without shaking or tilting a device</li>
-<li>clickable elements are at least 44 by 44 CSS pixels apart</li>
-<li>users are not restricted to using certain input modalities - for example, keyboard, mouse, touchscreen, voice input - and they can switch between them</li>
-<li>status messages are shown in a way that assistive technologies understand without losing focus</li>
-</ul>
-<p>This work will be completed by xxxxxxx.</p>
-<h3 class="heading-medium">Disproportionate burden</h3>
-<p>Not applicable</p>
-<h3 class="heading-medium">Content that’s not within the scope of the accessibility regulations</h3>
-<p>Not applicable</p>
-<h2 class="heading-medium">Preparation of this accessibility statement</h2>
-<p>This statement was prepared on [date]. It was last reviewed on <sup>[date]</sup>.</p>
-<p>This service was last tested on [date]. The test was carried out by Digital Accessibility Centre (DAC).</p></font></div>
+    <p>This online service is run by the <a href="https://www.gov.uk/government/organisations/office-of-the-public-guardian">Office of the Public Guardian</a>. We want as many people as possible to be able to use this service. For example, that means you should be able to:</p>
+    <ul class="list list-bullet">
+        <li>change colours, contrast levels and fonts</li>
+        <li>zoom in up to 300% without the text spilling off the screen</li>
+        <li>navigate most of the website using just a keyboard</li>
+        <li>navigate most of the website using speech recognition software</li>
+        <li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
+    </ul>
+    <p>We’ve also made the website text as simple as possible to understand.</p>
+    <h2 class="heading-medium">Get help</h2>
+    <p><a href="https://mcmw.abilitynet.org.uk">AbilityNet</a> has guidance about how to:</p>
+    <ul class="list list-bullet">
+        <li><a href="https://mcmw.abilitynet.org.uk/impairment/making-your-mouse-easier-to-use">make your mouse easier to use</a></li>
+        <li><a href="https://mcmw.abilitynet.org.uk/category/keyboard-shortcuts">use your keyboard instead of a mouse</a></li>
+        <li><a href="https://mcmw.abilitynet.org.uk/impairment/talking-to-your-device">talk to your device</a></li>
+        <li><a href="https://mcmw.abilitynet.org.uk/impairment/make-your-device-talk-to-you">make your device talk to you</a></li>
+        <li><a href="https://mcmw.abilitynet.org.uk/impairment/making-text-larger">make text larger</a></li>
+        <li><a href="https://mcmw.abilitynet.org.uk/impairment/changing-your-colours">change your colours</a></li>
+        <li><a href="https://mcmw.abilitynet.org.uk/impairment/magnifying-the-screen">magnify the screen</a></li>
+    </ul>
+    <h2 class="heading-medium">How accessible this website is</h2>
+    <p>We know some parts of this website are not fully accessible:</p>
+    <ul class="list list-bullet">
+        <li>the text will not reflow in a single column when you change the size of the browser window</li>
+        <li>you cannot modify the line height or spacing of text</li>
+        <li>the PDF document produced by the service is not fully accessible to screen reader software</li>
+        <li>some of our online forms are difficult to navigate using just a keyboard</li>
+        <li>you cannot skip to the main content when using a screen reader</li>
+    </ul>
+    <h2 class="heading-medium">What to do if you cannot access parts of this service</h2>
+    <p>If you cannot use this service, you can use the <a href="https://www.gov.uk/government/publications/make-a-lasting-power-of-attorney">paper version of the LPA</a>. </p>
+    <p>You can email <a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a> to get the paper LPA in an alternative format, such as:</p>
+    <ul class="list list-bullet">
+        <li>large print</li>
+        <li>braille</li>
+        <li>audio</li>
+    </ul>
+    <p>Include your address, the title of the document you need and the format you need it in.</p>
+    <h2 class="heading-medium">Reporting accessibility problems with this service</h2>
+    <p>We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please contact us. </p>
+    <h3 class="heading-small">Email</h4>
+    <p><a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a></p>
+    <h3 class="heading-small">Telephone</h3>
+    <p>0300 456 0300</p>
+    <p>Monday to Friday 9:30am to 5pm, except Wednesday.</p>
+    <p>Wednesday 10am to 5pm</p>
+    <p><a href="https://www.gov.uk/call-charges">Find out about call charges</a></p>
+    <h3 class="heading-small">Textphone</h3>
+    0115 934 2778</h4>
+    <h2 class="heading-medium">Enforcement procedure</h2>
+    <p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <a href="https://www.equalityadvisoryservice.com" target="_blank">contact the Equality Advisory and Support Service (EASS)</a>.</p>
+    <h2 class="heading-medium">Technical information about this website’s accessibility</h2>
+    <p>The Office of the Public Guardian is committed to making its online services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
+    <h3 class="heading-medium">Compliance status</h3>
+    <p>This website is partially compliant with the <a href="https://www.w3.org/TR/WCAG21" target="_blank">Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliances listed below.</p>
+    <h2 class="heading-medium">Non-accessible content</h2>
+    <p>This service was fully compliant with Web Content Accessibility Guidelines (WCAG) 2.0.</p>
+    <p>However, we’re currently checking that the service is compliant with Web Content Accessibility Guidelines (WCAG) 2.1.</p>
+    <p>The content listed below may be non-accessible. We need to check:</p>
+    <ul class="list list-bullet">
+        <li>users can zoom in on content without needing to scroll or without causing poor experience</li>
+        <li>non-text content has enough contrast with the background</li>
+        <li>text spacing can be changed</li>
+        <li>any additional content - for example, pop-ups, submenus - can be dismissed </li>
+        <li>users can turn off or change keyboard shortcut</li>
+        <li>users are warned when their session will timeout and lose any data they’ve entered</li>
+        <li>users can use touchscreens with simple actions, like taps, double taps, and long presses</li>
+        <li>users can cancel the trigger when they click down on a mouse or press down with their finger</li>
+        <li>accessible labels are the same as the visual text for components</li>
+        <li>any function can be activated without shaking or tilting a device</li>
+        <li>clickable elements are at least 44 by 44 CSS pixels apart</li>
+        <li>users are not restricted to using certain input modalities - for example, keyboard, mouse, touchscreen, voice input - and they can switch between them</li>
+        <li>status messages are shown in a way that assistive technologies understand without losing focus</li>
+    </ul>
+    <p>This work will be completed by xxxxxxx.</p>
+    <h3 class="heading-medium">Disproportionate burden</h3>
+    <p>Not applicable</p>
+    <h3 class="heading-medium">Content that’s not within the scope of the accessibility regulations</h3>
+    <p>Not applicable</p>
+    <h2 class="heading-medium">Preparation of this accessibility statement</h2>
+    <p>This statement was prepared on [date]. It was last reviewed on <sup>[date]</sup>.</p>
+    <p>This service was last tested on [date]. The test was carried out by Digital Accessibility Centre (DAC).</p></font></div>
 </div>
-	    
+            
 {% endblock content %}
 
 

--- a/service-front/module/Application/view/application/general/home/accessibility.twig
+++ b/service-front/module/Application/view/application/general/home/accessibility.twig
@@ -3,10 +3,6 @@
 {% block htmlTitle %}Accessibility statement for Make a lasting power of attorney - {% endblock %}
 {% block pageTitle %}Accessibility statement for Make a lasting power of attorney{% endblock %}
 
-{% block supportTitleBottom %}
-	<span class="heading-secondary">Telephone, email, post or fax</span>
-{% endblock %}
-
 {% block content %}
 
 <p>This online service is run by the <a href="https://www.gov.uk/government/organisations/office-of-the-public-guardian">Office of the Public Guardian</a>. We want as many people as possible to be able to use this service. For example, that means you should be able to:</p>
@@ -16,7 +12,7 @@
 <li>navigate most of the website using speech recognition software</li>
 <li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
 <p>We’ve also made the website text as simple as possible to understand.</p>
-<h1><strong>Get help</strong></h1>
+<h2 class="heading-medium">Get help</h2>
 <p><a href="https://mcmw.abilitynet.org.uk">AbilityNet</a> has guidance about how to:</p>
 <ul><li>make your mouse easier to use</li></ul>
 <li>use your keyboard instead of a mouse</li>
@@ -25,7 +21,7 @@
 <li>make text larger</li>
 <li>change your colours</li>
 <li>magnify the screen</li>
-<h3><strong>How accessible this website is</strong></h3>
+<h2 class="heading-medium">How accessible this website is</h2>
 <p>We know some parts of this website are not fully accessible:</p>
 <ul><li>the text will not reflow in a single column when you change the size of the browser window</li></ul>
 <li>you cannot modify the line height or spacing of text</li>
@@ -33,14 +29,14 @@
 <li>live video streams do not have captions</li>
 <li>some of our online forms are difficult to navigate using just a keyboard</li>
 <li>you cannot skip to the main content when using a screen reader</li>
-<h3><strong>What to do if you cannot access parts of this service</strong></h3>
+<h2 class="heading-medium">What to do if you cannot access parts of this service</h2>
 <p>If you cannot use this service, you can use the <a href="https://www.gov.uk/government/publications/make-a-lasting-power-of-attorney">paper version of the LPA</a>. </p>
 <p>You can email <a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a> to get the paper LPA in an alternative format, such as:</p>
 <ul><li>large print</li></ul>
 <li>braille</li>
 <li>audio</li>
 <p>Include your address, the title of the document you need and the format you need it in.</p>
-<h3><strong>Reporting accessibility problems with this service</strong></h3>
+<h2 class="medium">Reporting accessibility problems with this service</h2>
 <p>We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please contact us. </p>
 <h4><strong>Email
 </strong><u><a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a></u></h4>
@@ -51,14 +47,40 @@ Wednesday 10am to 5pm</p>
 <p>Find out about call charges</p>
 <h4><strong>Textphone
 </strong>0115 934 2778</h4>
-<h3><strong>Enforcement procedure</strong></h3>
+<h2 class="heading-medium">Enforcement procedure</h2>
 <p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <a href="https://www.equalityadvisoryservice.com" target="_blank">contact the Equality Advisory and Support Service (EASS)</a>.</p>
-<h2><strong>Technical information about this website’s accessibility</strong></h2>
+<h2 class="heading-medium">Technical information about this website’s accessibility</h2>
 <p>The Office of the Public Guardian is committed to making its online services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
-<h3><strong>Compliance status</strong></h3>
+<h3 class="heading-medium">Compliance status</h3>
 <p>This website is partially compliant with the <a href="https://www.w3.org/TR/WCAG21" target="_blank">Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliances listed below.</p>
-<h2><strong>Non-accessible content</strong></h2>
+<h2 class="heading-medium">Non-accessible content</h2>
 <p>The content listed below is non-accessible for the following reasons.</p>
+<h2 class="heading-medium">Distinguishable</h2>
+<p>Some content cannot be magnified without loss of information or functionality. This fails WCAG 2.1 success criteria 1.4.10 (Reflow).</p>
+<p>Some sight impaired users might not see important controls and understand graphics. This fails WCAG 2.1 success criteria 1.4.11 (Non-Text Contrast).</p>
+<p>Some users might not be able to modify text line height, letter or word spacing. This fails WCAG 2.1 success criteria 1.4.12 (Text Spacing).</p>
+<p>Some users might not be able to interact with or dismiss any ‘extra’ content that becomes visible. This fails WCAG 2.1 success criteria 1.4.13 (Content on Hover or Focus).</p>
+<h2 class="heading-medium">Operable</h2>
+<p>Some users might not be able to switch off or remap keyboard shortcuts. This fails WCAG 2.1 success criteria 2.1.4 (Character Key Shortcuts).</p>
+<p>Users might not be warned when their session will timeout and lose any data they’ve entered. This fails WCAG 2.1 success criteria 2.2.6 (Timeouts).</p>
+<ul><li>2.3.3 Animation from Interactions (AAA)</li></ul>
+<p>Motion animation triggered by interaction can be disabled</p>
+<p>Some users might not be able to turn off animation triggered by</p>
+<p>Some users might not be able to use touchscreens with simple actions, like taps, double taps, and long presses. This fails WCAG 2.1 success criteria 2.5.1 (Pointer Gestures).</p>
+<p>Some users might not be able to cancel or undo an action once they’ve selected a control or user interface component. This fails WCAG 2.1 success criteria 2.5.2 (Pointer Cancellation).</p>
+<p>Some component labels might have text that does not match the Accessible name in the element label. This fails WCAG 2.1 success criteria 2.5.3 (Label in Name).</p>
+<p>Some functionality might only be activated by shaking or tilting the device. This fails WCAG 2.1 success criteria 2.5.4 (Motion Actuation).</p>
+<p>The size of the target for pointer inputs might be smaller than 44 by 44 CSS pixels. This fails WCAG 2.1 success criteria 2.5.5 (Target Size).</p>
+<p>Some users might restricted to using certain input modalities (for example, keyboard, mouse, touchscreen, voice input) and might not be able to switch between them. This fails WCAG 2.1 success criteria 2.5.6 (Concurrent Input Mechanisms). </p>
+<h2 class="heading-medium">Robust</h2>
+<p>Some content might not be shown in a way that assistive technologies understand. This fails WCAG 2.1 AA success criteria 4.1.3 (Status Messages)</p>
+<h3 class="heading-medium">Disproportionate burden</h3>
+<p>Not applicable</p>
+<h3 class="heading-medium">Content that’s not within the scope of the accessibility regulations</h3>
+<p>Not applicable</p>
+<h2 class="heading-medium">Preparation of this accessibility statement</h2>
+<p>This statement was prepared on [date]. It was last reviewed on <sup>[date]</sup>.</p>
+<p>This service was last tested on [date]. The test was carried out by Digital Accessibility Centre (DAC).</p></font></div>
 	    
 {% endblock content %}
 

--- a/service-front/module/Application/view/application/general/home/accessibility.twig
+++ b/service-front/module/Application/view/application/general/home/accessibility.twig
@@ -1,7 +1,7 @@
 {% extends 'layout/twig/layout.twig' %}
 
-{% block htmlTitle %}Accessibility statement - {% endblock %}
-{% block pageTitle %}Accessibility statement{% endblock %}
+{% block htmlTitle %}Accessibility statement for Make a lasting power of attorney - {% endblock %}
+{% block pageTitle %}Accessibility statement for Make a lasting power of attorney{% endblock %}
 
 {% block supportTitleBottom %}
 	<span class="heading-secondary">Telephone, email, post or fax</span>
@@ -9,52 +9,57 @@
 
 {% block content %}
 
-<div class="text">
-	<p class="lede"><strong>If you have a query about using the online service or completing your LPA and cannot find the answer in the online help, then please contact us.</strong></p>
-
-	<h2 class="heading-medium">
-		<i class="icon icon-phone"></i>
-		Telephone
-	</h2>
-
-	<p class="lede">0300 456 0300</p>
-
-	<p class="bold">Call centre opening times:</p>
-
-	<p>
-		Monday, Tuesday, Thursday, Friday 9.30am to 5pm<br>
-		Wednesday 10am to 5pm
-	</p>
-
-	<h2 class="heading-medium">
-		<i class="icon icon-email"></i>
-		Email
-	</h2>
-
-	<p class="lede"><a href="mailto:customerservices@publicguardian.gov.uk">customerservices@publicguardian.gov.uk</a></p>
-
-	<p>Our target is to respond to emails within 10 working days</p>
-
-	<h2 class="heading-medium">
-		<i class="icon icon-fax"></i>
-		Fax
-	</h2>
-
-	<p class="lede">0870 739 5780</p>
-
-	<h2 id="postal-address" class="heading-medium">
-		<i class="icon icon-post"></i>
-		Post your LPA documents for registration to:
-	</h2>
-
-	<p class="lede">
-	    Office of the Public Guardian<br>
-	    PO Box 16185<br>
-	    Birmingham<br>
-	    B2 2WH
-    </p>
-</div>
-
+<p>This online service is run by the <u>Office of the Public Guardian</u>. We want as many people as possible to be able to use this service. For example, that means you should be able to:</p>
+<ul><li>change colours, contrast levels and fonts</li></ul>
+<li>zoom in up to 300% without the text spilling off the screen</li>
+<li>navigate most of the website using just a keyboard</li>
+<li>navigate most of the website using speech recognition software</li>
+<li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
+<p>We’ve also made the website text as simple as possible to understand.</p>
+<h1><strong>Get help</strong></h1>
+<p><u>AbilityNet</u> has guidance about how to:</p>
+<ul><li>make your mouse easier to use</li></ul>
+<li>use your keyboard instead of a mouse</li>
+<li>talk to your device</li>
+<li>make your device talk to you</li>
+<li>make text larger</li>
+<li>change your colours</li>
+<li>magnify the screen</li>
+<h3><strong>How accessible this website is</strong></h3>
+<p>We know some parts of this website are not fully accessible:</p>
+<ul><li>the text will not reflow in a single column when you change the size of the browser window</li></ul>
+<li>you cannot modify the line height or spacing of text</li>
+<li>most older PDF documents are not fully accessible to screen reader software</li>
+<li>live video streams do not have captions</li>
+<li>some of our online forms are difficult to navigate using just a keyboard</li>
+<li>you cannot skip to the main content when using a screen reader</li>
+<h3><strong>What to do if you cannot access parts of this service</strong></h3>
+<p>If you cannot use this service, you can use the <u>paper version of the LPA</u>. </p>
+<p>You can email <a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a> to get the paper LPA in an alternative format, such as:</p>
+<ul><li>large print</li></ul>
+<li>braille</li>
+<li>audio</li>
+<p>Include your address, the title of the document you need and the format you need it in.</p>
+<h3><strong>Reporting accessibility problems with this service</strong></h3>
+<p>We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please contact us. </p>
+<h4><strong>Email
+</strong><u><a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a></u></h4>
+<p><strong>Telephone
+</strong>0300 456 0300
+Monday to Friday 9:30am to 5pm, except Wednesday.
+Wednesday 10am to 5pm</p>
+<p>Find out about call charges</p>
+<h4><strong>Textphone
+</strong>0115 934 2778</h4>
+<h3><strong>Enforcement procedure</strong></h3>
+<p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <u>contact the Equality Advisory and Support Service (EASS)</u>.</p>
+<h2><strong>Technical information about this website’s accessibility</strong></h2>
+<p>The Office of the Public Guardian is committed to making its online services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
+<h3><strong>Compliance status</strong></h3>
+<p>This website is partially compliant with the <u>Web Content Accessibility Guidelines version 2.1</u> AA standard, due to ‘the non-compliances listed below.</p>
+<h2><strong>Non-accessible content</strong></h2>
+<p>The content listed below is non-accessible for the following reasons.</p>
+	    
 {% endblock content %}
 
 

--- a/service-front/module/Application/view/application/general/home/accessibility.twig
+++ b/service-front/module/Application/view/application/general/home/accessibility.twig
@@ -14,19 +14,18 @@
 <p>We’ve also made the website text as simple as possible to understand.</p>
 <h2 class="heading-medium">Get help</h2>
 <p><a href="https://mcmw.abilitynet.org.uk">AbilityNet</a> has guidance about how to:</p>
-<li>make your mouse easier to use</li>
-<li>use your keyboard instead of a mouse</li>
-<li>talk to your device</li>
-<li>make your device talk to you</li>
-<li>make text larger</li>
-<li>change your colours</li>
-<li>magnify the screen</li>
+<li><a href="https://mcmw.abilitynet.org.uk/impairment/making-your-mouse-easier-to-use">make your mouse easier to use</a></li>
+<li><a href="https://mcmw.abilitynet.org.uk/category/keyboard-shortcuts">use your keyboard instead of a mouse</a></li>
+<li><a href="https://mcmw.abilitynet.org.uk/impairment/talking-to-your-device">talk to your device</a></li>
+<li><a href="https://mcmw.abilitynet.org.uk/impairment/make-your-device-talk-to-you">make your device talk to you</a></li>
+<li><a href="https://mcmw.abilitynet.org.uk/impairment/making-text-larger">make text larger</a></li>
+<li><a href="https://mcmw.abilitynet.org.uk/impairment/changing-your-colours">change your colours</a></li>
+<li><a href="https://mcmw.abilitynet.org.uk/impairment/magnifying-the-screen">magnify the screen</a></li>
 <h2 class="heading-medium">How accessible this website is</h2>
 <p>We know some parts of this website are not fully accessible:</p>
 <li>the text will not reflow in a single column when you change the size of the browser window</li>
 <li>you cannot modify the line height or spacing of text</li>
-<li>most older PDF documents are not fully accessible to screen reader software</li>
-<li>live video streams do not have captions</li>
+<li>the PDF document produced by the service is not fully accessible to screen reader software</li>
 <li>some of our online forms are difficult to navigate using just a keyboard</li>
 <li>you cannot skip to the main content when using a screen reader</li>
 <h2 class="heading-medium">What to do if you cannot access parts of this service</h2>
@@ -36,15 +35,15 @@
 <li>braille</li>
 <li>audio</li>
 <p>Include your address, the title of the document you need and the format you need it in.</p>
-<h2 class="medium">Reporting accessibility problems with this service</h2>
+<h2 class="heading-medium">Reporting accessibility problems with this service</h2>
 <p>We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please contact us. </p>
-<h4><strong>Email
+<h4 class="heading-medium">Email
 </strong><u><a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a></u></h4>
 <p><strong>Telephone
 </strong>0300 456 0300
 Monday to Friday 9:30am to 5pm, except Wednesday.
 Wednesday 10am to 5pm</p>
-<p>Find out about call charges</p>
+<p><a href="https://www.gov.uk/call-charges">Find out about call charges</a></p>
 <h4><strong>Textphone
 </strong>0115 934 2778</h4>
 <h2 class="heading-medium">Enforcement procedure</h2>
@@ -54,26 +53,23 @@ Wednesday 10am to 5pm</p>
 <h3 class="heading-medium">Compliance status</h3>
 <p>This website is partially compliant with the <a href="https://www.w3.org/TR/WCAG21" target="_blank">Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliances listed below.</p>
 <h2 class="heading-medium">Non-accessible content</h2>
-<p>The content listed below is non-accessible for the following reasons.</p>
-<h2 class="heading-medium">Distinguishable</h2>
-<p>Some content cannot be magnified without loss of information or functionality. This fails WCAG 2.1 success criteria 1.4.10 (Reflow).</p>
-<p>Some sight impaired users might not see important controls and understand graphics. This fails WCAG 2.1 success criteria 1.4.11 (Non-Text Contrast).</p>
-<p>Some users might not be able to modify text line height, letter or word spacing. This fails WCAG 2.1 success criteria 1.4.12 (Text Spacing).</p>
-<p>Some users might not be able to interact with or dismiss any ‘extra’ content that becomes visible. This fails WCAG 2.1 success criteria 1.4.13 (Content on Hover or Focus).</p>
-<h2 class="heading-medium">Operable</h2>
-<p>Some users might not be able to switch off or remap keyboard shortcuts. This fails WCAG 2.1 success criteria 2.1.4 (Character Key Shortcuts).</p>
-<p>Users might not be warned when their session will timeout and lose any data they’ve entered. This fails WCAG 2.1 success criteria 2.2.6 (Timeouts).</p>
-<ul><li>2.3.3 Animation from Interactions (AAA)</li></ul>
-<p>Motion animation triggered by interaction can be disabled</p>
-<p>Some users might not be able to turn off animation triggered by</p>
-<p>Some users might not be able to use touchscreens with simple actions, like taps, double taps, and long presses. This fails WCAG 2.1 success criteria 2.5.1 (Pointer Gestures).</p>
-<p>Some users might not be able to cancel or undo an action once they’ve selected a control or user interface component. This fails WCAG 2.1 success criteria 2.5.2 (Pointer Cancellation).</p>
-<p>Some component labels might have text that does not match the Accessible name in the element label. This fails WCAG 2.1 success criteria 2.5.3 (Label in Name).</p>
-<p>Some functionality might only be activated by shaking or tilting the device. This fails WCAG 2.1 success criteria 2.5.4 (Motion Actuation).</p>
-<p>The size of the target for pointer inputs might be smaller than 44 by 44 CSS pixels. This fails WCAG 2.1 success criteria 2.5.5 (Target Size).</p>
-<p>Some users might restricted to using certain input modalities (for example, keyboard, mouse, touchscreen, voice input) and might not be able to switch between them. This fails WCAG 2.1 success criteria 2.5.6 (Concurrent Input Mechanisms). </p>
-<h2 class="heading-medium">Robust</h2>
-<p>Some content might not be shown in a way that assistive technologies understand. This fails WCAG 2.1 AA success criteria 4.1.3 (Status Messages)</p>
+<p>This service was fully compliant with Web Content Accessibility Guidelines (WCAG) 2.0.</p>
+<p>However, we’re currently checking that the service is compliant with Web Content Accessibility Guidelines (WCAG) 2.1.</p>
+<p>The content listed below may be non-accessible. We need to check:</p>
+<li>users can zoom in on content without needing to scroll or without causing poor experience</li>
+<li>non-text content has enough contrast with the background</li>
+<li>text spacing can be changed</li>
+<li>any additional content - for example, pop-ups, submenus - can be dismissed </li>
+<li>users can turn off or change keyboard shortcut</li>
+<li>users are warned when their session will timeout and lose any data they’ve entered</li>
+<li>users can use touchscreens with simple actions, like taps, double taps, and long presses</li>
+<li>users can cancel the trigger when they click down on a mouse or press down with their finger</li>
+<li>accessible labels are the same as the visual text for components</li>
+<li>any function can be activated without shaking or tilting a device</li>
+<li>clickable elements are at least 44 by 44 CSS pixels apart</li>
+<li>users are not restricted to using certain input modalities - for example, keyboard, mouse, touchscreen, voice input - and they can switch between them</li>
+<li>status messages are shown in a way that assistive technologies understand without losing focus</li>
+<p>This work will be completed by xxxxxxx.</p>
 <h3 class="heading-medium">Disproportionate burden</h3>
 <p>Not applicable</p>
 <h3 class="heading-medium">Content that’s not within the scope of the accessibility regulations</h3>

--- a/service-front/module/Application/view/application/general/home/accessibility.twig
+++ b/service-front/module/Application/view/application/general/home/accessibility.twig
@@ -5,15 +5,19 @@
 
 {% block content %}
 
+<div class="text">
 <p>This online service is run by the <a href="https://www.gov.uk/government/organisations/office-of-the-public-guardian">Office of the Public Guardian</a>. We want as many people as possible to be able to use this service. For example, that means you should be able to:</p>
+<ul class="list list-bullet">
 <li>change colours, contrast levels and fonts</li>
 <li>zoom in up to 300% without the text spilling off the screen</li>
 <li>navigate most of the website using just a keyboard</li>
 <li>navigate most of the website using speech recognition software</li>
 <li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
+</ul>
 <p>We’ve also made the website text as simple as possible to understand.</p>
 <h2 class="heading-medium">Get help</h2>
 <p><a href="https://mcmw.abilitynet.org.uk">AbilityNet</a> has guidance about how to:</p>
+<ul class="list list-bullet">
 <li><a href="https://mcmw.abilitynet.org.uk/impairment/making-your-mouse-easier-to-use">make your mouse easier to use</a></li>
 <li><a href="https://mcmw.abilitynet.org.uk/category/keyboard-shortcuts">use your keyboard instead of a mouse</a></li>
 <li><a href="https://mcmw.abilitynet.org.uk/impairment/talking-to-your-device">talk to your device</a></li>
@@ -21,31 +25,36 @@
 <li><a href="https://mcmw.abilitynet.org.uk/impairment/making-text-larger">make text larger</a></li>
 <li><a href="https://mcmw.abilitynet.org.uk/impairment/changing-your-colours">change your colours</a></li>
 <li><a href="https://mcmw.abilitynet.org.uk/impairment/magnifying-the-screen">magnify the screen</a></li>
+</ul>
 <h2 class="heading-medium">How accessible this website is</h2>
 <p>We know some parts of this website are not fully accessible:</p>
+<ul class="list list-bullet">
 <li>the text will not reflow in a single column when you change the size of the browser window</li>
 <li>you cannot modify the line height or spacing of text</li>
 <li>the PDF document produced by the service is not fully accessible to screen reader software</li>
 <li>some of our online forms are difficult to navigate using just a keyboard</li>
 <li>you cannot skip to the main content when using a screen reader</li>
+</ul>
 <h2 class="heading-medium">What to do if you cannot access parts of this service</h2>
 <p>If you cannot use this service, you can use the <a href="https://www.gov.uk/government/publications/make-a-lasting-power-of-attorney">paper version of the LPA</a>. </p>
 <p>You can email <a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a> to get the paper LPA in an alternative format, such as:</p>
+<ul class="list list-bullet">
 <li>large print</li>
 <li>braille</li>
 <li>audio</li>
+</ul>
 <p>Include your address, the title of the document you need and the format you need it in.</p>
 <h2 class="heading-medium">Reporting accessibility problems with this service</h2>
 <p>We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please contact us. </p>
-<h4 class="heading-medium">Email
-</strong><u><a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a></u></h4>
-<p><strong>Telephone
-</strong>0300 456 0300
-Monday to Friday 9:30am to 5pm, except Wednesday.
-Wednesday 10am to 5pm</p>
+<h3 class="heading-small">Email</h4>
+<p><a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a></p>
+<h3 class="heading-small">Telephone</h3>
+<p>0300 456 0300</p>
+<p>Monday to Friday 9:30am to 5pm, except Wednesday.</p>
+<p>Wednesday 10am to 5pm</p>
 <p><a href="https://www.gov.uk/call-charges">Find out about call charges</a></p>
-<h4><strong>Textphone
-</strong>0115 934 2778</h4>
+<h3 class="heading-small">Textphone</h3>
+0115 934 2778</h4>
 <h2 class="heading-medium">Enforcement procedure</h2>
 <p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <a href="https://www.equalityadvisoryservice.com" target="_blank">contact the Equality Advisory and Support Service (EASS)</a>.</p>
 <h2 class="heading-medium">Technical information about this website’s accessibility</h2>
@@ -56,6 +65,7 @@ Wednesday 10am to 5pm</p>
 <p>This service was fully compliant with Web Content Accessibility Guidelines (WCAG) 2.0.</p>
 <p>However, we’re currently checking that the service is compliant with Web Content Accessibility Guidelines (WCAG) 2.1.</p>
 <p>The content listed below may be non-accessible. We need to check:</p>
+<ul class="list list-bullet">
 <li>users can zoom in on content without needing to scroll or without causing poor experience</li>
 <li>non-text content has enough contrast with the background</li>
 <li>text spacing can be changed</li>
@@ -69,6 +79,7 @@ Wednesday 10am to 5pm</p>
 <li>clickable elements are at least 44 by 44 CSS pixels apart</li>
 <li>users are not restricted to using certain input modalities - for example, keyboard, mouse, touchscreen, voice input - and they can switch between them</li>
 <li>status messages are shown in a way that assistive technologies understand without losing focus</li>
+</ul>
 <p>This work will be completed by xxxxxxx.</p>
 <h3 class="heading-medium">Disproportionate burden</h3>
 <p>Not applicable</p>
@@ -77,6 +88,7 @@ Wednesday 10am to 5pm</p>
 <h2 class="heading-medium">Preparation of this accessibility statement</h2>
 <p>This statement was prepared on [date]. It was last reviewed on <sup>[date]</sup>.</p>
 <p>This service was last tested on [date]. The test was carried out by Digital Accessibility Centre (DAC).</p></font></div>
+</div>
 	    
 {% endblock content %}
 

--- a/service-front/module/Application/view/application/general/home/accessibility.twig
+++ b/service-front/module/Application/view/application/general/home/accessibility.twig
@@ -86,8 +86,8 @@
     <h3 class="heading-medium">Content that’s not within the scope of the accessibility regulations</h3>
     <p>Not applicable</p>
     <h2 class="heading-medium">Preparation of this accessibility statement</h2>
-    <p>This statement was prepared on [date]. It was last reviewed on <sup>[date]</sup>.</p>
-    <p>This service was last tested on [date]. The test was carried out by Digital Accessibility Centre (DAC).</p></font>
+    <p>This statement was prepared on 21 Sep 2021. </p>
+    <p>This service was last tested on 10 Oct 2018. The test was carried out by Digital Accessibility Centre (DAC).</p></font>
 </div>
             
 {% endblock content %}

--- a/service-front/module/Application/view/application/general/home/accessibility.twig
+++ b/service-front/module/Application/view/application/general/home/accessibility.twig
@@ -9,7 +9,7 @@
 
 {% block content %}
 
-<p>This online service is run by the <u>Office of the Public Guardian</u>. We want as many people as possible to be able to use this service. For example, that means you should be able to:</p>
+<p>This online service is run by the <a href="https://www.gov.uk/government/organisations/office-of-the-public-guardian">Office of the Public Guardian</a>. We want as many people as possible to be able to use this service. For example, that means you should be able to:</p>
 <ul><li>change colours, contrast levels and fonts</li></ul>
 <li>zoom in up to 300% without the text spilling off the screen</li>
 <li>navigate most of the website using just a keyboard</li>
@@ -17,7 +17,7 @@
 <li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
 <p>We’ve also made the website text as simple as possible to understand.</p>
 <h1><strong>Get help</strong></h1>
-<p><u>AbilityNet</u> has guidance about how to:</p>
+<p><a href="https://mcmw.abilitynet.org.uk">AbilityNet</a> has guidance about how to:</p>
 <ul><li>make your mouse easier to use</li></ul>
 <li>use your keyboard instead of a mouse</li>
 <li>talk to your device</li>
@@ -34,7 +34,7 @@
 <li>some of our online forms are difficult to navigate using just a keyboard</li>
 <li>you cannot skip to the main content when using a screen reader</li>
 <h3><strong>What to do if you cannot access parts of this service</strong></h3>
-<p>If you cannot use this service, you can use the <u>paper version of the LPA</u>. </p>
+<p>If you cannot use this service, you can use the <a href="https://www.gov.uk/government/publications/make-a-lasting-power-of-attorney">paper version of the LPA</a>. </p>
 <p>You can email <a href="mailto:customerservices@publicguardian.gov.uk" target="_blank">customerservices@<wbr>publicguardian.gov.uk</a> to get the paper LPA in an alternative format, such as:</p>
 <ul><li>large print</li></ul>
 <li>braille</li>
@@ -52,11 +52,11 @@ Wednesday 10am to 5pm</p>
 <h4><strong>Textphone
 </strong>0115 934 2778</h4>
 <h3><strong>Enforcement procedure</strong></h3>
-<p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <u>contact the Equality Advisory and Support Service (EASS)</u>.</p>
+<p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <a href="https://www.equalityadvisoryservice.com" target="_blank">contact the Equality Advisory and Support Service (EASS)</a>.</p>
 <h2><strong>Technical information about this website’s accessibility</strong></h2>
 <p>The Office of the Public Guardian is committed to making its online services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
 <h3><strong>Compliance status</strong></h3>
-<p>This website is partially compliant with the <u>Web Content Accessibility Guidelines version 2.1</u> AA standard, due to ‘the non-compliances listed below.</p>
+<p>This website is partially compliant with the <a href="https://www.w3.org/TR/WCAG21" target="_blank">Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliances listed below.</p>
 <h2><strong>Non-accessible content</strong></h2>
 <p>The content listed below is non-accessible for the following reasons.</p>
 	    

--- a/service-front/module/Application/view/layout/twig/layout.twig
+++ b/service-front/module/Application/view/layout/twig/layout.twig
@@ -127,6 +127,7 @@
                     <h2 class="visually-hidden">Support links</h2>
                     <ul class="group">
                         <li><a href="/contact">Contact us</a></li>
+                        <li><a href="/accessibility" target="_blank">Accessibility statement</a></li>
                         <li><a href="/terms" target="_blank">Terms of use</a></li>
                         <li><a href="/privacy-notice" target="_blank">Privacy notice</a></li>
                         <li><a href="/cookies" target="_blank">Cookies</a></li>


### PR DESCRIPTION
## Purpose
_LPA-3752 Create an Accessibility page_


## Approach

_Add the page, and a link to it in the footer. Works along the same lines as the existing Contact Us page. Test to see that its there, similar to the test for the Contact Us page. Have also done an improvement to the README to include info on how to spin it up with the Sirius API Gateway when needed _

## Learning

_Learned about the routing and structure of these pages_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [x] The product team have tested these changes
