### PR TITLE
run functional tests locally, from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,3 +91,8 @@ dc-unit-tests:
 	export OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY=${ORDNANCESURVEY}; \
 	export OPG_LPA_COMMON_ADMIN_ACCOUNTS=${ADMIN_USERS}; \
 	docker-compose run pdf-app /app/vendor/bin/phpunit
+
+.PHONY: functional-local
+functional-local:
+	docker build -f ./tests/Dockerfile  -t casperjs:latest .; \
+	docker run --rm -it --network="host" -e "BASE_DOMAIN=localhost:7002" --name casperjs casperjs:latest ./start.sh 'tests/'

--- a/Makefile
+++ b/Makefile
@@ -95,4 +95,4 @@ dc-unit-tests:
 .PHONY: functional-local
 functional-local:
 	docker build -f ./tests/Dockerfile  -t casperjs:latest .; \
-	docker run --rm -it --network="host" -e "BASE_DOMAIN=localhost:7002" --name casperjs casperjs:latest ./start.sh 'tests/'
+	aws-vault exec identity -- docker run -it -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e "BASE_DOMAIN=localhost:7002" --network="host" --rm casperjs:latest ./start.sh 'tests/'

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ To run the unit tests
 make dc-unit-tests
 ```
 
+For how to run the functional tests, please see seperate README in tests/functional directory
+
 ### Updating composer dependencies
 
 Composer install is run when the app containers are built, and on a standard `docker-compose up`.

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -31,7 +31,7 @@ docker run -d -e "CASPER_EMAIL_USER=CASPER_EMAIL_USER" -e "CASPER_EMAIL_PASSWORD
 docker exec casperjs ./start.sh 'tests/'
 ```
 
-that old way, some tests will fail though, because S3Monitor only works via aws-vault, because needs to talk to real S3 
+That old way, some tests will fail though, because S3Monitor only works via aws-vault, because S3Monitor needs to talk to real S3 
 
 ## Advanced information
 

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -8,8 +8,9 @@ Run the following command in CI to run all the tests
 aws-vault exec identity -- docker run -it -v ${PWD}/tests:/mnt/test -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e "BASE_DOMAIN=<PUBLIC_FRONT_URL>" --net=host --rm casperjs:latest ./start.sh 'tests/'
 ```
 
-Running the tests with start.sh automatically runs S3Monitor. If for some reason you need to individually run the S3Monitor on terminal you can do :
 By specifying the volume with -v,  we can change edit tests on the host machine and not constantly have to rebuild the docker container
+
+Running the tests with start.sh automatically runs S3Monitor. If for some reason you need to individually run the S3Monitor on terminal you can do :
 
 ```bash
 aws-vault exec identity -- php S3Monitor.php

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -1,33 +1,41 @@
-# Casper JS tests
+# Casper JS functional tests
 
-## Running the tests
+## Running the functional tests
 
-Run the following command to run all the tests
+Run the following command in CI to run all the tests
 
 ```bash
 aws-vault exec identity -- docker run -it -v ${PWD}/tests:/mnt/test -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e "BASE_DOMAIN=<PUBLIC_FRONT_URL>" --net=host --rm casperjs:latest ./start.sh 'tests/'
 ```
 
-To run the S3Monitor on terminal
+Running the tests with start.sh automatically runs S3Monitor. If for some reason you need to individually run the S3Monitor on terminal you can do :
+By specifying the volume with -v,  we can change edit tests on the host machine and not constantly have to rebuild the docker container
 
 ```bash
 aws-vault exec identity -- php S3Monitor.php
 ```
 
-To run the casper tests in local environment
+To run the tests in local environment
+
+```bash
+aws-vault exec identity -- docker run -it -v ${PWD}/tests:/mnt/test -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e "BASE_DOMAIN=localhost:7002" --network="host" --rm casperjs:latest ./start.sh 'tests/'
+```
+
+the old way of doing this (left here for historical reasons) was:
 
 ```bash
 docker run -d -e "CASPER_EMAIL_USER=CASPER_EMAIL_USER" -e "CASPER_EMAIL_PASSWORD=CASPER_EMAIL_PASSWORD" -e "BASE_DOMAIN=BASE_DOMAIN" --name casperjs casperjs:latest
-
 docker exec casperjs ./start.sh 'tests/'
 ```
+
+that old way, some tests will fail though, because S3Monitor only works via aws-vault, because needs to talk to real S3 
 
 ## Advanced information
 
 When a test suite is run, a service is activated inside the container. The relevant test emails got to S3 and S3 bucket is monitored. This allows the test
 suites to activate accounts and reset passwords. The email account needs to be setup for IMAP and should have auto-expunge set to Off.
 
-To login to the docker container.
+It can be useful to start up a shell to debug failing tests.  To login to the docker container:
 
 ```bash
 aws-vault exec identity -- docker run -it -v ${PWD}/tests:/mnt/test -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e "BASE_DOMAIN=<PUBLIC_FRONT_URL>" --net=host --rm casperjs:latest /usr/bin/env bash

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -18,10 +18,12 @@ aws-vault exec identity -- php S3Monitor.php
 To run the tests in local environment
 
 ```bash
-aws-vault exec identity -- docker run -it -v ${PWD}/tests:/mnt/test -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e "BASE_DOMAIN=localhost:7002" --network="host" --rm casperjs:latest ./start.sh 'tests/'
+aws-vault exec identity -- docker run -it -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e "BASE_DOMAIN=localhost:7002" --network="host" --rm casperjs:latest ./start.sh 'tests/'
 ```
 
-the old way of doing this (left here for historical reasons) was:
+Note that in order for S3monitor to work locally, it is necessary to omit the -v volume option
+
+The old way of doing this (left here for historical reasons) was:
 
 ```bash
 docker run -d -e "CASPER_EMAIL_USER=CASPER_EMAIL_USER" -e "CASPER_EMAIL_PASSWORD=CASPER_EMAIL_PASSWORD" -e "BASE_DOMAIN=BASE_DOMAIN" --name casperjs casperjs:latest


### PR DESCRIPTION
## Purpose
_LPAL-179 add capability to run functional tests locally from Makefile_

## Approach

_docker build and docker run to run this locally. Similar to how Circle does it_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
