### PR TITLE
Update remote docker version due to deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 18.06.0-ce
+              version: 19.03.12
               docker_layer_caching: false
           - run:
               name: Build web container
@@ -581,7 +581,7 @@ orbs:
         steps:
           - checkout
           - setup_remote_docker:
-              version: 18.06.0-ce
+              version: 19.03.12
               docker_layer_caching: false
           - attach_workspace:
               at: /tmp


### PR DESCRIPTION
## Purpose
Avoid using the deprecated docker version

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
