### PR TITLE
LPAL-317 Show error in page title / LPAL-278 Replace cypress-axe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,5 +189,5 @@ endif
 ifeq ($(UNAME_S),Linux)
 cypress-gui-local:
 	xhost + 127.0.0.1
-	aws-vault exec moj-lpa-dev -- docker run -it -v ~/.Xauthority:/root/.Xauthority:ro -e DISPLAY -e "CYPRESS_VIDEO=true" -e "CYPRESS_baseUrl=https://localhost:7002"  --entrypoint "./cypress/start.sh" --network="host" --rm cypress:latest open --project /app
+	aws-vault exec moj-lpa-dev -- docker run -it -v ~/.Xauthority:/root/.Xauthority:ro -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e DISPLAY -e "CYPRESS_VIDEO=true" -e "CYPRESS_baseUrl=https://localhost:7002"  --entrypoint "./cypress/start.sh" --network="host" --rm cypress:latest open --project /app
 endif

--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 RUN pip3 install boto3
 
-RUN npm install --save-dev cypress-axe@0.12.1 axe-core \
+RUN npm install --save-dev axe-core \
     cypress-cucumber-preprocessor cypress-plugin-tab
 
 # unset CI which gets set in Cypress's dockerfile

--- a/cypress/integration/CreateHwLpa.feature
+++ b/cypress/integration/CreateHwLpa.feature
@@ -15,6 +15,7 @@ Feature: Create a Health and Welfare LPA
         Then I see in the page text
             | There is a problem |
             | Choose a type of LPA |
+        And I see "Error" in the title
         When I choose Health and Welfare
         And I click "save"
         Then I am taken to the donor page
@@ -86,13 +87,14 @@ Feature: Create a Health and Welfare LPA
         Then I see in the page text
             | There is a problem |
             | Choose an option |
+        And I see "Error" in the title
         When I check "canSustainLife-1"
         And I click "save"
         Then I am taken to the primary attorney page
         And I cannot find "save"
 
         # Donor page tests end here and Primary Attorney page tests start. Ultimately a good place to start a new Scenario
-        
+
         When I click "add-attorney"
         Then I can see popup
         And I can find "form-cancel"
@@ -100,7 +102,7 @@ Feature: Create a Health and Welfare LPA
         # todo - casper just looked for use-my-details. We need ultimately to actually test this
         And I can find "use-my-details"
         When I select "Mrs" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | Amy |
             | name-last | Wheeler |
             | dob-date-day| 22 |
@@ -125,7 +127,7 @@ Feature: Create a Health and Welfare LPA
         # Test adding same attorney twice
         When I click "add-attorney"
         When I select "Mrs" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | Amy |
             | name-last | Wheeler |
             | dob-date-day| 22 |
@@ -139,7 +141,7 @@ Feature: Create a Health and Welfare LPA
         Then I see "There is also an attorney called Amy Wheeler. A person cannot be named as an attorney twice on the same LPA." in the page text
         # Add 2cnd attorney
         When I select "Mr" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | David |
             | name-last | Wheeler |
             | dob-date-day| 12 |
@@ -166,7 +168,7 @@ Feature: Create a Health and Welfare LPA
         # Re-add 2cnd attorney
         When I click "add-attorney"
         When I select "Mr" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | David |
             | name-last | Wheeler |
             | dob-date-day| 12 |
@@ -206,18 +208,20 @@ Feature: Create a Health and Welfare LPA
         Then I see in the page text
             | There is a problem |
             | How should the attorneys make decisions |
+        And I see "Error" in the title
         When I click "how-depends"
         # test save without typing anything in how-details
         When I click "save"
         Then I see in the page text
             | There is a problem |
             | Tell us which decisions have to be made jointly, and which can be made jointly and severally |
+        And I see "Error" in the title
         When I click "how-jointly-attorney-severally"
         When I click "save"
         Then I am taken to the replacement attorney page
 
         # Primary Attorney page tests end here and Replacement Attorney tests start. Ultimately a good place to start a new Scenario
-        
+
         When I click "save"
         Then I am taken to the certificate provider page
         When I click occurrence 4 of "accordion-view-change"
@@ -228,7 +232,7 @@ Feature: Create a Health and Welfare LPA
         And I can find "postcode-lookup"
         And I can find "name-title" with 8 options
         When I select "Ms" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | Isobel |
             | name-last | Ward |
             | dob-date-day | 01 |
