### PR TITLE
build pipeline improvements (docker credentials and circleci resource classes)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,6 +216,7 @@ orbs:
     commands:
       dockerhub_login:
         steps:
+          - docker/install-docker-credential-helper
           - docker/check:
               docker-password: DOCKER_ACCESS_TOKEN
               docker-username: DOCKER_USER
@@ -330,6 +331,7 @@ orbs:
     commands:
       dockerhub_login:
         steps:
+          - docker/install-docker-credential-helper
           - docker/check:
               docker-password: DOCKER_ACCESS_TOKEN
               docker-username: DOCKER_USER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,7 @@ orbs:
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN
+        resource_class: small
     jobs:
       checkout_docker_build_push_web-app:
         executor: python
@@ -367,18 +368,21 @@ orbs:
            auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN
+        resource_class: small
       python-build:
         docker:
           - image: python:alpine
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN
+        resource_class: small
       python-browsers:
         docker:
           - image: circleci/python:3.6-stretch-browsers
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN
+        resource_class: small
 
       terraform:
         docker:
@@ -386,6 +390,7 @@ orbs:
           auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN
+        resource_class: small
     jobs:
       #----------------------------------------------------
       # Lambda
@@ -730,6 +735,7 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_ACCESS_TOKEN
+    resource_class: small
     parameters:
       workspace:
         description: Terraform workspace name
@@ -756,6 +762,7 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_ACCESS_TOKEN
+    resource_class: small
     parameters:
       workspace:
         description: Terraform workspace name
@@ -784,6 +791,7 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_ACCESS_TOKEN
+    resource_class: small
     steps:
       - checkout
       - run:
@@ -800,6 +808,7 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_ACCESS_TOKEN
+    resource_class: small
     steps:
       - checkout
       - infrastructure_and_deployment/install_workspace_manager


### PR DESCRIPTION
## Purpose
making a couple of useful fixes whilst i'm in the config.yaml for circleci. 

This is based on:
 - conversations with @andrewpearce-digital around `resource_class`
 - Use an LPA PR:https://github.com/ministryofjustice/opg-use-an-lpa/pull/590.

2 improvements:
- add a credential manager to docker logins.
- change resource class to small as this is sufficient for our build = less credits spent!


## Approach

update`config.yaml`

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
