### PR TITLE
LPA-3447  and LPAL-15 PSQL Version to 10.13

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -77,8 +77,8 @@
       "prevent_db_destroy": true,
       "backup_retention_period": 30,
       "skip_final_snapshot" : false,
-      "psql_engine_version": "9.6.15",
-      "psql_parameter_group_family": "postgres9.6",
+      "psql_engine_version": "10.13",
+      "psql_parameter_group_family": "postgres10",
       "autoscaling": {
         "front": {
           "minimum": 3,


### PR DESCRIPTION
## Purpose
UPGRADE PRODUCTION DATABASE VERSION to PSQL 10.3. DO NOT MERGE UNTIL REQUIRED

Fixes LPA-3447 and LPAL-15

## Approach

change tfvars.json prod variables for postgres to be 10.13.
Note this is to retrofit the manual change as the path to live takes time.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
