### PR TITLE
LPAL-18 workflow refactor and schedule for weekly deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,12 +217,12 @@ workflows:
   weekly_refresh_build:
     triggers:
       - schedule:
-           cron: "50 9 * * 1" # 2 am on wednesday (CHANGEME!)
+           cron: "0 3 * * 3" # 3 am (UTC) on wednesday
            filters:
              branches:
                only:
-                 - LPAL-18-run-scheduled-refresh
-    <<: *pr_build
+                 - master
+    <<: *path_to_live
 
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,200 +13,222 @@ workflows:
        - workspace_cleanup:
            name: workspace_cleanup
 
-  pr_build:
+  pr_build_workflow:
     jobs:
-      - cancel_redundant_builds:
-          name: cancel_previous_jobs
-          filters: { branches: { ignore: [master] } }
+      - pr_build:
+          name: pr_build
 
-      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
-          name: front_docker_build
-          ecr_repository_name_prefix: online-lpa/front
-          service_path: service-front
-          filters: { branches: { ignore: [master] } }
-
-      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
-          name: admin_docker_build
-          ecr_repository_name_prefix: online-lpa/admin
-          service_path: service-admin
-          filters: { branches: { ignore: [master] } }
-
-      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
-          name: api_docker_build
-          ecr_repository_name_prefix: online-lpa/api
-          service_path: service-api
-          filters: { branches: { ignore: [master] } }
-
-      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
-          name: pdf_docker_build
-          ecr_repository_name_prefix: online-lpa/pdf
-          service_path: service-pdf
-          build_web: false
-          filters: { branches: { ignore: [master] } }
-
-      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
-          name: seeding_docker_build
-          ecr_repository_name_prefix: online-lpa/seeding
-          service_path: service-seeding
-          build_web: false
-          unit_test: false
-          filters: { branches: { ignore: [master] } }
-
-      - infrastructure_and_deployment/lint_and_validate_terraform:
-          name: lint_and_validate_terraform
-          filters: { branches: { ignore: [master] } }
-
-      - infrastructure_and_deployment/apply_account_terraform:
-          name: dev_account_apply_terraform
-          workspace: development
-          filters: { branches: { ignore: [master] } }
-          requires: [cancel_previous_jobs, lint_and_validate_terraform]
-
-      - infrastructure_and_deployment/apply_email_terraform:
-          name: email_apply_terraform
-          workspace: development
-          filters: { branches: { ignore: [master] } }
-          requires: [cancel_previous_jobs, lint_and_validate_terraform]
-
-      - infrastructure_and_deployment/apply_environment_terraform:
-          name: dev_environment_apply_terraform
-          filters: { branches: { ignore: [master] } }
-          requires:
-            [
-              cancel_previous_jobs,
-              dev_account_apply_terraform,
-              front_docker_build,
-              admin_docker_build,
-              api_docker_build,
-              pdf_docker_build,
-              seeding_docker_build,
-            ]
-
-      - ecr_scan_results:
-          name: ecr_scan_results_development
-          filters: { branches: { ignore: [master] } }
-          requires:
-            [
-              front_docker_build,
-              admin_docker_build,
-              api_docker_build,
-              pdf_docker_build,
-              seeding_docker_build,
-            ]
-
-      - infrastructure_and_deployment/seed_environment_databases:
-          name: dev_seed_environment_databases
-          filters: { branches: { ignore: [master] } }
-          requires: [dev_environment_apply_terraform]
-
-      - infrastructure_and_deployment/run_functional_test:
-          name: run_functional_test
-          filters: { branches: { ignore: [master] } }
-          requires: [dev_seed_environment_databases]
-
-      - slack_notify_domain:
-          name: post_environment_domains
-          filters: { branches: { ignore: [master] } }
-          requires: [run_functional_test]
-
-  path_to_live:
+  path_to_live_workflow:
     jobs:
-      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
-          name: front_docker_build
-          ecr_repository_name_prefix: online-lpa/front
-          service_path: service-front
-          filters: { branches: { only: [master] } }
+      - path_to_live:
+          name: path_to_live
 
-      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
-          name: admin_docker_build
-          ecr_repository_name_prefix: online-lpa/admin
-          service_path: service-admin
-          filters: { branches: { only: [master] } }
+  weekly_refresh_build:
+    triggers:
+      - schedule:
+           cron: "30 10 * * 1" # 2 am on wednesday (proposed)
+           filters:
+             branches:
+               only:
+                 - LPAL-18-run-scheduled-refresh
+    jobs:
+    - pr_build:
+          name: weekly_refresh
 