@@ -248,7 +252,7 @@ Feature: Create a Health and Welfare LPA
         When I click "add-replacement-attorney"
         # deliberately Mrs instead of Ms this time
         When I select "Mrs" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | Isobel |
             | name-last | Ward |
             | dob-date-day | 22 |
@@ -260,7 +264,7 @@ Feature: Create a Health and Welfare LPA
             | address-postcode| ST14 8NX |
         Then I see "There is also a replacement attorney called Isobel Ward. A person cannot be named as a replacement attorney twice on the same LPA." in the page text
         When I select "Mr" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | Ewan |
             | name-last | Adams |
             | dob-date-day | 12 |
@@ -275,13 +279,13 @@ Feature: Create a Health and Welfare LPA
         And I see "Mr Ewan Adams" in the page text
         When I click occurrence 1 of "delete-attorney"
         And I click "delete"
-        # Check we are back to 1 attorney listed 
+        # Check we are back to 1 attorney listed
         Then I am taken to the replacement attorney page
         Then I do not see "Mr Ewan Adams" in the page text
         # re-add 2cnd replacement attorney
         When I click "add-replacement-attorney"
         And I select "Mr" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | Ewan |
             | name-last | Adams |
             | dob-date-day | 12 |
@@ -315,16 +319,18 @@ Feature: Create a Health and Welfare LPA
         Then I am taken to the when replacement attorneys step in page
 
         # Replacement Attorney details tests end and When Replacement Attorney should Act tests start. Ultimately a good place to start a new Scenario
-        
+
         When I click "save"
         Then I see in the page text
             | There is a problem |
             | Choose how the replacement attorneys should step in |
+        And I see "Error" in the title
         When I click "when-depends"
         And I click "save"
         Then I see in the page text
             | There is a problem |
             | Tell us how you'd like the replacement attorneys to step in |
+        And I see "Error" in the title
         And I can find "when-details" wrapped with error highlighting
         When I click "when-first"
         And I click "save"
@@ -336,24 +342,26 @@ Feature: Create a Health and Welfare LPA
         Then I am taken to the how replacement attorneys make decision page
 
         # When Replacement Attorney should Act tests end and How Replacement Attorney make decisions start. Ultimately a good place to start a new Scenario
-        
+
         # test save without selecting anything
         When I click "save"
         Then I see in the page text
             | There is a problem |
             | How should the replacement attorneys make decisions |
+        And I see "Error" in the title
         When I click "how-depends"
         # test save without typing anything in how-details
         When I click "save"
         Then I see in the page text
             | There is a problem |
             | Tell us which decisions have to be made jointly, and which can be made jointly and severally |
+        And I see "Error" in the title
         When I click "how-jointly-attorney-severally"
         When I click "save"
         Then I am taken to the certificate provider page
 
         # How Replacement Attorney make decisions end and Certificate Provider tests start. Ultimately a good place to start a new Scenario
-        
+
         When I click "add-certificate-provider"
         Then I can see popup
         And I can find "form-cancel"
@@ -361,7 +369,7 @@ Feature: Create a Health and Welfare LPA
         # todo - casper just looked for use-my-details. We need ultimately to actually test this
         And I can find "use-my-details"
         When I select "Mr" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | Reece |
             | name-last | Richards |
             | address-address1 | 11 Brookside |
@@ -390,7 +398,7 @@ Feature: Create a Health and Welfare LPA
         Then I am taken to the people to notify page
 
         # Certificate Provider tests end and Person to Notify Tests start. Ultimately a good place to start a new Scenario
-        
+
         When I click "add"
         Then I can see popup
         And I can find "form-cancel"
@@ -398,7 +406,7 @@ Feature: Create a Health and Welfare LPA
         # todo - casper just looked for use-my-details. We need ultimately to actually test this
         And I can find "use-my-details"
         When I select "Other" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-title | Sir |
             | name-first | Anthony |
             | name-last | Webb |

--- a/cypress/integration/CreatePfLpa.feature
+++ b/cypress/integration/CreatePfLpa.feature
@@ -15,6 +15,7 @@ Feature: Create a Property and Finance LPA
         Then I see in the page text
             | There is a problem |
             | Choose a type of LPA |
