### PR TITLE
Lpa 3447 postgres upgrade

### DIFF
--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -16,6 +16,7 @@ variable "accounts" {
       backup_retention_period       = number
       skip_final_snapshot           = bool
       psql_engine_version           = string
+      psql_parameter_group_family   = string
       autoscaling = object({
         front = object({
           minimum = number

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -15,6 +15,7 @@ variable "accounts" {
       prevent_db_destroy            = bool
       backup_retention_period       = number
       skip_final_snapshot           = bool
+      psql_engine_version           = string
       autoscaling = object({
         front = object({
           minimum = number

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -24,7 +24,7 @@ resource "aws_db_instance" "api" {
 resource "aws_db_parameter_group" "postgres-db-params" {
   name        = lower("postgres-db-params-${local.environment}")
   description = "default postgres rds parameter group"
-  family      = "postgres${local.account.psql_engine_version}"
+  family      = "postgres${local.account.psql_parameter_group_family}"
 
   parameter {
     name         = "log_min_duration_statement"

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -1,38 +1,38 @@
 resource "aws_db_instance" "api" {
-  identifier                 = lower("api-${local.environment}")
-  name                       = "api2"
-  allocated_storage          = 10
-  storage_type               = "gp2"
-  storage_encrypted          = true
-  skip_final_snapshot        = local.account.skip_final_snapshot
-  engine                     = "postgres"
-  engine_version             = local.account.psql_engine_version
-  instance_class             = "db.m3.medium"
-  port                       = "5432"
-  username                   = data.aws_secretsmanager_secret_version.api_rds_username.secret_string
-  password                   = data.aws_secretsmanager_secret_version.api_rds_password.secret_string
-  parameter_group_name       = aws_db_parameter_group.postgres-db-params.name
-  vpc_security_group_ids     = [aws_security_group.rds-api.id]
-  auto_minor_version_upgrade = false
-  maintenance_window         = "sun:01:00-sun:01:30"
-  multi_az                   = true
-  backup_retention_period    = local.account.backup_retention_period
-  deletion_protection        = local.account.prevent_db_destroy
-  tags                       = local.default_tags
-  allow_major_version_upgrade= true
+  identifier                  = lower("api-${local.environment}")
+  name                        = "api2"
+  allocated_storage           = 10
+  storage_type                = "gp2"
+  storage_encrypted           = true
+  skip_final_snapshot         = local.account.skip_final_snapshot
+  engine                      = "postgres"
+  engine_version              = local.account.psql_engine_version
+  instance_class              = "db.m3.medium"
+  port                        = "5432"
+  username                    = data.aws_secretsmanager_secret_version.api_rds_username.secret_string
+  password                    = data.aws_secretsmanager_secret_version.api_rds_password.secret_string
+  parameter_group_name        = aws_db_parameter_group.postgres-db-params.name
+  vpc_security_group_ids      = [aws_security_group.rds-api.id]
+  auto_minor_version_upgrade  = false
+  maintenance_window          = "sun:01:00-sun:01:30"
+  multi_az                    = true
+  backup_retention_period     = local.account.backup_retention_period
+  deletion_protection         = local.account.prevent_db_destroy
+  tags                        = local.default_tags
+  allow_major_version_upgrade = true
 }
 
 resource "aws_db_parameter_group" "postgres-db-params" {
   name        = lower("postgres-db-params-${local.environment}")
   description = "default postgres rds parameter group"
   family      = local.account.psql_parameter_group_family
-
+  # -1 is default which would not log anything
   parameter {
     name         = "log_min_duration_statement"
     value        = "500"
     apply_method = "immediate"
   }
-
+  # none is default
   parameter {
     name         = "log_statement"
     value        = "none"

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -26,13 +26,13 @@ resource "aws_db_parameter_group" "postgres-db-params" {
   name        = lower("postgres-db-params-${local.environment}")
   description = "default postgres rds parameter group"
   family      = local.account.psql_parameter_group_family
-  # -1 is default which would not log anything
+
   parameter {
     name         = "log_min_duration_statement"
     value        = "500"
     apply_method = "immediate"
   }
-  # none is default
+
   parameter {
     name         = "log_statement"
     value        = "none"

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -6,7 +6,7 @@ resource "aws_db_instance" "api" {
   storage_encrypted          = true
   skip_final_snapshot        = local.account.skip_final_snapshot
   engine                     = "postgres"
-  engine_version             = "9.6.15"
+  engine_version             = local.account.psql_engine_version
   instance_class             = "db.m3.medium"
   port                       = "5432"
   username                   = data.aws_secretsmanager_secret_version.api_rds_username.secret_string

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -19,6 +19,7 @@ resource "aws_db_instance" "api" {
   backup_retention_period    = local.account.backup_retention_period
   deletion_protection        = local.account.prevent_db_destroy
   tags                       = local.default_tags
+  allow_major_version_upgrade= true
 }
 
 resource "aws_db_parameter_group" "postgres-db-params" {

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -24,7 +24,7 @@ resource "aws_db_instance" "api" {
 resource "aws_db_parameter_group" "postgres-db-params" {
   name        = lower("postgres-db-params-${local.environment}")
   description = "default postgres rds parameter group"
-  family      = "${local.account.psql_parameter_group_family}"
+  family      = local.account.psql_parameter_group_family
 
   parameter {
     name         = "log_min_duration_statement"

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -13,7 +13,7 @@ resource "aws_db_instance" "api" {
   password                   = data.aws_secretsmanager_secret_version.api_rds_password.secret_string
   parameter_group_name       = aws_db_parameter_group.postgres-db-params.name
   vpc_security_group_ids     = [aws_security_group.rds-api.id]
-  auto_minor_version_upgrade = true
+  auto_minor_version_upgrade = false
   maintenance_window         = "sun:01:00-sun:01:30"
   multi_az                   = true
   backup_retention_period    = local.account.backup_retention_period

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -24,7 +24,7 @@ resource "aws_db_instance" "api" {
 resource "aws_db_parameter_group" "postgres-db-params" {
   name        = lower("postgres-db-params-${local.environment}")
   description = "default postgres rds parameter group"
-  family      = "postgres9.6"
+  family      = "postgres${local.account.psql_engine_version}"
 
   parameter {
     name         = "log_min_duration_statement"

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -24,7 +24,7 @@ resource "aws_db_instance" "api" {
 resource "aws_db_parameter_group" "postgres-db-params" {
   name        = lower("postgres-db-params-${local.environment}")
   description = "default postgres rds parameter group"
-  family      = "postgres${local.account.psql_parameter_group_family}"
+  family      = "${local.account.psql_parameter_group_family}"
 
   parameter {
     name         = "log_min_duration_statement"

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -15,6 +15,7 @@
       "prevent_db_destroy": false,
       "backup_retention_period": 0,
       "skip_final_snapshot" : true,
+      "psql_engine_version": "10.13",
       "autoscaling": {
         "front": {
           "minimum": 1,
@@ -44,6 +45,7 @@
       "prevent_db_destroy": false,
       "backup_retention_period": 0,
       "skip_final_snapshot" : true,
+      "psql_engine_version": "9.6.15",
       "autoscaling": {
         "front": {
           "minimum": 1,
@@ -73,6 +75,7 @@
       "prevent_db_destroy": true,
       "backup_retention_period": 30,
       "skip_final_snapshot" : false,
+      "psql_engine_version": "9.6.15",
       "autoscaling": {
         "front": {
           "minimum": 3,

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -16,6 +16,7 @@
       "backup_retention_period": 0,
       "skip_final_snapshot" : true,
       "psql_engine_version": "10.13",
+      "psql_parameter_group_family": "postgres10",
       "autoscaling": {
         "front": {
           "minimum": 1,
@@ -46,6 +47,7 @@
       "backup_retention_period": 0,
       "skip_final_snapshot" : true,
       "psql_engine_version": "9.6.15",
+      "psql_parameter_group_family": "postgres9.6",
       "autoscaling": {
         "front": {
           "minimum": 1,
@@ -76,6 +78,7 @@
       "backup_retention_period": 30,
       "skip_final_snapshot" : false,
       "psql_engine_version": "9.6.15",
+      "psql_parameter_group_family": "postgres9.6",
       "autoscaling": {
         "front": {
           "minimum": 3,


### PR DESCRIPTION
## Purpose
Upgrade postgres version so can be moved to aurora later

Fixes LPA-3447

## Learning

Upgrading has version matching (version x should move to version y) see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
