### PR TITLE
change pdf to point at PHP 7.4 image

### DIFF
--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -4,14 +4,14 @@ COPY service-pdf /app
 
 RUN composer install --prefer-dist --no-suggest --no-interaction --no-scripts --optimize-autoloader
 
-FROM php:7-cli
+FROM php:7.4-cli
 
 # mkdir below fixes a known issue with openjdk https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN apt-get -y update \
     && mkdir -p /usr/share/man/man1 \
     && apt-get -y install pdftk \
     && apt-get -y clean \
-    && pecl install xdebug \ 
+    && pecl install xdebug \
     && pecl clear-cache
 
 COPY service-pdf /app

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -4,7 +4,7 @@ COPY service-pdf /app
 
 RUN composer install --prefer-dist --no-suggest --no-interaction --no-scripts --optimize-autoloader
 
-FROM php:7.4-cli
+FROM php:cli-buster
 
 # mkdir below fixes a known issue with openjdk https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN apt-get -y update \


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

check for vulnerabilities in pdf container after 

## Approach

see if we can get rid of CVE errors listed by ecs scan

## Learning



## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