+        And I see "Error" in the title
         When I choose Property and Finance
         And I click "save"
         Then I am taken to the donor page
@@ -106,13 +107,14 @@ Feature: Create a Property and Finance LPA
         Then I see in the page text
             | There is a problem |
             | Choose when your LPA can be used |
+        And I see "Error" in the title
         When I check "when-now"
         And I click "save"
         Then I am taken to the primary attorney page
         And I cannot find "save"
 
         # Donor page tests end here and Primary Attorney page tests start. Ultimately a good place to start a new Scenario
-        
+
         When I click "add-attorney"
         Then I can see popup
         And I can find "form-cancel"
@@ -263,18 +265,19 @@ Feature: Create a Property and Finance LPA
         Then I see in the page text
             | There is a problem |
             | How should the attorneys make decisions |
+        And I see "Error" in the title
         When I click "how-depends"
         # test save without typing anything in how-details
         When I click "save"
         Then I see in the page text
             | There is a problem |
             | Tell us which decisions have to be made jointly, and which can be made jointly and severally |
+        And I see "Error" in the title
         When I click "how-jointly-attorney-severally"
         When I click "save"
         Then I am taken to the replacement attorney page
 
         # Primary Attorney page tests end here and Replacement Attorney tests start. Ultimately a good place to start a new Scenario
-        
         When I click "save"
         Then I am taken to the certificate provider page
         When I click occurrence 4 of "accordion-view-change"
@@ -284,7 +287,6 @@ Feature: Create a Property and Finance LPA
         And I can find "use-my-details"
         And I can find "postcode-lookup"
         And I can find "name-title" with 8 options
-        When I force fill out  
             | name-first | qo06zCs3DEtroWJF8U7eqo7LWeO47Cc5NVbCLPOfL7TROMO5S7JCCZkNulCD7tpVi0x9kB |
             | name-last | qo06zCs3DEtroWJF8U7eqo7LWeO47Cc5NVbCLPOfL7TROMO5S7JCCZkNulCD7tpVi0x9kB |
             | dob-date-day | 01 |
@@ -304,7 +306,7 @@ Feature: Create a Property and Finance LPA
             | Change address line 2 so that it has fewer than 51 characters |
             | Change address line 3 so that it has fewer than 51 characters |
         When I select "Ms" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | Isobel |
             | name-last | Ward |
             | address-address1 | 2 Westview |
@@ -316,7 +318,7 @@ Feature: Create a Property and Finance LPA
         When I click "add-replacement-attorney"
         # deliberately Mrs instead of Ms this time
         When I select "Mrs" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | Isobel |
             | name-last | Ward |
             | dob-date-day | 22 |
@@ -328,7 +330,7 @@ Feature: Create a Property and Finance LPA
             | address-postcode| ST14 8NX |
         Then I see "There is also a replacement attorney called Isobel Ward. A person cannot be named as a replacement attorney twice on the same LPA." in the page text
         When I select "Mr" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | Ewan |
             | name-last | Adams |
             | dob-date-day | 12 |
@@ -343,13 +345,13 @@ Feature: Create a Property and Finance LPA
         And I see "Mr Ewan Adams" in the page text
         When I click occurrence 1 of "delete-attorney"
         And I click "delete"
-        # Check we are back to 1 attorney listed 
+        # Check we are back to 1 attorney listed
         Then I am taken to the replacement attorney page
         Then I do not see "Mr Ewan Adams" in the page text
         # re-add 2cnd replacement attorney
         When I click "add-replacement-attorney"
         And I select "Mr" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | Ewan |
             | name-last | Adams |
             | dob-date-day | 12 |
@@ -383,16 +385,18 @@ Feature: Create a Property and Finance LPA
         Then I am taken to the when replacement attorneys step in page
 
         # Replacement Attorney details tests end and when Replacement Attorney should Act tests start. Ultimately a good place to start a new Scenario
-        
+
         When I click "save"
         Then I see in the page text
             | There is a problem |
             | Choose how the replacement attorneys should step in |
+        And I see "Error" in the title
         When I click "when-depends"
         And I click "save"
         Then I see in the page text
             | There is a problem |
             | Tell us how you'd like the replacement attorneys to step in |
