### PR TITLE
pin to previous version 3.12 alpine

### DIFF
--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -5,7 +5,7 @@ COPY service-admin/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7.4-fpm-alpine
+FROM php:7.4-fpm-alpine3.12
 
 RUN apk add --update --no-cache icu
 

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -5,7 +5,7 @@ COPY service-api/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7.4-fpm-alpine
+FROM php:7.4-fpm-alpine3.12
 
 # Postgres lib needs to remain in the container
 RUN apk add --update --no-cache postgresql-libs

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -5,7 +5,7 @@ COPY service-front/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7-fpm-alpine3.13
+FROM php:7-fpm-alpine3.12
 
 RUN apk add --update --no-cache icu
 

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -5,7 +5,7 @@ COPY service-front/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7-fpm-alpine
+FROM php:7-fpm-alpine3.12
 
 RUN apk add --update --no-cache icu
 

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -5,7 +5,7 @@ COPY service-front/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7-fpm-alpine3.12
+FROM php:7-fpm-alpine3.13
 
 RUN apk add --update --no-cache icu
 

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -5,7 +5,7 @@ COPY service-pdf/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7-cli-alpine
+FROM php:7-cli-alpine3.12
 
 RUN apk update \
     && apk add --no-cache openjdk8-jre gcc make musl-dev pkgconfig bash\


### PR DESCRIPTION
## Purpose
pin php-fpm-alpine to 3.12. this is to see if it removes low severity vulnerability

Fixes LPAL-292

## Approach

- pin dockerfile in front_app, service_api, service_admin and service_pdf.

## Learning

- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28928

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
