### PR TITLE
Lpal-77 create slack alert breakglass

### DIFF
--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -9,3 +9,38 @@ resource "aws_cloudwatch_log_group" "online-lpa" {
     },
   )
 }
+
+data "aws_cloudwatch_log_group" "cloudtrail" {
+  name = "online_lpa_cloudtrail_${local.account_name}"
+}
+
+resource "aws_cloudwatch_log_metric_filter" "breakglass_metric" {
+  name           = "BreakGlassConsoleLogin"
+  pattern        = "{ $.userIdentity.arn = \"arn:aws:sts::${local.account_id}:assumed-role/breakglass/*\"  && $.eventType = \"AwsConsoleSignIn\" }"
+  log_group_name = data.aws_cloudwatch_log_group.cloudtrail.name
+
+  metric_transformation {
+    name      = "EventCount"
+    namespace = "online-lpa/Cloudtrail"
+    value     = "1"
+  }
+}
+
+
+resource "aws_cloudwatch_metric_alarm" "account_breakglass_login_alarm" {
+  actions_enabled     = true
+  alarm_name          = "${local.environment} breakglass console login check"
+  alarm_actions       = [aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn]
+  alarm_description   = "number of breakglass attempts"
+  namespace           = "online-lpa/Cloudtrail"
+  metric_name         = "BreakGlassConsoleLogin"
+  comparison_operator = "GreaterThanThreshold"
+  ok_actions          = [aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn]
+  period              = 60
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  statistic           = "Sum"
+  tags                = {}
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+}

--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_log_metric_filter" "breakglass_metric" {
 
 resource "aws_cloudwatch_metric_alarm" "account_breakglass_login_alarm" {
   actions_enabled     = true
-  alarm_name          = "${local.environment} breakglass console login check"
+  alarm_name          = "${local.account_name} breakglass console login check"
   alarm_actions       = [aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn]
   alarm_description   = "number of breakglass attempts"
   namespace           = "online-lpa/Cloudtrail"

--- a/terraform/account/put_secrets.tf
+++ b/terraform/account/put_secrets.tf
@@ -62,3 +62,8 @@ resource "aws_secretsmanager_secret" "api_rds_password" {
   name = "${local.account_name}/api_rds_password"
   tags = local.default_tags
 }
+
+resource "aws_secretsmanager_secret" "slack_incoming_webhook" {
+  name = "${local.account_name}/slack_incoming_webhook"
+  tags = local.default_tags
+}

--- a/terraform/account/sns.tf
+++ b/terraform/account/sns.tf
@@ -1,0 +1,3 @@
+resource "aws_sns_topic" "cloudwatch_to_slack_breakglass_alerts" {
+  name = "CloudWatch-to-PagerDuty-${local.account_name}-Breakglass-alert"
+}


### PR DESCRIPTION
## Purpose
**ACCOUNT LEVEL CHANGE** (DRAFT)
Part 1 
- CloudWatch metric and alert
- SNS topic to facilitate breakglass check for console access. 
- Slack secret placeholder.
This looks at cloudtrail logs.


Fixes LPAL-77

## Approach

- terraform account level additions

## Learning

- CloudTrail: https://docs.aws.amazon.com/cloudtrail/index.html
- cloudwatch metrics: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Metric
- publishing custom metrics: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html
- monitor IAM access: https://aws.amazon.com/premiumsupport/knowledge-center/view-iam-history/
- AWS Secrets manager: https://docs.aws.amazon.com/secretsmanager/index.html

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