+        And I see "Error" in the title
         And I can find "when-details" wrapped with error highlighting
         When I click "when-first"
         And I click "save"
@@ -404,31 +408,33 @@ Feature: Create a Property and Finance LPA
         Then I am taken to the how replacement attorneys make decision page
 
         # When Replacement Attorney should Act tests end and How Replacement Attorney make decisions start. Ultimately a good place to start a new Scenario
-        
+
         # test save without selecting anything
         When I click "save"
         Then I see in the page text
             | There is a problem |
             | How should the replacement attorneys make decisions |
+        And I see "Error" in the title
         When I click "how-depends"
         # test save without typing anything in how-details
         When I click "save"
         Then I see in the page text
             | There is a problem |
             | Tell us which decisions have to be made jointly, and which can be made jointly and severally |
+        And I see "Error" in the title
         When I click "how-jointly-attorney-severally"
         When I click "save"
         Then I am taken to the certificate provider page
 
         # How Replacement Attorney make decisions end and Certificate Provider tests start. Ultimately a good place to start a new Scenario
-        
+
         When I click "add-certificate-provider"
         Then I can see popup
         And I can find "form-cancel"
         And I can find "name-title" with 8 options
         # todo - casper just looked for use-my-details. We need ultimately to actually test this
         And I can find "use-my-details"
-        When I force fill out  
+        When I force fill out
             | name-first | qo06zCs3DEtroWJF8U7eqo7LWeO47Cc5NVbCLPOfL7TROMO5S7JCCZkNulCD7tpVi0x9kB |
             | name-last | qo06zCs3DEtroWJF8U7eqo7LWeO47Cc5NVbCLPOfL7TROMO5S7JCCZkNulCD7tpVi0x9kB |
             | address-address1 | qo06zCs3DEtroWJF8U7eqo7LWeO47Cc5NVbCLPOfL7TROMO5S7JCCZkNulCD7tpVi0x9kB |
@@ -445,7 +451,7 @@ Feature: Create a Property and Finance LPA
             | Change address line 2 so that it has fewer than 51 characters |
             | Change address line 3 so that it has fewer than 51 characters |
         When I select "Mr" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-first | Reece |
             | name-last | Richards |
             | address-address1 | 11 Brookside |
@@ -473,14 +479,14 @@ Feature: Create a Property and Finance LPA
         Then I am taken to the people to notify page
 
         # Certificate Provider tests end and Person to Notify Tests start. Ultimately a good place to start a new Scenario
-        
+
         When I click "add"
         Then I can see popup
         And I can find "form-cancel"
         And I can find "name-title" with 8 options
         # todo - casper just looked for use-my-details. We need ultimately to actually test this
         And I can find "use-my-details"
-        When I force fill out  
+        When I force fill out
             | name-first | qo06zCs3DEtroWJF8U7eqo7LWeO47Cc5NVbCLPOfL7TROMO5S7JCCZkNulCD7tpVi0x9kB |
             | name-last | qo06zCs3DEtroWJF8U7eqo7LWeO47Cc5NVbCLPOfL7TROMO5S7JCCZkNulCD7tpVi0x9kB |
             | address-address1 | qo06zCs3DEtroWJF8U7eqo7LWeO47Cc5NVbCLPOfL7TROMO5S7JCCZkNulCD7tpVi0x9kB |
@@ -497,7 +503,7 @@ Feature: Create a Property and Finance LPA
             | Change address line 2 so that it has fewer than 51 characters |
             | Change address line 3 so that it has fewer than 51 characters |
         When I select "Other" on "name-title"
-        And I force fill out  
+        And I force fill out
             | name-title | Sir |
             | name-first | Anthony |
             | name-last | Webb |
@@ -521,9 +527,9 @@ Feature: Create a Property and Finance LPA
         Then I am taken to the instructions page
 
         # Person to Notify Tests end and Instructions tests start. Ultimately a good place to start a new Scenario
-        
+
         When I click "add-extra-preferences"
-        And I force fill out  
+        And I force fill out
             | instruction | Lorem Ipsum |
             | preferences | Neque porro quisquam |
         When I click "save"
@@ -537,7 +543,7 @@ Feature: Create a Property and Finance LPA
         When I visit link containing "preview the LPA"
 
         # Instructions tests end here and Summary tests start. Ultimately a good place to start a new Scenario
