### PR TITLE
LPAL-3 make seeding more robust to db not being ready

### DIFF
--- a/scripts/non_live_seeding/seed_environment.sh
+++ b/scripts/non_live_seeding/seed_environment.sh
@@ -22,16 +22,6 @@ else
 fi
 }
 
-#check_users_table_exists()
-#{
-#if [ "$( PGPASSWORD=${OPG_LPA_POSTGRES_PASSWORD} psql ${API_OPTS} lpadb -tAc "SELECT 1 FROM pg_database WHERE datname='${OPG_LPA_POSTGRES_NAME}'" )" = '1' ]
-#then
-    #echo "Users table exists. Can continue"
-#else
-    #echo "Users table does not exist. Seeding will fail"
-#fi
-#}
-
 if [ "$OPG_LPA_STACK_NAME" == "production" ]; then
   echo "These scripts must not be run on production."
   exit 0

--- a/scripts/non_live_seeding/seed_environment.sh
+++ b/scripts/non_live_seeding/seed_environment.sh
@@ -12,16 +12,43 @@
 
 AWS_DEFAULT_REGION=eu-west-1
 
+check_db_exists()
+{
+if [ "$( PGPASSWORD=${OPG_LPA_POSTGRES_PASSWORD} psql ${API_OPTS} lpadb -tAc "SELECT 1 FROM pg_database WHERE datname='${OPG_LPA_POSTGRES_NAME}'" )" = '1' ]
+then
+    echo "LPA Database exists. Can continue"
+else
+    echo "LPA Database does not exist. Seeding will fail"
+fi
+}
+
+#check_users_table_exists()
+#{
+#if [ "$( PGPASSWORD=${OPG_LPA_POSTGRES_PASSWORD} psql ${API_OPTS} lpadb -tAc "SELECT 1 FROM pg_database WHERE datname='${OPG_LPA_POSTGRES_NAME}'" )" = '1' ]
+#then
+    #echo "Users table exists. Can continue"
+#else
+    #echo "Users table does not exist. Seeding will fail"
+#fi
+#}
+
 if [ "$OPG_LPA_STACK_NAME" == "production" ]; then
   echo "These scripts must not be run on production."
   exit 0
 fi
 
+echo "Waiting for postgres to be ready"
+timeout 90s sh -c 'pgready=1; until [ ${pgready} -eq 0 ]; do pg_isready -h ${OPG_LPA_POSTGRES_HOSTNAME} -d ${OPG_LPA_POSTGRES_NAME}; pgready=$? ; sleep 5 ; done'
+
 API_OPTS="--host=${OPG_LPA_POSTGRES_HOSTNAME} --username=${OPG_LPA_POSTGRES_USERNAME}"
+echo "Waiting for database to be created"
+check_db_exists
 
 # PGPASSWORD=${OPG_LPA_POSTGRES_PASSWORD} psql ${API_OPTS} \
 #   ${OPG_LPA_POSTGRES_NAME} \
 #   -f clear_tables.sql
+
+sleep 20
 
 PGPASSWORD=${OPG_LPA_POSTGRES_PASSWORD} psql ${API_OPTS} \
   ${OPG_LPA_POSTGRES_NAME} \


### PR DESCRIPTION
## Purpose
_When running locally, seeding has often been failing because the database was not ready_

## Approach

_Modified the seeding script. This waits for postgres to be ready. It then checks the database exists and warns if not. It then sleeps for a further 20 secs for the tables to be created. This could be improved to do a proper db query for the existence of the table we want to insert into. However, remember this is dev only and a simple sleep likely does the trick. No need for complexity if it doesn't add anything_

## Learning

_Along the way, doing related work on trying to slim down what starts, I've played with trying to put services into seperate docker-compose files. This isn't straightforward. You then have to always specify files with -f .  Which doesn't work with docker build. So all too easy to forget to rebuild all services and get an obscure problem. I also tried specifying only certain services with docker-compose up but the way we have them now they don't seem to start up their dependencies properly. Maybe our docker-compose.yml needs tweaking for this to work properly. Can be investigated on another ticket _

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
