### PR TITLE
Lpa 3762 fix localstack compatibility issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,11 @@ services:
       - 8000:8000
 
   localstack:
-    image: localstack/localstack:0.9.1
+    image: localstack/localstack:latest
     ports:
-      - 4569:4569
-      - 4576:4576
+      - 4566:4566
     environment:
-      - SERVICES=s3:4569,sqs:4576
+      - SERVICES=sqs,s3
       - DEFAULT_REGION=eu-west-1
       - HOSTNAME=localstack
 
@@ -43,10 +42,10 @@ services:
       AWS_SECRET_ACCESS_KEY: "-"
       AWS_ENDPOINT_DYNAMODB: dynamodb:8000
 
-      OPG_LPA_COMMON_SQS_ENDPOINT: http://localstack:4576
+      OPG_LPA_COMMON_SQS_ENDPOINT: localstack:4566
       OPG_LPA_COMMON_PDF_QUEUE_NAME: pdf-queue.fifo
 
-      OPG_LPA_COMMON_S3_ENDPOINT: http://localstack:4569
+      OPG_LPA_COMMON_S3_ENDPOINT: localstack:4566
       OPG_LPA_COMMON_PDF_CACHE_S3_BUCKET: "LpaCache"
 
   # ---------------------------
@@ -192,8 +191,8 @@ services:
       AWS_SECRET_ACCESS_KEY: "-"
 
       OPG_LPA_COMMON_DYNAMODB_ENDPOINT: http://dynamodb:8000
-      OPG_LPA_COMMON_S3_ENDPOINT: http://localstack:4569
-      OPG_LPA_COMMON_PDF_QUEUE_URL: http://localstack:4576/queue/pdf-queue.fifo
+      OPG_LPA_COMMON_S3_ENDPOINT: http://localstack:4566
+      OPG_LPA_COMMON_PDF_QUEUE_URL: http://localstack:4566/000000000000/pdf-queue.fifo
 
       PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
       ENABLE_XDEBUG: "true"
@@ -314,8 +313,8 @@ services:
       AWS_ACCESS_KEY_ID: "-"
       AWS_SECRET_ACCESS_KEY: "-"
 
-      OPG_LPA_COMMON_S3_ENDPOINT: http://localstack:4569
-      OPG_LPA_COMMON_PDF_QUEUE_URL: http://localstack:4576/queue/pdf-queue.fifo
+      OPG_LPA_COMMON_S3_ENDPOINT: http://localstack:4566
+      OPG_LPA_COMMON_PDF_QUEUE_URL: http://localstack:4566/000000000000/pdf-queue.fifo
 
   pdf-composer:
     image: composer

--- a/local-config/start.sh
+++ b/local-config/start.sh
@@ -33,7 +33,7 @@ aws dynamodb create-table \
 --endpoint $DYNAMODN_ENDPOINT
 
 # ----------------------------------------------------------
-/usr/local/bin/waitforit -address=${OPG_LPA_COMMON_SQS_ENDPOINT} -timeout 60 -retry 6000 -debug
+/usr/local/bin/waitforit -address=tcp://${OPG_LPA_COMMON_SQS_ENDPOINT} -timeout 60 -retry 6000 -debug
 
 ATTR="MessageRetentionPeriod=3600,\
 FifoQueue=true,\
@@ -44,13 +44,13 @@ aws sqs create-queue \
 --queue-name=${OPG_LPA_COMMON_PDF_QUEUE_NAME} \
 --attributes="$ATTR" \
 --region=eu-west-1 \
---endpoint=${OPG_LPA_COMMON_SQS_ENDPOINT}
+--endpoint=http://${OPG_LPA_COMMON_SQS_ENDPOINT}
 
 
 # ----------------------------------------------------------
-/usr/local/bin/waitforit -address=${OPG_LPA_COMMON_S3_ENDPOINT} -timeout 60 -retry 6000 -debug
+/usr/local/bin/waitforit -address=tcp://${OPG_LPA_COMMON_S3_ENDPOINT} -timeout 60 -retry 6000 -debug
 
 aws s3api create-bucket \
---endpoint=${OPG_LPA_COMMON_S3_ENDPOINT} \
+--endpoint=http://${OPG_LPA_COMMON_S3_ENDPOINT} \
 --region=eu-west-1 \
 --bucket=${OPG_LPA_COMMON_PDF_CACHE_S3_BUCKET}


### PR DESCRIPTION
## Purpose
Fixes issues with localstack, which were found during running the latest version. This does not affect live systems, because the changes only affect development environments. This can be merged safely once reviewed.

Fixes LPA-3762

## Approach

- Fix port configs to edge port 4566 for localstack
- Workaround issue with http request not returning a value when executing waitforit on 4566. 
- Fix subsequent issue with SQS queue URN configuration changing

## Learning

There have been a couple of breaking changes in LocalStack, which is used for the queuing and file generation of PDFs.

Since 0.11.6, All traffic now has to go through the AWS edge port (4655), rather than as specified for each service.
See:

- https://github.com/localstack/localstack/pull/2905
- https://github.com/localstack/localstack/issues/2983

Note the legacy ports had been deprecated on previous versions.

since 0.11.3 of localstack, SQS queue creation added a fake account id to the urn used for the queue, to be consistent with the live AWS SQS services. this broke the PDF generation messaging queue.

- https://github.com/localstack/localstack/issues/2612 
- https://github.com/localstack/localstack/issues/2877
- https://github.com/localstack/localstack/pull/2591

rather than pinning to a working version, we fixed the breaking docker-compose configuration. there were also  issues with waitforit on the local-config service, which we could workaround using a tcp check only.

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