-        
+
         Then I am taken to the summary page
         And I see the following summary information
             | Type | Property and finance | |
@@ -561,7 +567,7 @@ Feature: Create a Property and Finance LPA
             | Attorney decisions | | |
             | How decisions are made | The attorneys will act jointly and severally | how-primary-attorneys-make-decision |
             | 1st replacement attorney | | |
-            | Name | Ms Isobel Ward | replacement-attorney | 
+            | Name | Ms Isobel Ward | replacement-attorney |
             | Date of birth | 1 February 1937 | |
             | Address | 2 Westview $ Staplehay $ Trull, Taunton, Somerset $ TA3 7HF | |
             | 2nd replacement attorney | | |
@@ -569,7 +575,7 @@ Feature: Create a Property and Finance LPA
             | Date of birth | 12 March 1972 | |
             | Address | 2 Westview $ Staplehay $ Trull, Taunton, Somerset $ TA3 7HF | |
             | Replacement attorney decisions | | |
-            | When they step in | The replacement attorneys will only step in when none of the original attorneys can act | when-replacement-attorney-step-in | 
+            | When they step in | The replacement attorneys will only step in when none of the original attorneys can act | when-replacement-attorney-step-in |
             | How decisions are made | The replacement attorneys will act jointly and severally | how-replacement-attorneys-make-decision |
             | Certificate provider | | |
             | Name | Mr Reece Richards | certificate-provider |
@@ -584,18 +590,19 @@ Feature: Create a Property and Finance LPA
         And I click "continue"
 
         # Summary tests end here and Applicant tests start. Ultimately a good place to start a new Scenario
-        
+
         Then I am taken to the applicant page
         When I click "save"
         Then I see in the page text
             | There is a problem |
             | Select the person who is applying to register the LPA |
+        And I see "Error" in the title
         # select the donor as applicant
         When I check occurrence 0 of checkbox
         And I click "save"
 
         # Applicant tests end here and Correspondent tests start. Ultimately a good place to start a new Scenario
-        
+
         Then I am taken to the correspondent page
         And I can find "contactInWelsh-0"
         And I can find "contactInWelsh-1"

--- a/cypress/integration/Errors.feature
+++ b/cypress/integration/Errors.feature
@@ -1,7 +1,7 @@
 @Errors
 Feature: Errors
 
-    I want to be see useful and relevant error messages
+    I want to see useful and relevant error messages
 
     Background:
         Given I ignore application exceptions
@@ -16,8 +16,12 @@ Feature: Errors
         And there is "one" "level 1 heading" element on the page
 
     @focus
-    # requires additional scenario as login page doesn't use the error macro
-    Scenario: Error message heading level and text / server-rendered auth (LPAL-247)
+    # requires additional scenarios as login page doesn't use the error macro;
+    # this path attempts to log the user in and fails, but doesn't use
+    # the same path through the code as invalid form fields (see below);
+    # a failed login (but valid email input) produces a different type of error
+    # from invalid form fields
+    Scenario: Error message heading level and text / server-rendered auth - valid email (LPAL-247)
         Given I visit "/login"
         And I type "foo@example.com" into "login-email"
         And I type "aaa" into "login-password"
@@ -35,5 +39,19 @@ Feature: Errors
         Then I see in the page text
             | There is a problem |
             | Choose a type of LPA |
+        And I see "Error" in the title
         When I visit link containing "Choose a type of LPA"
         Then I am focused on "type-property-and-financial"
+
+    # requires additional scenarios as login page doesn't use the error macro;
+    # this scenario covers invalid email entered, which uses a different branch
+    # of the code from a failed user login
+    Scenario: Error message heading level and text / server-rendered auth - invalid email (LPAL-247)
+        Given I visit "/login"
+        And I type "foo" into "login-email"
+        And I type "aaa" into "login-password"
+        And I click "login-submit-button"
+        Then I see "There is a problem" in the page text
+        And I see "Error" in the title
+        And "error-heading" is a "level 2 heading" element
+        And there is "one" "level 1 heading" element on the page

--- a/cypress/integration/Errors.feature
+++ b/cypress/integration/Errors.feature
@@ -11,6 +11,7 @@ Feature: Errors
         Given I visit "/send-feedback"
         When I submit the feedback
         Then I see "There is a problem" in the page text
