### PR TITLE
LPAL-226 Update alpine version for seeding container

### DIFF
--- a/service-seeding/docker/app/Dockerfile
+++ b/service-seeding/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.12.3
 
 RUN apk add --update --no-cache postgresql-client
 


### PR DESCRIPTION
## Purpose

Update the version of Alpine used for the seeding container to fix security alerts thrown by the ECR check in CircleCI.

Fixes LPAL-226

## Approach

Simple update to the Alpine version in the seeding Dockerfile.

I've run the pipeline with the new Dockerfile and there are no errors due to security issues in the seeding image.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
