### PR TITLE
Makefile and build speed improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       OPG_LPA_COMMON_DYNAMODB_ENDPOINT: http://dynamodb:8000
 
       PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
-      #ENABLE_XDEBUG: 'true'
+      ENABLE_XDEBUG: 'true'
       PHP_IDE_CONFIG: serverName=lpa-front-app
       XDEBUG_CONFIG: remote_host=host.docker.internal remote_enable=1
 
@@ -111,12 +111,17 @@ services:
     volumes:
       - ./service-front:/app
     command:
+      - global require hirak/prestissimo 
+      - --no-plugins
+      - --no-scripts 
+    command:
       - install
       - --prefer-dist
       - --no-suggest
       - --no-interaction
       - --no-scripts
       - --optimize-autoloader
+      - --ignore-platform-reqs
 
   front-ssl:
     container_name: lpa-front-ssl
@@ -206,12 +211,17 @@ services:
     volumes:
       - ./service-api:/app
     command:
+      - global require hirak/prestissimo 
+      - --no-plugins
+      - --no-scripts 
+    command:
       - install
       - --prefer-dist
       - --no-suggest
       - --no-interaction
       - --no-scripts
       - --optimize-autoloader
+      - --ignore-platform-reqs
 
   # ---------------------------
   # Admin
@@ -272,12 +282,17 @@ services:
     volumes:
       - ./service-admin:/app
     command:
+      - global require hirak/prestissimo 
+      - --no-plugins
+      - --no-scripts 
+    command:
       - install
       - --prefer-dist
       - --no-suggest
       - --no-interaction
       - --no-scripts
       - --optimize-autoloader
+      - --ignore-platform-reqs
 
   admin-ssl:
     container_name: lpa-admin-ssl
@@ -324,12 +339,17 @@ services:
     volumes:
       - ./service-pdf:/app
     command:
+      - global require hirak/prestissimo 
+      - --no-plugins
+      - --no-scripts 
+    command:
       - install
       - --prefer-dist
       - --no-suggest
       - --no-interaction
       - --no-scripts
       - --optimize-autoloader
+      - --ignore-platform-reqs
   # ---------------------------
   # Seeding
   seeding:


### PR DESCRIPTION

## Purpose
_Improve the reset option to clean up properly, add options to only reset front and only run front unit tests. Make dc-run now runs in parallel. composer uses prestissimo in make dc-run_

## Approach

_See source files, fairly self-explanatory. _

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
