### PR TITLE
hashicorp upgraded docker image latest to 0.13.5. pinning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -825,7 +825,7 @@ jobs:
 
   workspace_cleanup:
     docker:
-      - image: hashicorp/terraform
+      - image: hashicorp/terraform:0.12.28
         auth:
           username: $DOCKER_USER
           password: $DOCKER_ACCESS_TOKEN


### PR DESCRIPTION
## Purpose
issue arose overnight with workspace cleanup. needed to pin this to 0.12.28 as terraform 0.13.5 is enforcing `required_providers` move for pagerduty. we will address this in a later terraform upgrade.


## Approach

pin workspace cleanup job docker executor to 0.12.28.

## Learning


## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
