### PR TITLE
LPA 3527 secrets change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,14 @@ dc-build:
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
 	docker-compose build
 
+
+.PHONY: dc-build-clean
+dc-build-clean:
+	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
+	docker-compose build --no-cache
+
 .PHONY: dc-down
 dc-down:
 	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := '/bin/bash'
-SENDGRID := $(shell aws-vault exec lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_email_sendgrid_api_key | jq -r .'SecretString')
-GOVPAY := $(shell aws-vault exec lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_gov_pay_key | jq -r .'SecretString')
-ORDNANCESURVEY := $(shell aws-vault exec lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_ordnance_survey_license_key | jq -r .'SecretString')
+SENDGRID := $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_email_sendgrid_api_key | jq -r .'SecretString')
+GOVPAY := $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_gov_pay_key | jq -r .'SecretString')
+ORDNANCESURVEY := $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_ordnance_survey_license_key | jq -r .'SecretString')
 
 .PHONY: all
 all:
@@ -9,7 +9,7 @@ all:
 
 .PHONY: dc-run
 dc-run:
-	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID} > /dev/null; \
 	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
 		docker-compose run front-composer
@@ -42,6 +42,13 @@ dc-build:
 	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
 		docker-compose build
+
+.PHONY: dc-down
+dc-down:
+	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
+		docker-compose down
 
 .PHONY: dc-unit-tests
 dc-unit-tests:

--- a/Makefile
+++ b/Makefile
@@ -9,50 +9,65 @@ all:
 
 .PHONY: dc-run
 dc-run:
-	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID} > /dev/null; \
+	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
 	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
-	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
-		docker-compose run front-composer
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY} ; \
+	docker-compose run front-composer
 
-	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
 	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
-		docker-compose run admin-composer
+	docker-compose run admin-composer
 
-	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
 	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
-		docker-compose run api-composer
+	docker-compose run api-composer
 
-	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
 	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
-		docker-compose run pdf-composer
+	docker-compose run pdf-composer
 
 .PHONY: dc-up
 dc-up:
-	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
 	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
-		docker-compose up
+	docker-compose up
 
 .PHONY: dc-build
 dc-build:
-	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
 	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
-		docker-compose build
+	docker-compose build
 
 .PHONY: dc-down
 dc-down:
-	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
 	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
-		docker-compose down
+	docker-compose down
 
 .PHONY: dc-unit-tests
 dc-unit-tests:
+	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
 	docker-compose run front-app /app/vendor/bin/phpunit
+
+	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
 	docker-compose run admin-app /app/vendor/bin/phpunit
+
+	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
 	docker-compose run api-app /app/vendor/bin/phpunit
