### PR TITLE
pin to specific composer version for now.

### DIFF
--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer AS composer
+FROM composer:1.10.16 AS composer
 
 COPY service-admin /app
 
@@ -23,4 +23,3 @@ WORKDIR /app
 
 CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug) \
     && php-fpm
-

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer AS composer
+FROM composer:1.10.16 AS composer
 
 COPY service-api /app
 

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer AS composer
+FROM composer:1.10.16 AS composer
 
 COPY service-front /app
 

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer AS composer
+FROM composer:1.10.16 AS composer
 
 COPY service-pdf /app
 
@@ -11,7 +11,7 @@ RUN apt-get -y update \
     && mkdir -p /usr/share/man/man1 \
     && apt-get -y install pdftk \
     && apt-get -y clean \
-    && pecl install xdebug \ 
+    && pecl install xdebug \
     && pecl clear-cache
 
 COPY service-pdf /app

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer AS composer
+FROM composer:1.10.16 AS composer
 
 COPY tests /app
 
@@ -45,5 +45,3 @@ COPY --from=composer /app/vendor /mnt/test/vendor
 
 WORKDIR /mnt/test/functional/
 CMD php
-
-


### PR DESCRIPTION
## Purpose
Docker hub had an updated push to composer image, which pushed it to 2.0. this broke our build. 
We will need to pin this for now to 1.10.16, with a view to upgrade to 2.0 after we've done a Laminas Upgrade.

## Approach

- pin dockerfiles

## Learning

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
