### PR TITLE
LPAL-131 add PDF message queue cloudwatch alarm for available items

### DIFF
--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -88,10 +88,10 @@ resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
   }
   ok_actions          = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
   period              = 60
-  evaluation_periods  = 2
-  datapoints_to_alarm = 2
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
   statistic           = "Sum"
   tags                = {}
-  threshold           = 10
+  threshold           = 6
   treat_missing_data  = "notBreaching"
 }

--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -74,3 +74,24 @@ resource "aws_cloudwatch_metric_alarm" "front_csrf_mismatch_errors" {
   threshold                 = 2
   treat_missing_data        = "notBreaching"
 }
+
+resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
+  actions_enabled     = true
+  alarm_name          = "${local.environment} pdf messages awaiting processing"
+  alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  alarm_description   = "number of pdf requests in queue"
+  namespace           = "AWS/SQS"
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  comparison_operator = "GreaterThanThreshold"
+  dimensions = {
+    QueueName = aws_sqs_queue.pdf_fifo_queue.name
+  }
+  ok_actions          = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  period              = 60
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  statistic           = "Sum"
+  tags                = {}
+  threshold           = 10
+  treat_missing_data  = "notBreaching"
+}


### PR DESCRIPTION
## Purpose
An additional CloudWatch alarm to check if we have too many pdf messages in the fifo queue.
We may want to add more, but this is a first stab.

- **NOTE**: This may also need a further tweak if too sensitive.

Current threshold is > sum of 6 in an evaluation period (60s).  
Looking at current metrics, we don't tend to get more than 4 in a minute stacked up, so seems like a reasonable attempt.

Fixes LPAL-131

## Approach

- Add cloudwatch alarm 
- add to pager duty SNS topic

## Learning

- SQS developer guide - available cloudwatch metrics: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-available-cloudwatch-metrics.html

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
