### PR TITLE
Lpal 182 fix seeding issues

### DIFF
--- a/scripts/non_live_seeding/seed_environment.sh
+++ b/scripts/non_live_seeding/seed_environment.sh
@@ -22,7 +22,7 @@ else
 fi
 }
 
-if [ "$OPG_LPA_STACK_NAME" == "production" ]; then
+if [ "$OPG_LPA_STACK_ENVIRONMENT" == "production" ]; then
   echo "These scripts must not be run on production."
   exit 0
 fi
@@ -34,11 +34,12 @@ API_OPTS="--host=${OPG_LPA_POSTGRES_HOSTNAME} --username=${OPG_LPA_POSTGRES_USER
 echo "Waiting for database to be created"
 check_db_exists
 
-# PGPASSWORD=${OPG_LPA_POSTGRES_PASSWORD} psql ${API_OPTS} \
-#   ${OPG_LPA_POSTGRES_NAME} \
-#   -f clear_tables.sql
 
 sleep 20
+
+ PGPASSWORD=${OPG_LPA_POSTGRES_PASSWORD} psql ${API_OPTS} \
+   ${OPG_LPA_POSTGRES_NAME} \
+   -f clear_tables.sql
 
 PGPASSWORD=${OPG_LPA_POSTGRES_PASSWORD} psql ${API_OPTS} \
   ${OPG_LPA_POSTGRES_NAME} \

--- a/terraform/environment/ecs_seeding.tf
+++ b/terraform/environment/ecs_seeding.tf
@@ -2,14 +2,13 @@
 // The Api service's Security Groups
 
 resource "aws_security_group" "seeding_ecs_service" {
-  count       = local.environment == "production" ? 0 : 1
   name_prefix = "${terraform.workspace}-seeding-ecs-service"
   vpc_id      = data.aws_vpc.default.id
   tags        = local.default_tags
 }
 
 //----------------------------------
-// Anything out
+// Anything out except production
 resource "aws_security_group_rule" "seeding_ecs_service_egress" {
   count             = local.environment == "production" ? 0 : 1
   type              = "egress"
@@ -31,7 +30,7 @@ resource "aws_ecs_task_definition" "seeding" {
   cpu                      = 2048
   memory                   = 4096
   container_definitions    = "[${local.seeding_app}]"
-  task_role_arn            = aws_iam_role.seeding_task_role.arn
+  task_role_arn            = aws_iam_role.seeding_task_role[count.index].arn
   execution_role_arn       = aws_iam_role.execution_role.arn
   tags                     = local.default_tags
 }
@@ -87,7 +86,7 @@ locals {
       { "name": "OPG_LPA_POSTGRES_NAME", "value": "${aws_db_instance.api.name}"},
       { "name": "OPG_LPA_POSTGRES_HOSTNAME", "value": "${aws_db_instance.api.address}"},
       { "name": "OPG_LPA_POSTGRES_PORT", "value": "${aws_db_instance.api.port}"},
-      { "name": "OPG_LPA_STACK_ENVIRONMENT", "value" : "${local.environment}"}
+      { "name": "OPG_LPA_STACK_ENVIRONMENT", "value" : "${local.account_name}"}
       ]
     }
   EOF

--- a/terraform/environment/ecs_seeding.tf
+++ b/terraform/environment/ecs_seeding.tf
@@ -2,6 +2,7 @@
 // The Api service's Security Groups
 
 resource "aws_security_group" "seeding_ecs_service" {
+  count       = local.environment == "production" ? 0 : 1
   name_prefix = "${terraform.workspace}-seeding-ecs-service"
   vpc_id      = data.aws_vpc.default.id
   tags        = local.default_tags
@@ -10,6 +11,7 @@ resource "aws_security_group" "seeding_ecs_service" {
 //----------------------------------
 // Anything out
 resource "aws_security_group_rule" "seeding_ecs_service_egress" {
+  count             = local.environment == "production" ? 0 : 1
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -22,6 +24,7 @@ resource "aws_security_group_rule" "seeding_ecs_service_egress" {
 // seeding ECS Service Task level config
 
 resource "aws_ecs_task_definition" "seeding" {
+  count                    = local.environment == "production" ? 0 : 1
   family                   = "${terraform.workspace}-seeding"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
@@ -38,6 +41,7 @@ resource "aws_ecs_task_definition" "seeding" {
 // Permissions
 
 resource "aws_iam_role" "seeding_task_role" {
+  count              = local.environment == "production" ? 0 : 1
   name               = "${local.environment}-seeding-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
   tags               = local.default_tags
@@ -82,7 +86,8 @@ locals {
     "environment": [
       { "name": "OPG_LPA_POSTGRES_NAME", "value": "${aws_db_instance.api.name}"},
       { "name": "OPG_LPA_POSTGRES_HOSTNAME", "value": "${aws_db_instance.api.address}"},
-      { "name": "OPG_LPA_POSTGRES_PORT", "value": "${aws_db_instance.api.port}"}
+      { "name": "OPG_LPA_POSTGRES_PORT", "value": "${aws_db_instance.api.port}"},
+      { "name": "OPG_LPA_STACK_ENVIRONMENT", "value" : "${local.environment}"}
       ]
     }
   EOF


### PR DESCRIPTION
## Purpose
- To address the issue with seeding in CircleCI failing on rerun
- To ensure we make it difficult enough to run these scripts on production, as we never need to do that!

Fixes LPAL-182

## Approach

- Reinstate the truncation of the tables as was previously commented out.
- Add environment variable containing account_name (e.g `development`,`preproduction` or `production`) to the seeding ecs task.
   - *Note:* shell script already exits on finding relevant env var value for `production` so just needed reinstating.
- Take out seeding ecs task, and associated egress rule if in `production` as it is not needed.
    - *Note:* security group will need further looking at as the config.tf file relies on this for the pipeline, not a major issue.

## Learning

- conditionals in terraform

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