-      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
-          name: api_docker_build
-          ecr_repository_name_prefix: online-lpa/api
-          service_path: service-api
-          filters: { branches: { only: [master] } }
+pr_build:
+  jobs:
+    - cancel_redundant_builds:
+        name: cancel_previous_jobs
+        filters: { branches: { ignore: [master] } }
 
-      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
-          name: pdf_docker_build
-          ecr_repository_name_prefix: online-lpa/pdf
-          service_path: service-pdf
-          build_web: false
-          filters: { branches: { only: [master] } }
+    - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+        name: front_docker_build
+        ecr_repository_name_prefix: online-lpa/front
+        service_path: service-front
+        filters: { branches: { ignore: [master] } }
 
-      - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
-          name: seeding_docker_build
-          ecr_repository_name_prefix: online-lpa/seeding
-          service_path: service-seeding
-          build_web: false
-          unit_test: false
-          filters: { branches: { only: [master] } }
+    - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+        name: admin_docker_build
+        ecr_repository_name_prefix: online-lpa/admin
+        service_path: service-admin
+        filters: { branches: { ignore: [master] } }
 
-      - infrastructure_and_deployment/apply_account_terraform:
-          name: preprod_account_apply_terraform
-          workspace: preproduction
-          filters: { branches: { only: [master] } }
+    - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+        name: api_docker_build
+        ecr_repository_name_prefix: online-lpa/api
+        service_path: service-api
+        filters: { branches: { ignore: [master] } }
 
-      - infrastructure_and_deployment/apply_environment_terraform:
-          name: preprod_environment_apply_terraform
-          workspace: preproduction
-          filters: { branches: { only: [master] } }
-          requires:
-            [
-              preprod_account_apply_terraform,
-              front_docker_build,
-              admin_docker_build,
-              api_docker_build,
-              pdf_docker_build,
-            ]
+    - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+        name: pdf_docker_build
+        ecr_repository_name_prefix: online-lpa/pdf
+        service_path: service-pdf
+        build_web: false
+        filters: { branches: { ignore: [master] } }
 
-      - ecr_scan_results:
-          name: ecr_scan_results_master
-          filters: { branches: { only: [master] } }
-          requires:
-            [
-              front_docker_build,
-              admin_docker_build,
-              api_docker_build,
-              pdf_docker_build,
-            ]
+    - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+        name: seeding_docker_build
+        ecr_repository_name_prefix: online-lpa/seeding
+        service_path: service-seeding
+        build_web: false
+        unit_test: false
+        filters: { branches: { ignore: [master] } }
 
-      - infrastructure_and_deployment/seed_environment_databases:
-          name: preprod_seed_environment_databases
-          workspace: preproduction
-          filters: { branches: { only: [master] } }
-          requires: [preprod_environment_apply_terraform]
+    - infrastructure_and_deployment/lint_and_validate_terraform:
+        name: lint_and_validate_terraform
+        filters: { branches: { ignore: [master] } }
 
-      - infrastructure_and_deployment/run_functional_test:
-          name: preprod_test_functional
-          workspace: preproduction
-          filters: { branches: { only: [master] } }
-          requires: [preprod_seed_environment_databases]
+    - infrastructure_and_deployment/apply_account_terraform:
+        name: dev_account_apply_terraform
+        workspace: development
+        filters: { branches: { ignore: [master] } }
+        requires: [cancel_previous_jobs, lint_and_validate_terraform]
 
-      - infrastructure_and_deployment/apply_account_terraform:
-          name: prod_account_apply_terraform
-          workspace: production
-          filters: { branches: { only: [master] } }
-          requires: [preprod_test_functional]
+    - infrastructure_and_deployment/apply_email_terraform:
+        name: email_apply_terraform
+        workspace: development
+        filters: { branches: { ignore: [master] } }
+        requires: [cancel_previous_jobs, lint_and_validate_terraform]
 
-      - infrastructure_and_deployment/apply_environment_terraform:
-          name: prod_environment_apply_terraform
-          requires: [prod_account_apply_terraform]
-          filters: { branches: { only: [master] } }
-          workspace: production
+    - infrastructure_and_deployment/apply_environment_terraform:
+        name: dev_environment_apply_terraform
+        filters: { branches: { ignore: [master] } }
+        requires:
+          [
+            cancel_previous_jobs,
+            dev_account_apply_terraform,
+            front_docker_build,
+            admin_docker_build,
+            api_docker_build,
+            pdf_docker_build,
+            seeding_docker_build,
+          ]
 
