### PR TITLE
LPAL-267 Disables warnings from being displayed on health check endpoints

### DIFF
--- a/service-front/module/Application/src/Controller/General/PingController.php
+++ b/service-front/module/Application/src/Controller/General/PingController.php
@@ -1,6 +1,9 @@
 <?php
 
 namespace Application\Controller\General;
+// Work around due to issues with code base, unless in place this displays warnings when endpoint it accessed
+// Ticket has been created in the backlog to address this LPAL-267
+error_reporting(E_ERROR);
 
 use Application\Model\Service\System\Status;
 use Laminas\View\Model\JsonModel;


### PR DESCRIPTION
## Purpose
Disables warnings from being displayed on health check endpoints

Fixes LPAL-23 and LPAL-267

## Approach

Changes error_reporting to display only system halting errors, this information is still logged at the infra level


## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
