### PR TITLE
Lpal 129 vuln fix for pdf container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,7 @@ orbs:
                 if << parameters.unit_test >> ; then
                   docker run -d --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name tests << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app:latest
                   docker exec tests docker-php-ext-enable xdebug
-                  docker exec tests /app/vendor/bin/phpunit --d memory_limit=256M
+                  docker exec tests /app/vendor/bin/phpunit -d memory_limit=256M
                 else
                   echo "phpunit tests not required for this service"
                 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,7 @@ orbs:
                 if << parameters.unit_test >> ; then
                   docker run -d --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name tests << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app:latest
                   docker exec tests docker-php-ext-enable xdebug
-                  docker exec tests /app/vendor/bin/phpunit
+                  docker exec tests /app/vendor/bin/phpunit --d memory_limit=256M
                 else
                   echo "phpunit tests not required for this service"
                 fi

--- a/service-pdf/bin/pdftk
+++ b/service-pdf/bin/pdftk
@@ -1,0 +1,4 @@
+
+#!/bin/sh
+
+exec java -jar "$(dirname "$0")/pdftk-all.jar" "$@"

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /usr/local/bin/
 RUN wget https://gitlab.com/pdftk-java/pdftk/-/jobs/812582458/artifacts/raw/build/libs/pdftk-all.jar
 
 COPY service-pdf/bin/pdftk pdftk
+RUN chmod +x pdftk
 
 COPY service-pdf /app
 COPY --from=composer /app/vendor /app/vendor

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -5,15 +5,21 @@ COPY service-pdf/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7-cli
+FROM php:7-cli-alpine
 
-# mkdir below fixes a known issue with openjdk https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
-RUN apt-get -y update \
-    && mkdir -p /usr/share/man/man1 \
-    && apt-get -y install pdftk \
-    && apt-get -y clean \
+RUN apk update \
+    && apk add --no-cache openjdk8-jre gcc make musl-dev pkgconfig bash\
+    && apk add --no-cache --update --virtual buildDeps autoconf \
     && pecl install xdebug \
-    && pecl clear-cache
+    && pecl clear-cache \
+    && apk del buildDeps
+WORKDIR /usr/local/bin/
+# This is version 3.2.1 of this tool, we will need to check this regularly.
+# PDFTK does have a community based docker container, but the version is not up to date.
+
+RUN wget https://gitlab.com/pdftk-java/pdftk/-/jobs/812582458/artifacts/raw/build/libs/pdftk-all.jar
+
+COPY service-pdf/bin/pdftk pdftk
 
 COPY service-pdf /app
 COPY --from=composer /app/vendor /app/vendor


### PR DESCRIPTION
## Purpose
We are seeing a number of vulnerabilities being picked up in the pdf (previously masked by an unknown CVE) container scan. the safest option here is to move to an alpine linux container, which has less in it. This will mean a number of changes as PDFTK is not supported as a package since 3.8 of alpine. 
However there is a maintainer of a java ported version, which we are now using.
 
This appears to be the recommended approach..

Fixes LPAL-129

## Approach
- Update dockerfile to Alpine
- Replace install libraries and include those needed for php, xdebug and bash
- Add install of openjdk8-jre to support the java port
- pull version 3.2.1 of the pdftk-java jar
- include executable shell script to sit over the top of the jar file

## Learning
Context:
- Removal of support for older PDFTK: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=892539
- stackoverflow research (relates to ubuntu, but gave pointers) : https://askubuntu.com/questions/1028522/how-can-i-install-pdftk-in-ubuntu-18-04-and-later#new-answer
- deprecation issue raised in Alpine: https://gitlab.alpinelinux.org/alpine/aports/-/issues/10136 

Sources:
- pdftk-java gitlab repo: https://gitlab.com/pdftk-java/pdftk
- pdftk Docker file definition: https://github.com/clevyr/docker-pdftk-java  

Note - PDFTK is pinned to 3.2.1 as the last stable release from the above gitlab repo. our internal channels are subscribed to the rss feed for this, so we can monitor for changes. 

in addition the pdftk-java repo maintainer is attempting to coordinate with the docker file repo maintainer to keep versions up-to-date, so we could use that [directly](https://github.com/clevyr/docker-pdftk-java/blob/master/README.md) instead in future.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
