### PR TITLE
add reference to docker hub credentials + cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,6 @@ workflows:
               api_docker_build,
               pdf_docker_build,
               seeding_docker_build,
-              #dev_environment_apply_terraform,
             ]
 
       - infrastructure_and_deployment/seed_environment_databases:
@@ -172,7 +171,6 @@ workflows:
               admin_docker_build,
               api_docker_build,
               pdf_docker_build,
-              preprod_environment_apply_terraform,
             ]
 
       - infrastructure_and_deployment/seed_environment_databases:
@@ -212,11 +210,19 @@ workflows:
 
 orbs:
   slack: circleci/slack@3.3.0
+  docker_common:
+    commands:
+      dockerhub_login:
+        steps:
+        - run:
+            name: Login to Docker hub
+            command: echo "$DOCKER_ACCESS_TOKEN" | docker login --username $DOCKER_USER --password-stdin
+
   build_containers_and_push_to_ecr:
     commands:
       install_aws_cli:
         steps:
-          - run:
+         - run:
               name: Install AWS CLI
               command: sudo pip3 install awscli --upgrade
       ecr_login:
@@ -233,6 +239,9 @@ orbs:
       python:
         docker:
           - image: circleci/python
+            auth:
+              username: $DOCKER_USER
+              password: $DOCKER_ACCESS_TOKEN
     jobs:
       checkout_docker_build_push_web-app:
         executor: python
@@ -259,6 +268,7 @@ orbs:
           - setup_remote_docker:
               version: 19.03.12
               docker_layer_caching: false
+          - docker_common/dockerhub_login
           - run:
               name: Build web container
               command: |
@@ -319,7 +329,7 @@ orbs:
       install_workspace_manager:
         steps:
           - run:
-              name: install Workspace Manager
+              name: Install Terraform Workspace Manager
               command: |
                 pwd
                 apk add libc6-compat
@@ -346,13 +356,30 @@ orbs:
                 rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
     executors:
       python:
-        docker: [image: circleci/python]
+        docker:
+         - image: circleci/python
+           auth:
+              username: $DOCKER_USER
+              password: $DOCKER_ACCESS_TOKEN
       python-build:
-        docker: [image: python:alpine]
+        docker:
+          - image: python:alpine
+            auth:
+              username: $DOCKER_USER
+              password: $DOCKER_ACCESS_TOKEN
       python-browsers:
-        docker: [image: circleci/python:3.6-stretch-browsers]
+        docker:
+          - image: circleci/python:3.6-stretch-browsers
+            auth:
+              username: $DOCKER_USER
+              password: $DOCKER_ACCESS_TOKEN
+
       terraform:
-        docker: [image: hashicorp/terraform:0.12.28]
+        docker:
+        - image: hashicorp/terraform:0.12.28
+          auth:
+              username: $DOCKER_USER
+              password: $DOCKER_ACCESS_TOKEN
     jobs:
       #----------------------------------------------------
       # Lambda
@@ -608,6 +635,7 @@ orbs:
               docker_layer_caching: false
           - attach_workspace:
               at: /tmp
+          - docker_common/dockerhub_login
           - run:
               name: Build casper JS container
               command: |
@@ -675,6 +703,9 @@ jobs:
   cancel_redundant_builds:
     docker:
       - image: circleci/python
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     resource_class: small
     steps:
       - checkout
@@ -690,6 +721,9 @@ jobs:
   slack_notify_domain:
     docker:
       - image: circleci/python
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     parameters:
       workspace:
         description: Terraform workspace name
@@ -713,6 +747,9 @@ jobs:
   slack_notify_production_release:
     docker:
       - image: circleci/python
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     parameters:
       workspace:
         description: Terraform workspace name
@@ -738,6 +775,9 @@ jobs:
   ecr_scan_results:
     docker:
       - image: circleci/python
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     steps:
       - checkout
       - run:
@@ -751,6 +791,9 @@ jobs:
   workspace_cleanup:
     docker:
       - image: hashicorp/terraform
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     steps:
       - checkout
       - infrastructure_and_deployment/install_workspace_manager

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ workflows:
 orbs:
   slack: circleci/slack@3.3.0
 
-  docker_common:
+  build_containers_and_push_to_ecr:
     commands:
       dockerhub_login:
         steps:
@@ -219,8 +219,6 @@ orbs:
             name: Login to Docker hub
             command: echo "$DOCKER_ACCESS_TOKEN" | docker login --username $DOCKER_USER --password-stdin
 
-  build_containers_and_push_to_ecr:
-    commands:
       install_aws_cli:
         steps:
          - run:
@@ -269,7 +267,7 @@ orbs:
           - setup_remote_docker:
               version: 19.03.12
               docker_layer_caching: false
-          - docker_common/dockerhub_login
+          - dockerhub_login
           - run:
               name: Build web container
               command: |
@@ -327,6 +325,12 @@ orbs:
 
   infrastructure_and_deployment:
     commands:
+      dockerhub_login:
+        steps:
+        - run:
+            name: Login to Docker hub
+            command: echo "$DOCKER_ACCESS_TOKEN" | docker login --username $DOCKER_USER --password-stdin
+
       install_workspace_manager:
         steps:
           - run:
@@ -636,7 +640,7 @@ orbs:
               docker_layer_caching: false
           - attach_workspace:
               at: /tmp
-          - docker_common/dockerhub_login
+          - dockerhub_login
           - run:
               name: Build casper JS container
               command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,8 +210,6 @@ workflows:
 
 orbs:
   slack: circleci/slack@3.3.0
-
-
   build_containers_and_push_to_ecr:
     orbs:
       docker: circleci/docker@1.4.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,7 @@ workflows:
 
 orbs:
   slack: circleci/slack@3.3.0
+
   docker_common:
     commands:
       dockerhub_login:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,14 +211,16 @@ workflows:
 orbs:
   slack: circleci/slack@3.3.0
 
+
   build_containers_and_push_to_ecr:
+    orbs:
+      docker: circleci/docker@1.4.0
     commands:
       dockerhub_login:
         steps:
-        - run:
-            name: Login to Docker hub
-            command: echo "$DOCKER_ACCESS_TOKEN" | docker login --username $DOCKER_USER --password-stdin
-
+          - docker/check:
+              docker-password: DOCKER_ACCESS_TOKEN
+              docker-username: DOCKER_USER
       install_aws_cli:
         steps:
          - run:
@@ -324,13 +326,14 @@ orbs:
                 fi
 
   infrastructure_and_deployment:
+    orbs:
+      docker: circleci/docker@1.4.0
     commands:
       dockerhub_login:
         steps:
-        - run:
-            name: Login to Docker hub
-            command: echo "$DOCKER_ACCESS_TOKEN" | docker login --username $DOCKER_USER --password-stdin
-
+          - docker/check:
+              docker-password: DOCKER_ACCESS_TOKEN
+              docker-username: DOCKER_USER
       install_workspace_manager:
         steps:
           - run:


### PR DESCRIPTION
## Purpose
Add Dockerhub authentication to CircleCI pipeline. See Learning notes and ticket for details.

Fixes LPAL-170

## Approach

Add details to retrieve env vars with docker credentials, to service authenticated pulls.

## Learning

We have prerequisite technical guidance, to cover set up steps for this: https://ministryofjustice.github.io/opg-technical-guidance/runbooks/CI_pipelines/adding-ci-dockerhub-users/#adding-a-service-dockerid-to-circleci-build, which we hope to improve in the future.
 see also: 
- Using Docker Authenticated Pulls https://circleci.com/docs/2.0/private-images/ 

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
