### PR TITLE
LPAL-23 - I want to see that relevant guidance on the LPA type page

### DIFF
--- a/service-front/module/Application/src/Model/Service/Session/PersistentSessionDetails.php
+++ b/service-front/module/Application/src/Model/Service/Session/PersistentSessionDetails.php
@@ -33,10 +33,6 @@ class PersistentSessionDetails {
         $this->sessionDetails->currentRoute = ($this->route instanceof RouteMatch) ?
             $this->route->getMatchedRouteName() :
             '';
-        
-        if (!isset($this->sessionDetails->previousRoute)) {
-            $this->sessionDetails->previousRoute = $this->sessionDetails->currentRoute;
-        }
 
         if ($this->sessionDetails->routeStore !== $this->sessionDetails->previousRoute) {
             $this->sessionDetails->previousRoute = $this->sessionDetails->routeStore;
@@ -50,6 +46,6 @@ class PersistentSessionDetails {
     }
 
     public function getPreviousRoute(): string {
-        return $this->sessionDetails->previousRoute;
+        return $this->sessionDetails->previousRoute ?? 'home';
     }
 }

--- a/service-front/module/Application/src/Model/Service/Session/PersistentSessionDetails.php
+++ b/service-front/module/Application/src/Model/Service/Session/PersistentSessionDetails.php
@@ -22,7 +22,6 @@ class PersistentSessionDetails {
     public function __construct(?RouteMatch $route) {
         $this->route = $route;
         $this->sessionDetails = new Container('SessionDetails');
-
         $this->setRouteDetails();
     }
     
@@ -30,7 +29,7 @@ class PersistentSessionDetails {
         // breadcrumb so we can determine user's last visited route.
         // Also account for any null values, eg activation links or status checks.
         // Unable to assign to RouteInterface, as RouteMatch does not implement RouteInterface
-        $this->sessionDetails->currentRoute = ($this->route instanceof RouteMatch) ?
+        $this->sessionDetails->currentRoute = (!is_null($this->route)) ?
             $this->route->getMatchedRouteName() :
             '';
 
@@ -42,10 +41,11 @@ class PersistentSessionDetails {
     }
 
     public function getCurrentRoute(): string {
-        return $this->sessionDetails->currentRoute;
+        return $this->sessionDetails->currentRoute ?? '';
     }
 
-    public function getPreviousRoute(): string {
+    public function getPreviousRoute(): string
+    {
         return $this->sessionDetails->previousRoute ?? 'home';
     }
 }

--- a/service-front/module/Application/src/Model/Service/Session/PersistentSessionDetails.php
+++ b/service-front/module/Application/src/Model/Service/Session/PersistentSessionDetails.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Model\Service\Session;
+
+use Laminas\Router\RouteMatch;
+use Laminas\Session\Container;
+
+class PersistentSessionDetails {
+
+    /**
+     * @var Container
+     */
+    private $sessionDetails;
+
+    /**
+     * @var RouteMatch|null
+     */
+    private $route;
+
+    public function __construct(?RouteMatch $route) {
+        $this->route = $route;
+        $this->sessionDetails = new Container('SessionDetails');
+
+        $this->setRouteDetails();
+    }
+    
+    private function setRouteDetails(): void {
+        // breadcrumb so we can determine user's last visited route.
+        // Also account for any null values, eg activation links or status checks.
+        // Unable to assign to RouteInterface, as RouteMatch does not implement RouteInterface
+        $this->sessionDetails->currentRoute = ($this->route instanceof RouteMatch) ?
+            $this->route->getMatchedRouteName() :
+            '';
+        
+        if (!isset($this->sessionDetails->previousRoute)) {
+            $this->sessionDetails->previousRoute = $this->sessionDetails->currentRoute;
+        }
+
+        if ($this->sessionDetails->routeStore !== $this->sessionDetails->previousRoute) {
+            $this->sessionDetails->previousRoute = $this->sessionDetails->routeStore;
+        }
+
+        $this->sessionDetails->routeStore = $this->sessionDetails->currentRoute;
+    }
+
+    public function getCurrentRoute(): string {
+        return $this->sessionDetails->currentRoute;
+    }
+
+    public function getPreviousRoute(): string {
+        return $this->sessionDetails->previousRoute;
+    }
+}

--- a/service-front/module/Application/src/View/Helper/RouteName.php
+++ b/service-front/module/Application/src/View/Helper/RouteName.php
@@ -18,8 +18,8 @@ class RouteName extends AbstractHelper
     public function __construct(?string $currentRoute, ?string $previousRoute)
     {
         $this->routes = [
-            'current'   => $currentRoute,
-            'previous'  => $previousRoute
+            'current'   => $currentRoute ?? '',
+            'previous'  => $previousRoute ?? ''
         ];
     }
 

--- a/service-front/module/Application/src/View/Helper/RouteNameFactory.php
+++ b/service-front/module/Application/src/View/Helper/RouteNameFactory.php
@@ -19,6 +19,9 @@ class RouteNameFactory implements FactoryInterface
         /** @var ContainerInterface $sessionDetails */
         $sessionDetails = $container->get('PersistentSessionDetails');
 
-        return new RouteName($sessionDetails->currentRoute, $sessionDetails->previousRoute);
+        $currentRoute = $sessionDetails->getCurrentRoute();
+        $previousRoute = $sessionDetails->getPreviousRoute();
+
+        return new RouteName($currentRoute, $previousRoute);
     }
 }

--- a/service-front/module/Application/tests/Model/Service/Session/PersistentSessionDetailsTest.php
+++ b/service-front/module/Application/tests/Model/Service/Session/PersistentSessionDetailsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Model\Service\Session;
+
+use Application\Model\Service\Session\PersistentSessionDetails;
+use Laminas\Router\RouteMatch;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class PersistentSessionDetailsTest extends TestCase {
+
+    /**
+     * @test
+     */
+    public function testSuccessfullyCreateClass() {
+
+        $routeMatch = Mockery::mock(RouteMatch::class);
+        $routeMatch->shouldReceive('getMatchedRouteName')->andReturn('lpa/applicant');
+
+        $persistentSession = new PersistentSessionDetails($routeMatch);
+
+        $this->assertInstanceOf(PersistentSessionDetails::class, $persistentSession);
+    }
+
+    /**
+     * @test
+     */
+    public function testExpectedValuesFromCurrentAndPreviousRoutes() {
+        $currentRoute = 'lpa/applicant';
+
+        $routeMatch = Mockery::mock(RouteMatch::class);
+        $routeMatch->shouldReceive('getMatchedRouteName')->andReturn($currentRoute);
+
+        $persistentSession = new PersistentSessionDetails($routeMatch);
+
+        $this->assertEquals($currentRoute, $persistentSession->getCurrentRoute());
+        $this->assertEquals($currentRoute, $persistentSession->getPreviousRoute());
+    }
+
+    /**
+     * @test
+     */
+    public function testExpectedValuesFromCurrentAndPreviousRoutesPersists() {
+        $currentRoute = 'lpa/primary-attorney/add';
+        $previousRoute = 'lpa/applicant';
+
+        $routeMatch = Mockery::mock(RouteMatch::class);
+        $routeMatch->shouldReceive('getMatchedRouteName')->andReturn($previousRoute)->once();
+
+        $persistentSession = new PersistentSessionDetails($routeMatch);
+
+        $routeMatch->shouldReceive('getMatchedRouteName')->andReturn($currentRoute)->once();
+        $persistentSession = new PersistentSessionDetails($routeMatch);
+
+        $this->assertEquals($currentRoute, $persistentSession->getCurrentRoute());
+        $this->assertEquals($previousRoute, $persistentSession->getPreviousRoute());
+    }
+
+    /**
+     * @test
+     */
+    public function testEmptyValuesFromCurrentRoute() {
+        $persistentSession = new PersistentSessionDetails(null);
+
+        $this->assertEquals('', $persistentSession->getCurrentRoute());
+    }
+
+
+}

--- a/service-front/module/Application/tests/View/Helper/RouteNameFactoryTest.php
+++ b/service-front/module/Application/tests/View/Helper/RouteNameFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace ApplicationTest\View\Helper;
 
+use Application\Model\Service\Session\PersistentSessionDetails;
 use Application\View\Helper\RouteName;
 use Application\View\Helper\RouteNameFactory;
 use Interop\Container\ContainerInterface;
@@ -12,9 +13,17 @@ class RouteNameFactoryTest extends MockeryTestCase
 {
     public function testInvoke():void
     {
+        $persistentSession = Mockery::mock(PersistentSessionDetails::class);
+        $persistentSession->shouldReceive('getCurrentRoute')
+            ->andReturn('')
+            ->once();
+        $persistentSession->shouldReceive('getPreviousRoute')
+            ->andReturn('')
+            ->once();
+
         $container = Mockery::mock(ContainerInterface::class);
         $container->shouldReceive('get')->withArgs(['PersistentSessionDetails'])
-            ->andReturn(Mockery::mock(ContainerInterface::class))->once();
+            ->andReturn($persistentSession)->once();
 
         $routeNameFactory = new RouteNameFactory();
         $result = $routeNameFactory($container, null, null);


### PR DESCRIPTION
## Purpose

As a first time user of the service, when I complete the "my details" page and then directed to the LPA type page, or log in for the first time after having only previously completed ‘my details’, I want to see the page from the top.

The page currently lands/anchors to the ‘What type of LPA’ question header and making it unclear to users that there is content with links above.

Fixes LPAL-23

## Approach

Creates a breadcrumb system that stores the previously accessed route, which is then passed to the RouteName twig helper function

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