+        And I see "Error" in the title
         And "error-heading" is a "level 2 heading" element
         And there is "one" "level 1 heading" element on the page
 
@@ -22,6 +23,7 @@ Feature: Errors
         And I type "aaa" into "login-password"
         And I click "login-submit-button"
         Then I see "There is a problem" in the page text
+        And I see "Error" in the title
         And "error-heading" is a "level 2 heading" element
         And there is "one" "level 1 heading" element on the page
 

--- a/cypress/integration/Feedback.feature
+++ b/cypress/integration/Feedback.feature
@@ -14,17 +14,18 @@ Feature: Feedback
         And I see "Send us feedback" in the title
         And I can find feedback buttons
         When I submit the feedback
-        Then I see "There is a problem" in the page text
         Then I see in the page text
             | There is a problem |
             | Select a rating for this service |
-            | Do not forget to leave your feedback in the box | 
+            | Do not forget to leave your feedback in the box |
+        And I see "Error" in the title
         When I select satisfied
         And I submit the feedback
         Then I see in the page text
             | There is a problem |
-            | Do not forget to leave your feedback in the box | 
+            | Do not forget to leave your feedback in the box |
         And I can find "feedback-textarea" wrapped with error highlighting
+        And I see "Error" in the title
         When I select neither satisfied or dissatisfied
         And I set feedback email as "cypress@opg-lpa-test.net"
         And I set feedback content as "Cypress feedback form test"

--- a/cypress/integration/Password.feature
+++ b/cypress/integration/Password.feature
@@ -24,6 +24,7 @@ Feature: Password
             | Choose a new password that includes at least one lower case letter (a-z) |
             | Choose a new password that includes at least one capital letter (A-Z) |
             | Enter matching passwords |
+        And I see "Error" in the title
 
     @focus
     Scenario: Reset Password using email link

--- a/cypress/integration/Signup.feature
+++ b/cypress/integration/Signup.feature
@@ -35,6 +35,7 @@ Feature: Signup
           | address-postcode| wrongpostcode |
         And I click "save"
         Then I see "There is a problem" in the page text
+        And I see "Error" in the title
 
         # todo - note we should be selecting Mr like we do in the Valid scenario, not typing it in here, but due to system bug, after a previous error we get a text box
         # instead of a dropdown. The line below will therefore need to change to When I select Mr on name-title, once this bug is fixed
@@ -49,6 +50,7 @@ Feature: Signup
           | address-postcode| PL45 9JA |
         And I click "save"
         Then I see "There is a problem" in the page text
+        And I see "Error" in the title
 
     @focus
     Scenario: Valid About Me details