+
+	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
 	docker-compose run pdf-app /app/vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ ORDNANCESURVEY := $(shell aws-vault exec lpa-dev -- aws secretsmanager get-secre
 
 .PHONY: all
 all:
-	@${MAKE} up
+	@${MAKE} dc-up
 
-.PHONY: run
-run:
+.PHONY: dc-run
+dc-run:
 	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
 	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
@@ -29,22 +29,22 @@ run:
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
 		docker-compose run pdf-composer
 
-.PHONY: up
-up:
+.PHONY: dc-up
+dc-up:
 	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
 	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
 		docker-compose up
 
-.PHONY: build
-build:
+.PHONY: dc-build
+dc-build:
 	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
 	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
 		docker-compose build
 
-.PHONY: unit-tests
-unit-tests:
+.PHONY: dc-unit-tests
+dc-unit-tests:
 	docker-compose run front-app /app/vendor/bin/phpunit
 	docker-compose run admin-app /app/vendor/bin/phpunit
 	docker-compose run api-app /app/vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+SHELL := '/bin/bash'
+SENDGRID := $(shell aws-vault exec lpa-dev-operator -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_email_sendgrid_api_key | jq -r .'SecretString')
+GOVPAY := $(shell aws-vault exec lpa-dev-operator -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_gov_pay_key | jq -r .'SecretString')
+ORDNANCESURVEY := $(shell aws-vault exec lpa-dev-operator -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_ordnance_survey_license_key | jq -r .'SecretString')
+
+.PHONY: all
+all:
+	@${MAKE} up
+
+.PHONY: run
+run:
+	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
+		docker-compose run front-composer
+
+	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
+		docker-compose run admin-composer
+
+	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
+		docker-compose run api-composer
+
+	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
+		docker-compose run pdf-composer
+
+.PHONY: up
+up:
+	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
+		docker-compose up
+
+.PHONY: build
+build:
+	export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
+	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
+	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
+		docker-compose build
+
+.PHONY: tests
+tests:
+	docker-compose run front-app /app/vendor/bin/phpunit
+	docker-compose run admin-app /app/vendor/bin/phpunit
+	docker-compose run api-app /app/vendor/bin/phpunit
+	docker-compose run pdf-app /app/vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := '/bin/bash'
-SENDGRID := $(shell aws-vault exec lpa-dev-operator -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_email_sendgrid_api_key | jq -r .'SecretString')
-GOVPAY := $(shell aws-vault exec lpa-dev-operator -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_gov_pay_key | jq -r .'SecretString')
-ORDNANCESURVEY := $(shell aws-vault exec lpa-dev-operator -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_ordnance_survey_license_key | jq -r .'SecretString')
+SENDGRID := $(shell aws-vault exec lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_email_sendgrid_api_key | jq -r .'SecretString')
+GOVPAY := $(shell aws-vault exec lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_gov_pay_key | jq -r .'SecretString')
+ORDNANCESURVEY := $(shell aws-vault exec lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_ordnance_survey_license_key | jq -r .'SecretString')
 
 .PHONY: all
 all:

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ build:
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
 		docker-compose build
 
-.PHONY: tests
-tests:
+.PHONY: unit-tests
+unit-tests:
 	docker-compose run front-app /app/vendor/bin/phpunit
 	docker-compose run admin-app /app/vendor/bin/phpunit
 	docker-compose run api-app /app/vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -9,17 +9,9 @@ The first time you bring up the environment:
 git clone git@github.com:ministryofjustice/opg-lpa.git
 cd opg-lpa
 
-docker-compose run front-composer
-docker-compose run admin-composer
-docker-compose run api-composer
-docker-compose run pdf-composer
-
-docker-compose up
+make run
+make
 ```
-
-You will also need a copy of the local config file `service-front/config/autoload/local.php`. Any developer on the team
-should be able to provide you with this.
-
 
 The LPA Tool service will be available via https://localhost:7002/home
 The Admin service will be available via https://localhost:7003
@@ -28,17 +20,14 @@ The API service will be available (direct) via http://localhost:7001
 
 After the first time, you bring up the environment with:
 ```
-docker-compose up
+make
 ```
 
 ### Tests
 
 To run the unit tests
 ```bash
-docker-compose run front-app /app/vendor/bin/phpunit
-docker-compose run admin-app /app/vendor/bin/phpunit
-docker-compose run api-app /app/vendor/bin/phpunit
-docker-compose run pdf-app /app/vendor/bin/phpunit
+make tests
 ```
 
 ### Updating composer dependencies

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The first time you bring up the environment:
 git clone git@github.com:ministryofjustice/opg-lpa.git
 cd opg-lpa
 
-make run
+make dc-run
 make
 ```
 
@@ -27,7 +27,7 @@ make
 
 To run the unit tests
 ```bash
-make unit-tests
+make dc-unit-tests
 ```
 
 ### Updating composer dependencies

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ make
 
 To run the unit tests
 ```bash
-make tests
+make unit-tests
 ```
 
 ### Updating composer dependencies

--- a/README.md
+++ b/README.md
@@ -3,22 +3,30 @@ The Office of the Public Guardian Lasting Power of Attorney online service: Mana
 
 
 ## Local Development Setup
-The first time you bring up the environment:
+
+Intially, download the repo via:
 
 ```
 git clone git@github.com:ministryofjustice/opg-lpa.git
 cd opg-lpa
+```
 
+Within `opg-lpa` directory to *run* the project for the first time use the following:
+
+```
 make dc-run
 make
 ```
+
+The `Makefile` will fetch secrets using `aws secretsmanager` and `docker-compose` commands together to pass along environment variables removing the need for local configuration files.
+
 
 The LPA Tool service will be available via https://localhost:7002/home
 The Admin service will be available via https://localhost:7003
 
 The API service will be available (direct) via http://localhost:7001
 
-After the first time, you bring up the environment with:
+After the first time, you can *run* the project by:
 ```
 make
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,10 @@ services:
       PHP_IDE_CONFIG: serverName=lpa-front-app
       XDEBUG_CONFIG: remote_host=host.docker.internal remote_enable=1
 
+      OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY: "${OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY}"
+      OPG_LPA_FRONT_GOV_PAY_KEY: "${OPG_LPA_FRONT_GOV_PAY_KEY}"
+      OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY: "${OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY}"
+
   front-composer:
     image: composer
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - 8000:8000
 
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:0.9.1
     ports:
       - 4569:4569
       - 4576:4576


### PR DESCRIPTION
## Purpose
Remove the need for local.php config file in the lpa-front-app container for local development. 

Fixes LPA-3527

## Approach

Utilise makefile to fetch secrets directly from aws so theres no need to store them locally or pass them around in files


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
