### PR TITLE
LPAL-315 migrate to OS Places Hub API

### DIFF
--- a/terraform/account/put_secrets.tf
+++ b/terraform/account/put_secrets.tf
@@ -47,6 +47,11 @@ resource "aws_secretsmanager_secret" "opg_lpa_front_ordnance_survey_license_key"
   tags = local.default_tags
 }
 
+resource "aws_secretsmanager_secret" "opg_lpa_front_os_places_hub_license_key" {
+  name = "${local.account_name}/opg_lpa_front_os_places_hub_license_key"
+  tags = local.default_tags
+}
+
 # pdf secrets
 resource "aws_secretsmanager_secret" "opg_lpa_pdf_owner_password" {
   name = "${local.account_name}/opg_lpa_pdf_owner_password"

--- a/terraform/environment/ecs_front.tf
+++ b/terraform/environment/ecs_front.tf
@@ -206,7 +206,9 @@ locals {
         { "name" : "OPG_LPA_FRONT_GOV_PAY_KEY", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_front_gov_pay_key.name}" },
         { "name" : "OPG_LPA_FRONT_ORDNANCE_SURVEY_LICENSE_KEY", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_front_ordnance_survey_license_key.name}" },
         { "name" : "OPG_LPA_COMMON_ACCOUNT_CLEANUP_NOTIFICATION_RECIPIENTS", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_common_account_cleanup_notification_recipients.name}" },
-        { "name" : "OPG_LPA_COMMON_ADMIN_ACCOUNTS", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_common_admin_accounts.name}" }
+        { "name" : "OPG_LPA_COMMON_ADMIN_ACCOUNTS", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_common_admin_accounts.name}" },
+        { "name" : "OPG_LPA_FRONT_OS_PLACES_HUB_LICENSE_KEY", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_front_os_places_hub_license_key.name}" }
+
       ],
       "environment" : [
         { "name" : "OPG_LPA_FRONT_NGINX_FRONTENDDOMAIN", "value" : "${local.dns_namespace_env}${local.front_dns}" },
@@ -227,7 +229,8 @@ locals {
         { "name" : "OPG_LPA_COMMON_RESQUE_REDIS_HOST", "value" : "redisback" },
         { "name" : "OPG_LPA_COMMON_PDF_CACHE_S3_BUCKET", "value" : data.aws_s3_bucket.lpa_pdf_cache.bucket },
         { "name" : "OPG_LPA_COMMON_PDF_QUEUE_URL", "value" : aws_sqs_queue.pdf_fifo_queue.id },
-        { "name" : "OPG_LPA_ENDPOINTS_API", "value" : "http://${local.api_service_fqdn}" }
+        { "name" : "OPG_LPA_ENDPOINTS_API", "value" : "http://${local.api_service_fqdn}" },
+        { "name" : "OPG_LPA_OS_PLACES_HUB_ENDPOINT", "value" : "https://api.os.uk/search/places/v1/postcode" }
       ]
     }
   )

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -34,7 +34,7 @@ module "api_aurora" {
   count                         = local.account.aurora_enabled ? 1 : 0
   aurora_serverless             = local.account.aurora_serverless
   account_id                    = data.aws_caller_identity.current.account_id
-  apply_immediately             = !local.account.deletion_protection
+  apply_immediately             = ! local.account.deletion_protection
   cluster_identifier            = "api2"
   db_subnet_group_name          = "data-persistence-subnet-default"
   deletion_protection           = local.account.deletion_protection
@@ -47,7 +47,7 @@ module "api_aurora" {
   instance_class                = "db.t3.medium"
   kms_key_id                    = data.aws_kms_key.rds.arn
   replication_source_identifier = local.account.always_on ? aws_db_instance.api[0].arn : ""
-  skip_final_snapshot           = !local.account.deletion_protection
+  skip_final_snapshot           = ! local.account.deletion_protection
   vpc_security_group_ids        = [aws_security_group.rds-api.id]
   tags                          = local.default_tags
 }

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -34,7 +34,7 @@ module "api_aurora" {
   count                         = local.account.aurora_enabled ? 1 : 0
   aurora_serverless             = local.account.aurora_serverless
   account_id                    = data.aws_caller_identity.current.account_id
-  apply_immediately             = ! local.account.deletion_protection
+  apply_immediately             = !local.account.deletion_protection
   cluster_identifier            = "api2"
   db_subnet_group_name          = "data-persistence-subnet-default"
   deletion_protection           = local.account.deletion_protection
@@ -47,7 +47,7 @@ module "api_aurora" {
   instance_class                = "db.t3.medium"
   kms_key_id                    = data.aws_kms_key.rds.arn
   replication_source_identifier = local.account.always_on ? aws_db_instance.api[0].arn : ""
-  skip_final_snapshot           = ! local.account.deletion_protection
+  skip_final_snapshot           = !local.account.deletion_protection
   vpc_security_group_ids        = [aws_security_group.rds-api.id]
   tags                          = local.default_tags
 }

--- a/terraform/environment/secrets.tf
+++ b/terraform/environment/secrets.tf
@@ -38,6 +38,10 @@ data "aws_secretsmanager_secret" "opg_lpa_front_ordnance_survey_license_key" {
   name = "${local.account_name}/opg_lpa_front_ordnance_survey_license_key"
 }
 
+data "aws_secretsmanager_secret" "opg_lpa_front_os_places_hub_license_key" {
+  name = "${local.account_name}/opg_lpa_front_os_places_hub_license_key"
+}
+
 # pdf secrets
 data "aws_secretsmanager_secret" "opg_lpa_pdf_owner_password" {
   name = "${local.account_name}/opg_lpa_pdf_owner_password"


### PR DESCRIPTION
## Purpose
- To create secrets for new endpoint 
- New endpoint env var to make Ordinance Survey api endpoint more configurable.

Part 1 of  LPAL-315

## Approach

- Add secret placeholder to account. This will then allow us to put new api keys in place.
- Add env vars to ECS front

## Learning
- Secrets manager: https://docs.aws.amazon.com/secretsmanager/index.html
- OS Places Hub API: https://osdatahub.os.uk/docs

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