--- a/cypress/integration/common/a11y.js
+++ b/cypress/integration/common/a11y.js
@@ -119,11 +119,15 @@ Then('my browser doesn\'t support details elements', () => {
  * (e.g. text with a background colour).
  */
 Then('elements on the page should have sufficient contrast', () => {
-    cy.injectAxe2();
-    cy.checkA11y(null, {
-        runOnly: {
-            type: 'tag',
-            values: ['cat.color']
-        }
+    cy.window().then((window) => {
+        cy.runAxe(window, {
+            axeOptions: {
+                runOnly: {
+                    type: 'tag',
+                    values: ['cat.color']
+                }
+            },
+            stopOnError: true
+        });
     });
 });

--- a/cypress/integration/common/attorney.js
+++ b/cypress/integration/common/attorney.js
@@ -1,19 +1,20 @@
 import { Then } from "cypress-cucumber-preprocessor/steps";
- 
+
 Then(`I can find save pointing to primary attorney decisions page`, (linkAddr) => {
-    canFindPage('how-primary-attorneys-make-decision');
+    canFindButtonLinkedTo('how-primary-attorneys-make-decision');
 })
 
 Then(`I can find save pointing to replacement attorney page`, (linkAddr) => {
-    canFindPage('replacement-attorney');
+    canFindButtonLinkedTo('replacement-attorney');
 })
 
 Then(`I can find save pointing to people to notify page`, (linkAddr) => {
-    canFindPage('people-to-notify');
+    canFindButtonLinkedTo('people-to-notify');
 })
 
-function canFindPage(urlPart) {
-    cy.getLpaId().then((lpaId) => { 
-        cy.get("[data-cy=save]").invoke('attr', 'href').should('eq','/lpa/' + lpaId + '/' + urlPart);
+function canFindButtonLinkedTo(urlPart) {
+    cy.getLpaId().then((lpaId) => {
+        let expectedHref = '/lpa/' + lpaId + '/' + urlPart;
+        cy.get('[data-cy=save][href="' + expectedHref + '"]');
     });
 }

--- a/cypress/support/axe_wrapper.js
+++ b/cypress/support/axe_wrapper.js
@@ -1,0 +1,89 @@
+/**
+ * Wrapper for axe accessibility testing library.
+ * Provides functionality to enable injection of axe into pages under
+ * test in Cypress, followed by running an a11y audit on the page.
+ */
+
+/**
+ * Inject axe into the page and run a11y audit
+ *
+ * window: browser window instance, typically derived via cy.window()
+ * axeOptions: object containing options to pass directly to axe.run();
+ *     see axe documentation for details
+ */
+function runAxe(window, axeOptions) {
+    axeOptions = axeOptions || {};
+
+    // only inject axe if <script id="axe"> isn't in the page already
+    if (Cypress.$('#axe').length < 1) {
+        const script = window.document.createElement('script');
+        script.id = 'axe';
+        script.async = false;
+        script.innerHTML = require('axe-core/axe.js').source;
+        window.document.body.appendChild(script);
+    }
+
+    // axe adds itself as a property on the window object
+    return window.axe.run(axeOptions).then((results) => {
+        let violations = results.violations;
+        let location = window.location.href.replace(Cypress.config('baseUrl'), '');
+
+        if (violations.length > 0) {
+            let dedupedViolations = dedupeViolations(location, violations);
+
+            // log to the console inside the browser
+            logViolations(dedupedViolations, console.log);
+
+            // this will be logged by cy.task('log', ...)
+            return dedupedViolations;
+        }
+
+        return null;
+    });
+}
+
+// Construct structured object for the violations;
+// object returned looks like:
+// { location: "<browser location where violations occurred>",
+//   reports: [
+//     { id: <id of violation>, impact: <impact of violation>,
+//       description: <long description>, snippets: [ <violating node HTML>, ... ]
+//   ] }
+function dedupeViolations(location, violations) {
+    // make a set of unique violations
+    let reports = new Set();
+
+    violations.forEach((violation) => {
+        reports.add({
+            id: violation.id,
+            impact: violation.impact,
+            description: violation.description,
+            snippets: violation.nodes.map((node) => node.html),
+        });
+    });
+
+    return {
+        location: location,
+        reports: reports
+    };
+}
+
+// violations is a de-duplicated violations object, in the format
+// produced by dedupeViolations;
+// this calls logFn(string) for each string in the violations object, writing it
+// to the desired output log
+function logViolations(violations, logFn) {
+    logFn(`\n******* ACCESSIBILITY VIOLATIONS ON ${violations.location}`);
+    violations.reports.forEach((report) => {
+        logFn(`------- ID: ${report.id}`);
+        logFn(`Impact: ${report.impact}`);
+        logFn(`Description: ${report.description}`);
+        logFn('HTML elements causing violation:');
+        logFn('* ' + report.snippets.join('\n* '));
+    });
+}
+
+module.exports = {
+    runAxe: runAxe,
+    logViolations: logViolations
+};

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,61 +25,43 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 //
 
+const axeWrapper = require('./axe_wrapper');
+
 Cypress.Commands.add("getLpaId", () => {
     cy.get('@donorPageUrl').then((donorPageUrl) => {
         return donorPageUrl.match(/\/(\d+)\//)[1];
     });
 });
 
-Cypress.Commands.add("OPGCheckA11y", () => {
-    cy.window({ log: false }).then((window) => {
-        if (Cypress.$('#axe').length < 1) {
-            const script = window.document.createElement('script');
-            script.id = 'axe';
-            script.async = false;
-            script.innerHTML = require('axe-core/axe.js').source;
-            window.document.body.appendChild(script);
+// window: DOM window instance
+// options: passed directly to axe
+// stopOnError: boolean, default=false; if true, if any violations are
+//     found, an exception is thrown, stopping the test
+Cypress.Commands.add("runAxe", (window, options, stopOnError) => {
+    stopOnError = !!stopOnError;
+
+    // wrap runAxe so that cypress understands the promise it returns
+    cy.wrap(axeWrapper.runAxe(window, options)).then((violations) => {
+        if (violations != null) {
+            // wrap this so that all the cy.task('log', ...) calls complete before
+            // throwing the error; without this, the error is thrown before
+            // the logging is completed
+            cy.wrap(axeWrapper.logViolations(violations, (msg) => {
+                cy.task('log', msg);
+            }))
+            .then(() => {
+                // throw an error to stop the test if configured to;
+                // otherwise we just see log messages and the test continues
+                if (stopOnError) {
+                    throw new Error('accessibility violations caused test to fail');
+                }
+            });
         }
-
-        let logFn = (msg) => {
-            Cypress.log({name: 'axe', message: msg});
-        };
-
-        window.axe.run().then((results) => {
-            let violations = results.violations;
-
-            if (violations.length > 0) {
-                showAccessibilityViolations(violations, logFn);
-            }
-        });
     });
 });
 
-// Show axe accessibility violations on the terminal
-function showAccessibilityViolations(violations, logFn) {
-    let location = window.location.href;
-
-    // make a set of unique violations; yes, I could have been clever
-    // and done it in one line, but the previous code confused me and
-    // I think this makes it clearer that we're populating a set
-    let reports = new Set();
-
-    violations.forEach((violation) => {
-        reports.add({
-            id: violation.id,
-            impact: violation.impact,
-            description: violation.description,
-            snippets: violation.nodes.map((node) => node.html),
-        });
+Cypress.Commands.add("OPGCheckA11y", () => {
+    cy.window({ log: false }).then((window) => {
+        cy.runAxe(window);
     });
-
-    logFn(`\n************** ACCESSIBILITY VIOLATIONS ON ${location}`);
-
-    reports.forEach((report) => {
-        logFn(`-------------- ID: ${report.id}`);
-        logFn(`Impact: ${report.impact}`);
-        logFn(`Description: ${report.description}`);
-        logFn('HTML elements causing violation:');
-        logFn('* ' + report.snippets.join('\n* '));
-    });
-}
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -17,12 +17,6 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-
-// pull in cypress-axe
-import 'cypress-axe'
-
 import 'cypress-plugin-tab'
 
 // note that userNumber is set in start.sh, to ensure that it applies to all feature files run during this session of Cypress

--- a/service-front/module/Application/view/layout/twig/layout.twig
+++ b/service-front/module/Application/view/layout/twig/layout.twig
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-    <title>{% if (error is not empty or (form is not empty and form.getMessages|length > 0)) %}Error: {% endif %}{% block htmlTitle %}{% endblock %}Make a lasting power of attorney - GOV.UK</title>
+    <title>{% if (authError is not empty or error is not empty or (form is not empty and form.getMessages|length > 0)) %}Error: {% endif %}{% block htmlTitle %}{% endblock %}Make a lasting power of attorney - GOV.UK</title>
 
     <link href="{{ StaticAssetPath( '/assets/v2/css/govuk-template.css', { 'minify':true } ) }}" rel="stylesheet" type="text/css"/>
 

--- a/service-front/module/Application/view/layout/twig/layout.twig
+++ b/service-front/module/Application/view/layout/twig/layout.twig
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-    <title>{% block htmlTitle %}{% endblock %}Make a lasting power of attorney - GOV.UK</title>
+    <title>{% if (error is not empty or (form is not empty and form.getMessages|length > 0)) %}Error: {% endif %}{% block htmlTitle %}{% endblock %}Make a lasting power of attorney - GOV.UK</title>
 
     <link href="{{ StaticAssetPath( '/assets/v2/css/govuk-template.css', { 'minify':true } ) }}" rel="stylesheet" type="text/css"/>
 


### PR DESCRIPTION
## Purpose

Add "Error: " to the start of the page title when an error occurred on the page.

https://opgtransform.atlassian.net/browse/LPAL-317
https://opgtransform.atlassian.net/browse/LPAL-278

Fixes LPAL-317, LPAL-278

## Approach

Simple change to layout template. Additionally worked on cypress tests so I could have passing tests to prove it works (removed cypress-axe in the process).

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [x] The product team have tested these changes
