### PR TITLE
additional init step for workspace cleanup

### DIFF
--- a/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
+++ b/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
@@ -29,6 +29,7 @@ do
     *)
       echo "cleaning up workspace $workspace..."
       terraform workspace select $workspace
+      terraform init
       terraform destroy -auto-approve
       terraform workspace select default
       terraform workspace delete $workspace


### PR DESCRIPTION
## Purpose
add `terraform init` to workspace cleanup on selection of workspace in job.

## Approach

During workspace housekeeping, I noticed we did not initialise workspaces prior to destroy. this can be an issue if the tfstate is on an older version. this fix should resolve this in future.

## Learning

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
