### PR TITLE
simplify running of the call api gateway script, align with UaL

### DIFF
--- a/scripts/call_api_gateway/.envrc
+++ b/scripts/call_api_gateway/.envrc
@@ -1,4 +1,0 @@
-export AWS_ACCOUNT_ID=288342028542
-export AWS_IAM_ROLE=sirius-api-gateway-access-lpa-online-tool
-export API_GATEWAY_URL="https://api.dev.sirius.opg.digital/v1/lpa-online-tool/lpas/"
-export BASE_URL='https://frontend-integration.sirius.opg.digital'

--- a/scripts/call_api_gateway/README.md
+++ b/scripts/call_api_gateway/README.md
@@ -2,23 +2,22 @@
 
 This script returns case data for a Sirius case ID.
 
-It makes an authenticated request to the sirius api gateway. 
-
-The script reads account id, iam role and api gateway url from environment variables.
-
-You can set these using direnv
-```bash
-direnv allow
-```
- or by sourcing the .envrc file
-```bash
-source .envrc
-```
+It makes an authenticated request to the sirius api gateway.
 
 The script uses your IAM user credentials to assume the appropriate role.
+By default will query the development Sirius API Gateway.
+The `--production` flag can be used to request a result from the production Sirius API Gateway.
 
-You can provide the script credentials using aws-vault
+You can provide the script credentials using aws-vault [aws-vault](https://github.com/99designs/aws-vault)
+
+Call the development gateway
 
 ```bash
 aws-vault exec identity -- python ./call_api_gateway.py A12345678
+```
+
+Call the production gateway
+
+```bash
+aws-vault exec identity -- python ./call_api_gateway.py A12345678 --production
 ```


### PR DESCRIPTION
## Purpose
to simplify the use call api gateway script, so there is no setup or .envrc needed, to align with UaL. 
This also adds a production switch.

## Approach

mirror UaL script, which is more fixed. operator role assume is default now.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