-      - infrastructure_and_deployment/run_healthcheck_test:
-          name: test_healthcheck_prod
-          requires: [prod_environment_apply_terraform]
-          filters: { branches: { only: [master] } }
-          workspace: production
+    - ecr_scan_results:
+        name: ecr_scan_results_development
+        filters: { branches: { ignore: [master] } }
+        requires:
+          [
+            front_docker_build,
+            admin_docker_build,
+            api_docker_build,
+            pdf_docker_build,
+            seeding_docker_build,
+          ]
 
-      - slack_notify_production_release:
-          name: post_production_release_message
-          filters: { branches: { only: [master] } }
-          requires: [test_healthcheck_prod]
+    - infrastructure_and_deployment/seed_environment_databases:
+        name: dev_seed_environment_databases
+        filters: { branches: { ignore: [master] } }
+        requires: [dev_environment_apply_terraform]
+
+    - infrastructure_and_deployment/run_functional_test:
+        name: run_functional_test
+        filters: { branches: { ignore: [master] } }
+        requires: [dev_seed_environment_databases]
+
+    - slack_notify_domain:
+        name: post_environment_domains
+        filters: { branches: { ignore: [master] } }
+        requires: [run_functional_test]
+
+path_to_live:
+  jobs:
+    - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+        name: front_docker_build
+        ecr_repository_name_prefix: online-lpa/front
+        service_path: service-front
+        filters: { branches: { only: [master] } }
+
+    - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+        name: admin_docker_build
+        ecr_repository_name_prefix: online-lpa/admin
+        service_path: service-admin
+        filters: { branches: { only: [master] } }
+
+    - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+        name: api_docker_build
+        ecr_repository_name_prefix: online-lpa/api
+        service_path: service-api
+        filters: { branches: { only: [master] } }
+
+    - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+        name: pdf_docker_build
+        ecr_repository_name_prefix: online-lpa/pdf
+        service_path: service-pdf
+        build_web: false
+        filters: { branches: { only: [master] } }
+
+    - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
+        name: seeding_docker_build
+        ecr_repository_name_prefix: online-lpa/seeding
+        service_path: service-seeding
+        build_web: false
+        unit_test: false
+        filters: { branches: { only: [master] } }
+
+    - infrastructure_and_deployment/apply_account_terraform:
+        name: preprod_account_apply_terraform
+        workspace: preproduction
+        filters: { branches: { only: [master] } }
+
+    - infrastructure_and_deployment/apply_environment_terraform:
+        name: preprod_environment_apply_terraform
+        workspace: preproduction
+        filters: { branches: { only: [master] } }
+        requires:
+          [
+            preprod_account_apply_terraform,
+            front_docker_build,
+            admin_docker_build,
+            api_docker_build,
+            pdf_docker_build,
+          ]
+
+    - ecr_scan_results:
+        name: ecr_scan_results_master
+        filters: { branches: { only: [master] } }
+        requires:
+          [
+            front_docker_build,
+            admin_docker_build,
+            api_docker_build,
+            pdf_docker_build,
+          ]
+
+    - infrastructure_and_deployment/seed_environment_databases:
+        name: preprod_seed_environment_databases
+        workspace: preproduction
+        filters: { branches: { only: [master] } }
+        requires: [preprod_environment_apply_terraform]
+
+    - infrastructure_and_deployment/run_functional_test:
+        name: preprod_test_functional
+        workspace: preproduction
+        filters: { branches: { only: [master] } }
+        requires: [preprod_seed_environment_databases]
+
+    - infrastructure_and_deployment/apply_account_terraform:
+        name: prod_account_apply_terraform
+        workspace: production
+        filters: { branches: { only: [master] } }
+        requires: [preprod_test_functional]
+
+    - infrastructure_and_deployment/apply_environment_terraform:
+        name: prod_environment_apply_terraform
+        requires: [prod_account_apply_terraform]
+        filters: { branches: { only: [master] } }
+        workspace: production
+
+    - infrastructure_and_deployment/run_healthcheck_test:
+        name: test_healthcheck_prod
+        requires: [prod_environment_apply_terraform]
+        filters: { branches: { only: [master] } }
+        workspace: production
+
+    - slack_notify_production_release:
+        name: post_production_release_message
+        filters: { branches: { only: [master] } }
+        requires: [test_healthcheck_prod]
 
 orbs:
   slack: circleci/slack@3.3.0
@@ -731,6 +753,7 @@ jobs:
             --circle_branch ${CIRCLE_BRANCH} \
             --circle_builds_token ${CIRCLECI_API_KEY} \
             --terms_to_waitfor "dev_account_apply_terraform,dev_environment_apply_terraform,apply_email_terraform"
