### PR TITLE
pin versions of ECS fargate to 1.3.0

### DIFF
--- a/terraform/environment/ecs_admin.tf
+++ b/terraform/environment/ecs_admin.tf
@@ -7,7 +7,7 @@ resource "aws_ecs_service" "admin" {
   task_definition  = aws_ecs_task_definition.admin.arn
   desired_count    = local.account.autoscaling.admin.minimum
   launch_type      = "FARGATE"
-  platform_version = "LATEST"
+  platform_version = "1.3.0"
 
   network_configuration {
     security_groups  = [aws_security_group.admin_ecs_service.id]

--- a/terraform/environment/ecs_api.tf
+++ b/terraform/environment/ecs_api.tf
@@ -7,7 +7,7 @@ resource "aws_ecs_service" "api" {
   task_definition  = aws_ecs_task_definition.api.arn
   desired_count    = local.account.autoscaling.api.minimum
   launch_type      = "FARGATE"
-  platform_version = "LATEST"
+  platform_version = "1.3.0"
 
   network_configuration {
     security_groups = [

--- a/terraform/environment/ecs_api_cron.tf
+++ b/terraform/environment/ecs_api_cron.tf
@@ -97,7 +97,7 @@ resource "aws_cloudwatch_event_target" "api_ecs_cron_event_account_cleanup" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.api.arn
     launch_type         = "FARGATE"
-    platform_version    = "LATEST"
+    platform_version    = "1.3.0"
 
     network_configuration {
       security_groups = [
@@ -134,7 +134,7 @@ resource "aws_cloudwatch_event_target" "api_ecs_cron_event_generate_stats" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.api.arn
     launch_type         = "FARGATE"
-    platform_version    = "LATEST"
+    platform_version    = "1.3.0"
 
     network_configuration {
       security_groups = [

--- a/terraform/environment/ecs_front.tf
+++ b/terraform/environment/ecs_front.tf
@@ -7,7 +7,7 @@ resource "aws_ecs_service" "front" {
   task_definition  = aws_ecs_task_definition.front.arn
   desired_count    = local.account.autoscaling.front.minimum
   launch_type      = "FARGATE"
-  platform_version = "LATEST"
+  platform_version = "1.3.0"
 
   network_configuration {
     security_groups  = [aws_security_group.front_ecs_service.id]

--- a/terraform/environment/ecs_pdf.tf
+++ b/terraform/environment/ecs_pdf.tf
@@ -7,7 +7,7 @@ resource "aws_ecs_service" "pdf" {
   task_definition  = aws_ecs_task_definition.pdf.arn
   desired_count    = local.account.autoscaling.pdf.minimum
   launch_type      = "FARGATE"
-  platform_version = "LATEST"
+  platform_version = "1.3.0"
 
   network_configuration {
     security_groups  = [aws_security_group.pdf_ecs_service.id]


### PR DESCRIPTION
## Purpose

Pin ECS to Fargate 1.3.0. Failure to do this will mean we are on 1.4.0. we need to test that version out and make appropriate adjustments as needed in a separate ticket.

Fixes LPAL-323

## Approach

replace `LATEST` tag with `1.3.0`

## Learning
- AWS Fargate versions: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html
## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
