### PR TITLE
Clean Make properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,12 +77,12 @@ dc-build-clean:
 	docker rmi seeding; \
 	docker rmi opg-lpa_local-config; \
 	rm -fr ./service-admin/vendor; \
-    rm -fr ./service-api/vendor; \
-    rm -fr ./service-front/node_modules/parse-json/vendor; \
-    rm -fr ./service-front/node_modules/govuk_frontend_toolkit/javascripts/vendor; \
-    rm -fr ./service-front/public/assets/v2/js/vendor; \
-    rm -fr ./service-front/vendor; \
-    rm -fr ./service-pdf/vendor; \
+	rm -fr ./service-api/vendor; \
+	rm -fr ./service-front/node_modules/parse-json/vendor; \
+	rm -fr ./service-front/node_modules/govuk_frontend_toolkit/javascripts/vendor; \
+	rm -fr ./service-front/public/assets/v2/js/vendor; \
+	rm -fr ./service-front/vendor; \
+	rm -fr ./service-pdf/vendor; \
 	docker-compose build --no-cache
 
 .PHONY: dc-down


### PR DESCRIPTION


## Purpose
_Provide the ability to do a proper clean of the Make environment, get it back to a sane state just like a fresh clone but plus any local code changes. Helps a lot when doing an upgrade, hopefully will make it easier to fix broken local dev environments_

## Approach

_Makefile now , in dc-build-clean, explicitly removes all the images that will have been left around - Note - rather than do a remove all we delete them by name, so as to leave other images such as localstack intact.  Have added a reset which calls this then does make dc-run, as thats only too easy to forget to do. So to use this we will type make reset in future_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