+
   slack_notify_domain:
     docker:
       - image: circleci/python
@@ -758,6 +781,7 @@ jobs:
           color: "#508c18"
           message: "User: $CIRCLE_USERNAME \nfront url: https://$FRONT_DOMAIN/home \nadmin url: https://$ADMIN_DOMAIN"
           footer: "$CIRCLE_BRANCH - Commit Message: $COMMIT_MESSAGE"
+
   slack_notify_production_release:
     docker:
       - image: circleci/python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,6 +196,7 @@ path_to_live: &path_to_live
         requires: [test_healthcheck_prod]
 
 workflows:
+  version: 2
   workspace_cleanup:
      triggers:
        - schedule:
@@ -208,13 +209,13 @@ workflows:
        - workspace_cleanup:
            name: workspace_cleanup
 
-  pr_build_workflow:
+  pr_build:
     <<: *pr_build
 
-  path_to_live_workflow:
+  path_to_live:
     <<: *path_to_live
 
-  weekly_refresh_build:
+  weekly_refresh:
     triggers:
       - schedule:
            cron: "0 3 * * 3" # 3 am (UTC) on wednesday

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,6 @@ path_to_live: &path_to_live
         requires: [test_healthcheck_prod]
 
 workflows:
-  version: 2
   workspace_cleanup:
      triggers:
        - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,41 +1,6 @@
 version: 2.1
 
-workflows:
-  workspace_cleanup:
-     triggers:
-       - schedule:
-           cron: "0 6,18 * * 0-6" # 6am and 6pm
-           filters:
-             branches:
-               only:
-                 - master
-     jobs:
-       - workspace_cleanup:
-           name: workspace_cleanup
-
-  pr_build_workflow:
-    jobs:
-      - pr_build:
-          name: pr_build
-
-  path_to_live_workflow:
-    jobs:
-      - path_to_live:
-          name: path_to_live
-
-  weekly_refresh_build:
-    triggers:
-      - schedule:
-           cron: "30 10 * * 1" # 2 am on wednesday (proposed)
-           filters:
-             branches:
-               only:
-                 - LPAL-18-run-scheduled-refresh
-    jobs:
-    - pr_build:
-          name: weekly_refresh
-
-pr_build:
+pr_build:  &pr_build
   jobs:
     - cancel_redundant_builds:
         name: cancel_previous_jobs
@@ -131,7 +96,7 @@ pr_build:
         filters: { branches: { ignore: [master] } }
         requires: [run_functional_test]
 
-path_to_live:
+path_to_live: &path_to_live
   jobs:
     - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
         name: front_docker_build
@@ -229,6 +194,36 @@ path_to_live:
         name: post_production_release_message
         filters: { branches: { only: [master] } }
         requires: [test_healthcheck_prod]
+
+workflows:
+  workspace_cleanup:
+     triggers:
+       - schedule:
+           cron: "0 6,18 * * 0-6" # 6am and 6pm
+           filters:
+             branches:
+               only:
+                 - master
+     jobs:
+       - workspace_cleanup:
+           name: workspace_cleanup
+
+  pr_build_workflow:
+    <<: *pr_build
+
+  path_to_live_workflow:
+    <<: *path_to_live
+
+  weekly_refresh_build:
+    triggers:
+      - schedule:
+           cron: "38 10 * * 1" # 2 am on wednesday (CHANGEME!)
+           filters:
+             branches:
+               only:
+                 - LPAL-18-run-scheduled-refresh
+    <<: *pr_build
+
 
 orbs:
   slack: circleci/slack@3.3.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ workflows:
   weekly_refresh_build:
     triggers:
       - schedule:
-           cron: "38 10 * * 1" # 2 am on wednesday (CHANGEME!)
+           cron: "50 9 * * 1" # 2 am on wednesday (CHANGEME!)
            filters:
              branches:
                only:


### PR DESCRIPTION
## Purpose
refactor so we can reuse build definition for scheduled triggering and path to live build

Fixes LPAL-18

## Approach

- Use anchor blocks to split out workflow jobs, for reuse.
- Tweak existing workflows to reuse the aliased workflow job blocks
- Add an additional schedule workflow to run weekly on weds early morning.

## Learning

- YAML anchors and aliases for reuse, doesn't seem to be a good circleCI way to reuse otherwise in circle for entire workflows. 
other options mentioned are available e.g. parameters but don't seem to be suitable for this purpose.
See https://discuss.circleci.com/t/step-reuse-commands-vs-jobs-vs-anchors/33997/2

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
