### PR TITLE
LPA-3720 - add missing security headers to nginx

### DIFF
--- a/service-admin/docker/web/etc/confd/templates/nginx.conf
+++ b/service-admin/docker/web/etc/confd/templates/nginx.conf
@@ -12,6 +12,12 @@ server {
 
     root /web;
 
+    # security headers
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options "nosniff";
+    add_header Strict-Transport-Security "max-age=3600; includeSubDomains";
+
     location / {
         try_files $uri /index.php$is_args$args;
     }

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -12,6 +12,14 @@ server {
 
     root /web;
 
+
+    # security headers
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options "nosniff";
+    add_header Strict-Transport-Security "max-age=3600; includeSubDomains";
+
+
     location / {
         try_files $uri /index.php$is_args$args;
     }


### PR DESCRIPTION
## Purpose
Add standard security headers in nginx 

Fixes LPA-3720

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
