### PR TITLE
aws environment provider upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,7 @@ orbs:
             type: boolean
             default: true
             description: Execute unit tests during this build
+
         steps:
           - checkout
           - install_aws_cli

--- a/terraform/environment/credentials.tf
+++ b/terraform/environment/credentials.tf
@@ -15,7 +15,6 @@ provider "aws" {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
-  version = "2.70"
 }
 
 provider "aws" {
@@ -25,7 +24,6 @@ provider "aws" {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
-  version = "2.70"
 }
 
 variable "default_role" {
@@ -43,7 +41,6 @@ provider "aws" {
     role_arn     = "arn:aws:iam::311462405659:role/${var.management_role}"
     session_name = "terraform-session"
   }
-  version = "2.70"
 }
 
 provider "pagerduty" {

--- a/terraform/environment/versions.tf
+++ b/terraform/environment/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.70"
+      version = "~> 3.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/terraform/terraform_maintenance/live_service_url.tf
+++ b/terraform/terraform_maintenance/live_service_url.tf
@@ -14,7 +14,7 @@ data "aws_lb" "new_lpa_production_front" {
 }
 
 resource "aws_route53_record" "lastingpowerofattorney_service_gov_uk" {
-  zone_id = "${data.aws_route53_zone.lastingpowerofattorney_service_gov_uk.zone_id}"
+  zone_id = data.aws_route53_zone.lastingpowerofattorney_service_gov_uk.zone_id
   name    = "lastingpowerofattorney.service.gov.uk"
   type    = "A"
 


### PR DESCRIPTION
## Purpose
Upgrade environment aws providers for version 3.0. 

Fixes LPAL-189

## Approach

- Remove references to 2.70 of the hashicorp/aws provider
- Add required_provider version to  `~> 3.0` for the aws provider
- note - no state moves required for this PR.
- note - previous provider moves done alongside a separate cycle of PRs for the terraform upgrade. 
- Full documentation check to ensure no resources needed changing.

## Learning
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade

where terraform state is in S3, in case a roll back needed.
other guidance from:
- https://github.com/ministryofjustice/opg-use-an-lpa/pull/499
- https://github.com/ministryofjustice/opg-use-an-lpa/pull/500 

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
