### PR TITLE
LPAL-326-tidy-tagging

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,4 +1,5 @@
 ## Purpose
+
 _Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_
 
 Fixes LPAL-####
@@ -16,4 +17,5 @@ _Any tips and tricks, blog posts or tools which helped you. Plus anything notabl
 * [ ] I have performed a self-review of my own code
 * [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
 * [ ] I have added tests to prove my work
+* [ ] I have added mandatory tags to terraformed resources, where possible
 * [ ] The product team have tested these changes

--- a/terraform/account/certificate.tf
+++ b/terraform/account/certificate.tf
@@ -41,6 +41,7 @@ resource "aws_acm_certificate_validation" "certificate_front" {
 resource "aws_acm_certificate" "certificate_front" {
   domain_name       = "${local.cert_prefix_internal}front.lpa.opg.service.justice.gov.uk"
   validation_method = "DNS"
+  tags              = local.default_tags
 }
 
 //------------------------
@@ -73,6 +74,7 @@ resource "aws_acm_certificate_validation" "certificate_admin" {
 resource "aws_acm_certificate" "certificate_admin" {
   domain_name       = "${local.cert_prefix_internal}admin.lpa.opg.service.justice.gov.uk"
   validation_method = "DNS"
+  tags              = local.default_tags
 }
 
 //---------------
@@ -106,7 +108,7 @@ resource "aws_acm_certificate" "certificate_public_facing" {
   domain_name               = "${local.cert_prefix_public_facing}${data.aws_route53_zone.live_lastingpowerofattorney_gov_uk.name}"
   validation_method         = "DNS"
   subject_alternative_names = terraform.workspace == "production" ? ["lastingpowerofattorney.service.gov.uk", "maintenance.lastingpowerofattorney.service.gov.uk"] : []
-
+  tags                      = local.default_tags
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/account/locals.tf
+++ b/terraform/account/locals.tf
@@ -33,7 +33,7 @@ locals {
   optional_tags = {
     environment-name       = local.account_name
     infrastructure-support = "OPG LPA Product Team: opgteam+online-lpa@digital.justice.gov.uk"
-    runbook                = "https://github.com/ministryofjustice/opg-webops-runbooks/tree/master/LPA"
+    runbook                = "https://github.com/ministryofjustice/opg-lpa/tree/master/docs/runbooks"
     source-code            = "https://github.com/ministryofjustice/opg-lpa"
   }
 

--- a/terraform/account/s3.tf
+++ b/terraform/account/s3.tf
@@ -99,6 +99,7 @@ resource "aws_s3_bucket_object" "govuk_logo" {
   source       = "../../email-assets/govuk-logo-v1.png"
   etag         = filemd5("../../email-assets/govuk-logo-v1.png")
   content_type = "image/png"
+  tags         = local.default_tags
 }
 
 resource "aws_s3_bucket_object" "opg_logo" {
@@ -108,6 +109,7 @@ resource "aws_s3_bucket_object" "opg_logo" {
   source       = "../../email-assets/opg-logo-v1.png"
   etag         = filemd5("../../email-assets/opg-logo-v1.png")
   content_type = "image/png"
+  tags         = local.default_tags
 }
 
 data "aws_iam_policy_document" "static_email_assets_policy" {

--- a/terraform/account/vpc_flowlogs.tf
+++ b/terraform/account/vpc_flowlogs.tf
@@ -3,15 +3,18 @@ resource "aws_flow_log" "vpc_flow_logs" {
   log_destination = aws_cloudwatch_log_group.vpc_flow_logs.arn
   traffic_type    = "ALL"
   vpc_id          = aws_default_vpc.default.id
+  tags            = local.default_tags
 }
 
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
   name = "vpc_flow_logs"
+  tags = local.default_tags
 }
 
 resource "aws_iam_role" "vpc_flow_logs" {
   name               = "vpc_flow_logs"
   assume_role_policy = data.aws_iam_policy_document.vpc_flow_logs_role_assume_role_policy.json
+  tags               = local.default_tags
 }
 
 data "aws_iam_policy_document" "vpc_flow_logs_role_assume_role_policy" {

--- a/terraform/account/workspace_cleanup.tf
+++ b/terraform/account/workspace_cleanup.tf
@@ -10,10 +10,8 @@ resource "aws_dynamodb_table" "workspace_cleanup_table" {
   }
 
   ttl {
-
     attribute_name = "ExpiresTTL"
     enabled        = true
-
   }
 
   tags = local.default_tags

--- a/terraform/email/locals.tf
+++ b/terraform/email/locals.tf
@@ -25,7 +25,7 @@ locals {
   optional_tags = {
     environment-name       = local.account_name
     infrastructure-support = "OPG LPA Product Team: opgteam+online-lpa@digital.justice.gov.uk"
-    runbook                = "https://github.com/ministryofjustice/opg-webops-runbooks/tree/master/LPA"
+    runbook                = "https://github.com/ministryofjustice/opg-lpa/tree/master/docs/runbooks"
     source-code            = "https://github.com/ministryofjustice/opg-lpa"
   }
 

--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -2,58 +2,57 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.21.0"
+  version     = "3.31.0"
   constraints = "~> 3.0"
   hashes = [
-    "h1:YGpoWikUMRAqKJAzT5llGi4fE/ce/MFqfXg7m0f7VNA=",
-    "h1:jvcUKDDNFXjIRWoxfw55vvfFTlSgnLMYe1qiSZNtWoE=",
-    "zh:11b8c85d063775029245e86ebce346ed86aa77aefaa72dc558da37ea347aa77c",
-    "zh:15f0f5bcbcffe1d2aeaa595f6573f0779932bd3a7647f28ad6aacf1a20f35562",
-    "zh:4459e3de50fa9ff64ce50b812ddbcfe7f6fe5fcdd1c23c35a85f11bda5ee8cdb",
-    "zh:4a146a958ff5997dca61c016330ed0546093873cce2791cdb727ef897b3d5bdd",
-    "zh:698717e66ad6cd58842b696c46c1f4d97c0e3cdad1b872665d79f74e6bbc4310",
-    "zh:7e270b37e275d17195993c0b13221e400a67eb26850517977a0587de092a055f",
-    "zh:7f14438403ca2ebbe39561f13b78d44bad83d519e907414c2e1f1dc9c2059c0f",
-    "zh:9799606edd2079c92e181e8a0f022ac69f2e7093bb23cc9348dc9db9b76aa7da",
-    "zh:b947e1a3768650aab0d4679a5202d17464f4ad8c429a57627f9cadf5b78843fc",
-    "zh:f7fbd8827afcbab1c5da907283acde543cd0ad8513cec0eea14afb7b926b5a5a",
+    "h1:Wou3ZnO10ZvN+n1iwyuaxn3zyGMFj9KYL+9IFb0gGkw=",
+    "zh:07f5b2f4cfaa25e26a4062ac675e3e5aaf65bb21b94b8fd7f30d576398e7410f",
+    "zh:08a2154ad29ae130ea9e46948b7b332ec4b45321b4852b45ba60adcfd049f8d6",
+    "zh:35ed643c2b999021ad56b49f7d9d3a77c98d152477fe54b5c8a68f696bb1a0b7",
+    "zh:3a8dc51b4be1c04130fd76cda4280019020b276336d307e7074ad52f35d4fdda",
+    "zh:3c910c4f25e3ffd6d84f051c32161f03d1843753cd545e769757d7b42d654003",
+    "zh:5d23f316f89937cbda36207271bbe150f633298f96d4644fd02063fc6bf0c28f",
+    "zh:61fedb2915c5188c6550677a10acb955f32834bbe99ba0cafb2a118be282827b",
+    "zh:65076a6899c0781ce95064d47d587ad07f80becd1510e4c475e4554131caec09",
+    "zh:acca833c2d9985e46298323222285b370ea7cf5299b131dbdfc7c3e66fa32401",
+    "zh:c212cf8ba7fdf64e75accf7e745f76d2349b00553ebd928cc6cafbfda99d97b7",
+    "zh:cd3f5e89ac5f5cf3f8fed3aca4cc50261d537b60a3490feaddf9ba2f06e5e7aa",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/local" {
-  version     = "2.0.0"
+  version     = "2.1.0"
   constraints = "~> 2.0"
   hashes = [
-    "h1:EC6eh7avwx1rF56h3RZcxgEp/14ihi7Sk/4J3Hn4nIE=",
-    "h1:pO1ANXtOCRfecKsY9Hn4UsXoPBLv6LFiDIEiS1MZ09E=",
-    "zh:34ce8b79493ace8333d094752b579ccc907fa9392a2c1d6933a6c95d0786d3f1",
-    "zh:5c5a19c4f614a4ffb68bae0b0563f3860115cf7539b8adc21108324cfdc10092",
-    "zh:67ddb1ca2cd3e1a8f948302597ceb967f19d2eeb2d125303493667388fe6330e",
-    "zh:68e6b16f3a8e180fcba1a99754118deb2d82331b51f6cca39f04518339bfdfa6",
-    "zh:8393a12eb11598b2799d51c9b0a922a3d9fadda5a626b94a1b4914086d53120e",
-    "zh:90daea4b2010a86f2aca1e3a9590e0b3ddcab229c2bd3685fae76a832e9e836f",
-    "zh:99308edc734a0ac9149b44f8e316ca879b2670a1cae387a8ae754c180b57cdb4",
-    "zh:c76594db07a9d1a73372a073888b672df64adb455d483c2426cc220eda7e092e",
-    "zh:dc09c1fb36c6a706bdac96cce338952888c8423978426a09f5df93031aa88b84",
-    "zh:deda88134e9780319e8de91b3745520be48ead6ec38cb662694d09185c3dac70",
+    "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
+    "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
+    "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
+    "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
+    "zh:719dfd97bb9ddce99f7d741260b8ece2682b363735c764cac83303f02386075a",
+    "zh:7598bb86e0378fd97eaa04638c1a4c75f960f62f69d3662e6d80ffa5a89847fe",
+    "zh:ad0a188b52517fec9eca393f1e2c9daea362b33ae2eb38a857b6b09949a727c1",
+    "zh:c46846c8df66a13fee6eff7dc5d528a7f868ae0dcf92d79deaac73cc297ed20c",
+    "zh:dc1a20a2eec12095d04bf6da5321f535351a594a636912361db20eb2a707ccc4",
+    "zh:e57ab4771a9d999401f6badd8b018558357d3cbdf3d33cc0c4f83e818ca8e94b",
+    "zh:ebdcde208072b4b0f8d305ebf2bfdc62c926e0717599dcf8ec2fd8c5845031c3",
+    "zh:ef34c52b68933bedd0868a13ccfd59ff1c820f299760b3c02e008dc95e2ece91",
   ]
 }
 
 provider "registry.terraform.io/pagerduty/pagerduty" {
-  version     = "1.8.0"
+  version     = "1.9.4"
   constraints = "~> 1.7"
   hashes = [
-    "h1:B3LN8m9q4S8eG2VZeCvYgzzerbZ3PeiA4TCJO4w4zvs=",
-    "h1:sdaC9JkUd9bfeoYi43CCZYzRAmKXacUlPaJGgEWRm1s=",
-    "zh:132c4501f1369c908b4313b82ae14cebc6f84af54a99f93e7a8365f15b39adc0",
-    "zh:1542bcb215d46ed79152b052b430b9d8e97860a82f4812e611470417ea99ee31",
-    "zh:301136662c3efcafe1e9023732c36626ed1b52cecc922fef34608495a4d718b4",
-    "zh:4bb856747adf2cadfbda0e22804eb68b930f535ce9053221fc48954451b6d5d1",
-    "zh:65f58195d66b8858ae0ddeceffd43642be34615b146c123743f540e98ca43acf",
-    "zh:6ebb53d504a7af57cbcdffe717dc6ba1ff827513ad5da4528b3962c3cdc65ce4",
-    "zh:8070884eb16e590787c0beeca433997950f1b6d3235fea7185faba67ffd7eddc",
-    "zh:a8a98e895188d6b90716c04412a92f63958d84510b392883d448f8b8d6f80dc5",
-    "zh:c93e202fb91d246277016b2e12552c2f616f9ed4c4b12d8d8760a9890eb155af",
-    "zh:f61e2e345a7bd7e708235bb124d8fb9c9ef394939825c9c7b50d634e22e1b769",
+    "h1:gqaBQtDqXJfBqgBeNhvk4AN54tBevdsN/FcnA18nkCU=",
+    "zh:05fc35395a3218438fcb99e49f52f7a9335533e60029e5c527ad462bb565d815",
+    "zh:2f0aebb7c3c53e08b578a09456ffd53a915630715f65fd21edc2ae2e37ae24d4",
+    "zh:383de069d17b8544d37ea188195bbfbf4344ee484c69b22b672eeff147157bd8",
+    "zh:4f8fb6f78b9899b4b5ef6767ec82e9c26b5c197d57af2e14545880fa28506100",
+    "zh:5a7f307fdce85fbfbd704bf2fcafbc1f0aa63ea92b990b95355dac92e24d4b90",
+    "zh:692dc123a2f0617da5a9608180a1fabfb45659f586446516006c5cb15a9526ce",
+    "zh:6ca0d12d56848479432d8d9a2ce8ba4b24d9798872b5a0c2434bc537b08771dd",
+    "zh:7fd9840bb164986e462ed87c6d0ac0cc3b4792c4d1fcd734c016f74237c5b842",
+    "zh:bd8625fe31c27e8e8bad0756088a5a5dfe93d78880c5a478eaf28a320eb5b4f5",
+    "zh:bd9973c2c33e9fe3aff7660565b2532a00f46cfb338eba14ad0476be3577a042",
   ]
 }

--- a/terraform/environment/autoscaling.tf
+++ b/terraform/environment/autoscaling.tf
@@ -6,6 +6,10 @@ module "front_ecs_autoscaling" {
   ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn
   ecs_task_autoscaling_minimum     = local.account.autoscaling.front.minimum
   ecs_task_autoscaling_maximum     = local.account.autoscaling.front.maximum
+  tags = merge(
+    local.default_tags,
+    { component = "front" }
+  )
 }
 
 module "api_ecs_autoscaling" {
@@ -16,6 +20,10 @@ module "api_ecs_autoscaling" {
   ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn
   ecs_task_autoscaling_minimum     = local.account.autoscaling.api.minimum
   ecs_task_autoscaling_maximum     = local.account.autoscaling.api.maximum
+  tags = merge(
+    local.default_tags,
+    { component = "api" }
+  )
 }
 
 module "pdf_ecs_autoscaling" {
@@ -26,4 +34,8 @@ module "pdf_ecs_autoscaling" {
   ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn
   ecs_task_autoscaling_minimum     = local.account.autoscaling.pdf.minimum
   ecs_task_autoscaling_maximum     = local.account.autoscaling.pdf.maximum
+  tags = merge(
+    local.default_tags,
+    { component = "pdf" }
+  )
 }

--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -16,9 +16,13 @@ resource "aws_cloudwatch_metric_alarm" "front_5xx_errors" {
   ok_actions                = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
   period                    = 60
   statistic                 = "Sum"
-  tags                      = {}
-  threshold                 = 2
-  treat_missing_data        = "notBreaching"
+  tags = merge(
+    local.default_tags, {
+      component = "front"
+    }
+  )
+  threshold          = 2
+  treat_missing_data = "notBreaching"
 }
 
 
@@ -39,9 +43,13 @@ resource "aws_cloudwatch_metric_alarm" "admin_5xx_errors" {
   ok_actions                = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
   period                    = 60
   statistic                 = "Sum"
-  tags                      = {}
-  threshold                 = 2
-  treat_missing_data        = "notBreaching"
+  tags = merge(
+    local.default_tags, {
+      component = "admin"
+    }
+  )
+  threshold          = 2
+  treat_missing_data = "notBreaching"
 }
 
 resource "aws_cloudwatch_log_metric_filter" "csrf_mistmatch_filter" {
@@ -70,9 +78,13 @@ resource "aws_cloudwatch_metric_alarm" "front_csrf_mismatch_errors" {
   ok_actions                = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
   period                    = 60
   statistic                 = "Sum"
-  tags                      = {}
-  threshold                 = 2
-  treat_missing_data        = "notBreaching"
+  tags = merge(
+    local.default_tags, {
+      component = "front"
+    }
+  )
+  threshold          = 2
+  treat_missing_data = "notBreaching"
 }
 
 resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
@@ -91,7 +103,11 @@ resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
   evaluation_periods  = 1
   datapoints_to_alarm = 1
   statistic           = "Sum"
-  tags                = {}
-  threshold           = 6
-  treat_missing_data  = "notBreaching"
+  tags = merge(
+    local.default_tags, {
+      component = "pdf"
+    }
+  )
+  threshold          = 6
+  treat_missing_data = "notBreaching"
 }

--- a/terraform/environment/dynamo_db.tf
+++ b/terraform/environment/dynamo_db.tf
@@ -8,7 +8,11 @@ resource "aws_dynamodb_table" "lpa-locks" {
     type = "S"
   }
 
-  tags = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "dynamodb"
+    }
+  )
 }
 
 resource "aws_dynamodb_table" "lpa-properties" {
@@ -21,7 +25,11 @@ resource "aws_dynamodb_table" "lpa-properties" {
     type = "S"
   }
 
-  tags = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "dynamodb"
+    }
+  )
 }
 
 resource "aws_dynamodb_table" "lpa-sessions" {
@@ -39,5 +47,9 @@ resource "aws_dynamodb_table" "lpa-sessions" {
     enabled        = true
   }
 
-  tags = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "dynamodb"
+    }
+  )
 }

--- a/terraform/environment/ecs_admin.tf
+++ b/terraform/environment/ecs_admin.tf
@@ -22,7 +22,11 @@ resource "aws_ecs_service" "admin" {
   }
 
   depends_on = [aws_lb.admin, aws_iam_role.admin_task_role, aws_iam_role.execution_role]
-  tags       = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "admin"
+    }
+  )
 }
 
 //----------------------------------
@@ -31,7 +35,11 @@ resource "aws_ecs_service" "admin" {
 resource "aws_security_group" "admin_ecs_service" {
   name_prefix = "${local.environment}-admin-ecs-service"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "admin"
+    }
+  )
 }
 
 // 80 in from the ELB
@@ -66,7 +74,11 @@ resource "aws_ecs_task_definition" "admin" {
   container_definitions    = "[${local.admin_web}, ${local.admin_app}]"
   task_role_arn            = aws_iam_role.admin_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "admin"
+    }
+  )
 }
 
 //----------------
@@ -75,7 +87,11 @@ resource "aws_ecs_task_definition" "admin" {
 resource "aws_iam_role" "admin_task_role" {
   name               = "${local.environment}-admin-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "admin"
+    }
+  )
 }
 
 resource "aws_iam_role_policy" "admin_permissions_role" {

--- a/terraform/environment/ecs_api.tf
+++ b/terraform/environment/ecs_api.tf
@@ -21,7 +21,11 @@ resource "aws_ecs_service" "api" {
   service_registries {
     registry_arn = aws_service_discovery_service.api.arn
   }
-  tags = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "api"
+    }
+  )
 }
 
 //-----------------------------------------------
@@ -57,7 +61,11 @@ locals {
 resource "aws_security_group" "api_ecs_service" {
   name_prefix = "${terraform.workspace}-api-ecs-service"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "api"
+    }
+  )
 }
 
 //----------------------------------
@@ -107,7 +115,11 @@ resource "aws_ecs_task_definition" "api" {
   container_definitions    = "[${local.api_web}, ${local.api_app}]"
   task_role_arn            = aws_iam_role.api_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "api"
+    }
+  )
 }
 
 
@@ -117,7 +129,11 @@ resource "aws_ecs_task_definition" "api" {
 resource "aws_iam_role" "api_task_role" {
   name               = "${local.environment}-api-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "api"
+    }
+  )
 }
 
 resource "aws_iam_role_policy" "api_permissions_role" {

--- a/terraform/environment/ecs_api_cron.tf
+++ b/terraform/environment/ecs_api_cron.tf
@@ -17,6 +17,11 @@ data "aws_iam_policy_document" "cloudwatch_events_assume_policy" {
 resource "aws_iam_role" "cloudwatch_events_ecs_role" {
   name               = "${local.environment}-cloudwatch_events_ecs_cron"
   assume_role_policy = data.aws_iam_policy_document.cloudwatch_events_assume_policy.json
+  tags = merge(
+    local.default_tags, {
+      component = "api"
+    }
+  )
 }
 
 //---
@@ -58,11 +63,21 @@ resource "aws_iam_role_policy" "ecs_events_run_task_with_any_role" {
 resource "aws_cloudwatch_event_rule" "middle_of_the_night" {
   name                = "${local.environment}-middle-of-the-night-cron"
   schedule_expression = "cron(0 3 * * ? *)" // 3am UTC, every day.
+  tags = merge(
+    local.default_tags, {
+      component = "api"
+    }
+  )
 }
 
 resource "aws_cloudwatch_event_rule" "mid_morning" {
   name                = "${local.environment}-mid-morning-cron"
   schedule_expression = "cron(0 10 * * ? *)" // 10am UTC, every day.
+  tags = merge(
+    local.default_tags, {
+      component = "api"
+    }
+  )
 }
 
 //------------------------------------------------
@@ -77,9 +92,12 @@ resource "aws_ecs_task_definition" "api_crons" {
   container_definitions    = "[${local.api_app}]"
   task_role_arn            = aws_iam_role.api_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "api"
+    }
+  )
 }
-
 
 //------------------------------------------------
 // Account Cleanup Task

--- a/terraform/environment/ecs_cluster.tf
+++ b/terraform/environment/ecs_cluster.tf
@@ -5,6 +5,7 @@ resource "aws_ecs_cluster" "online-lpa" {
 
 data "aws_cloudwatch_log_group" "online-lpa" {
   name = "online-lpa"
+  tags = local.default_tags
 }
 
 resource "aws_iam_role" "execution_role" {

--- a/terraform/environment/ecs_front.tf
+++ b/terraform/environment/ecs_front.tf
@@ -22,7 +22,11 @@ resource "aws_ecs_service" "front" {
   }
 
   depends_on = [aws_lb.front, aws_iam_role.front_task_role, aws_iam_role.execution_role]
-  tags       = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "front"
+    }
+  )
 }
 
 //----------------------------------
@@ -31,7 +35,11 @@ resource "aws_ecs_service" "front" {
 resource "aws_security_group" "front_ecs_service" {
   name_prefix = "${local.environment}-front-ecs-service"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "front"
+    }
+  )
 }
 
 // 80 in from the ELB
@@ -66,7 +74,11 @@ resource "aws_ecs_task_definition" "front" {
   container_definitions    = "[${local.front_web}, ${local.front_app}]"
   task_role_arn            = aws_iam_role.front_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "front"
+    }
+  )
 }
 
 //----------------
@@ -75,7 +87,11 @@ resource "aws_ecs_task_definition" "front" {
 resource "aws_iam_role" "front_task_role" {
   name               = "${local.environment}-front-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "front"
+    }
+  )
 }
 
 resource "aws_iam_role_policy" "front_permissions_role" {

--- a/terraform/environment/ecs_pdf.tf
+++ b/terraform/environment/ecs_pdf.tf
@@ -16,7 +16,11 @@ resource "aws_ecs_service" "pdf" {
   }
 
   depends_on = [aws_iam_role.pdf_task_role, aws_iam_role.execution_role]
-  tags       = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "pdf"
+    }
+  )
 }
 
 //----------------------------------
@@ -25,7 +29,11 @@ resource "aws_ecs_service" "pdf" {
 resource "aws_security_group" "pdf_ecs_service" {
   name_prefix = "${local.environment}-pdf-ecs-service"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "pdf"
+    }
+  )
 }
 
 //----------------------------------
@@ -51,7 +59,11 @@ resource "aws_ecs_task_definition" "pdf" {
   container_definitions    = "[${local.pdf_app}]"
   task_role_arn            = aws_iam_role.pdf_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "pdf"
+    }
+  )
 }
 
 //----------------
@@ -60,7 +72,11 @@ resource "aws_ecs_task_definition" "pdf" {
 resource "aws_iam_role" "pdf_task_role" {
   name               = "${local.environment}-pdf-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "pdf"
+    }
+  )
 }
 
 resource "aws_iam_role_policy" "pdf_permissions_role" {

--- a/terraform/environment/ecs_seeding.tf
+++ b/terraform/environment/ecs_seeding.tf
@@ -4,7 +4,11 @@
 resource "aws_security_group" "seeding_ecs_service" {
   name_prefix = "${terraform.workspace}-seeding-ecs-service"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "seeding"
+    }
+  )
 }
 
 //----------------------------------
@@ -32,7 +36,11 @@ resource "aws_ecs_task_definition" "seeding" {
   container_definitions    = "[${local.seeding_app}]"
   task_role_arn            = aws_iam_role.seeding_task_role[count.index].arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "seeding"
+    }
+  )
 }
 
 
@@ -43,7 +51,11 @@ resource "aws_iam_role" "seeding_task_role" {
   count              = local.environment == "production" ? 0 : 1
   name               = "${local.environment}-seeding-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "seeding"
+    }
+  )
 }
 
 data "aws_ecr_repository" "lpa_seeding_app" {

--- a/terraform/environment/load_balancer_admin.tf
+++ b/terraform/environment/load_balancer_admin.tf
@@ -73,7 +73,7 @@ resource "aws_security_group_rule" "admin_loadbalancer_ingress" {
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = module.whitelist.moj_sites
+  cidr_blocks       = module.allowed_ip_list.moj_sites
   security_group_id = aws_security_group.admin_loadbalancer.id
 }
 resource "aws_security_group_rule" "admin_loadbalancer_ingress_production" {

--- a/terraform/environment/load_balancer_admin.tf
+++ b/terraform/environment/load_balancer_admin.tf
@@ -14,7 +14,11 @@ resource "aws_lb_target_group" "admin" {
     matcher             = 200
   }
   depends_on = [aws_lb.admin]
-  tags       = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "admin"
+    }
+  )
 }
 
 resource "aws_lb" "admin" {
@@ -22,7 +26,11 @@ resource "aws_lb" "admin" {
   internal           = false
   load_balancer_type = "application"
   subnets            = data.aws_subnet_ids.public.ids
-  tags               = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "admin"
+    }
+  )
 
   security_groups = [
     aws_security_group.admin_loadbalancer.id,
@@ -53,7 +61,11 @@ resource "aws_security_group" "admin_loadbalancer" {
   name        = "${local.environment}-admin-loadbalancer"
   description = "Allow inbound traffic"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "admin"
+    }
+  )
 }
 
 resource "aws_security_group_rule" "admin_loadbalancer_ingress" {

--- a/terraform/environment/load_balancer_front.tf
+++ b/terraform/environment/load_balancer_front.tf
@@ -73,7 +73,7 @@ resource "aws_security_group_rule" "front_loadbalancer_ingress" {
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = module.whitelist.moj_sites
+  cidr_blocks       = module.allowed_ip_list.moj_sites
   security_group_id = aws_security_group.front_loadbalancer.id
 }
 resource "aws_security_group_rule" "front_loadbalancer_ingress_production" {

--- a/terraform/environment/load_balancer_front.tf
+++ b/terraform/environment/load_balancer_front.tf
@@ -14,7 +14,11 @@ resource "aws_lb_target_group" "front" {
     matcher             = 200
   }
   depends_on = [aws_lb.front]
-  tags       = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "front"
+    }
+  )
 }
 
 resource "aws_lb" "front" {
@@ -22,7 +26,11 @@ resource "aws_lb" "front" {
   internal           = false
   load_balancer_type = "application"
   subnets            = data.aws_subnet_ids.public.ids
-  tags               = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "front"
+    }
+  )
 
   security_groups = [
     aws_security_group.front_loadbalancer.id,
@@ -53,7 +61,11 @@ resource "aws_security_group" "front_loadbalancer" {
   name        = "${local.environment}-front-loadbalancer"
   description = "Allow inbound traffic"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags = merge(
+    local.default_tags, {
+      component = "front"
+    }
+  )
 }
 
 resource "aws_security_group_rule" "front_loadbalancer_ingress" {

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -28,7 +28,7 @@ locals {
   optional_tags = {
     environment-name       = local.environment
     infrastructure-support = "OPG LPA Product Team: opgteam+online-lpa@digital.justice.gov.uk"
-    runbook                = "https://github.com/ministryofjustice/opg-webops-runbooks/tree/master/LPA"
+    runbook                = "https://github.com/ministryofjustice/opg-lpa/tree/master/docs/runbooks"
     source-code            = "https://github.com/ministryofjustice/opg-lpa"
   }
 

--- a/terraform/environment/modules/ecs_autoscaling/main.tf
+++ b/terraform/environment/modules/ecs_autoscaling/main.tf
@@ -54,6 +54,7 @@ resource "aws_cloudwatch_metric_alarm" "max_scaling_reached" {
   threshold                 = var.ecs_task_autoscaling_maximum
   alarm_description         = "This metric monitors ecs running task count for the ${var.environment} ${var.aws_ecs_service_name} service"
   insufficient_data_actions = []
+  tags                      = var.tags
   dimensions = {
     ServiceName = var.aws_ecs_service_name
     ClusterName = "${var.environment}-online-lpa"

--- a/terraform/environment/modules/ecs_autoscaling/variables.tf
+++ b/terraform/environment/modules/ecs_autoscaling/variables.tf
@@ -64,3 +64,8 @@ variable "cpu_track_metric_scale_out_cooldown" {
   type        = number
   default     = 60
 }
+
+variable "tags" {
+  description = "the AWS tags to apply to the resources in ths module."
+  type        = map(any)
+}

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -4,28 +4,33 @@ data "aws_kms_key" "rds" {
 }
 
 resource "aws_db_instance" "api" {
-  count                       = local.account.always_on ? 1 : 0
-  identifier                  = lower("api-${local.environment}")
-  name                        = "api2"
-  allocated_storage           = 10
-  storage_type                = "gp2"
-  storage_encrypted           = true
-  skip_final_snapshot         = local.account.skip_final_snapshot
-  engine                      = "postgres"
-  engine_version              = local.account.psql_engine_version
-  instance_class              = "db.m3.medium"
-  port                        = "5432"
-  kms_key_id                  = data.aws_kms_key.rds.arn
-  username                    = data.aws_secretsmanager_secret_version.api_rds_username.secret_string
-  password                    = data.aws_secretsmanager_secret_version.api_rds_password.secret_string
-  parameter_group_name        = aws_db_parameter_group.postgres-db-params.name
-  vpc_security_group_ids      = [aws_security_group.rds-api.id]
-  auto_minor_version_upgrade  = false
-  maintenance_window          = "sun:01:00-sun:01:30"
-  multi_az                    = true
-  backup_retention_period     = local.account.backup_retention_period
-  deletion_protection         = local.account.deletion_protection
-  tags                        = local.default_tags
+  count                      = local.account.always_on ? 1 : 0
+  identifier                 = lower("api-${local.environment}")
+  name                       = "api2"
+  allocated_storage          = 10
+  storage_type               = "gp2"
+  storage_encrypted          = true
+  skip_final_snapshot        = local.account.skip_final_snapshot
+  engine                     = "postgres"
+  engine_version             = local.account.psql_engine_version
+  instance_class             = "db.m3.medium"
+  port                       = "5432"
+  kms_key_id                 = data.aws_kms_key.rds.arn
+  username                   = data.aws_secretsmanager_secret_version.api_rds_username.secret_string
+  password                   = data.aws_secretsmanager_secret_version.api_rds_password.secret_string
+  parameter_group_name       = aws_db_parameter_group.postgres-db-params.name
+  vpc_security_group_ids     = [aws_security_group.rds-api.id]
+  auto_minor_version_upgrade = false
+  maintenance_window         = "sun:01:00-sun:01:30"
+  multi_az                   = true
+  backup_retention_period    = local.account.backup_retention_period
+  deletion_protection        = local.account.deletion_protection
+  tags = merge(
+    local.default_tags,
+    {
+      component = "db"
+    }
+  )
   allow_major_version_upgrade = true
 }
 
@@ -49,7 +54,12 @@ module "api_aurora" {
   replication_source_identifier = local.account.always_on ? aws_db_instance.api[0].arn : ""
   skip_final_snapshot           = !local.account.deletion_protection
   vpc_security_group_ids        = [aws_security_group.rds-api.id]
-  tags                          = local.default_tags
+  tags = merge(
+    local.default_tags,
+    {
+      component = "db"
+    }
+  )
 }
 
 resource "aws_db_parameter_group" "postgres-db-params" {
@@ -80,7 +90,12 @@ resource "aws_security_group" "rds-client" {
   description            = "rds access for ${local.environment}"
   vpc_id                 = data.aws_vpc.default.id
   revoke_rules_on_delete = true
-  tags                   = local.default_tags
+  tags = merge(
+    local.default_tags,
+    {
+      component = "db"
+    }
+  )
 }
 
 resource "aws_security_group" "rds-api" {
@@ -88,8 +103,12 @@ resource "aws_security_group" "rds-api" {
   description            = "api rds access"
   vpc_id                 = data.aws_vpc.default.id
   revoke_rules_on_delete = true
-  tags                   = local.default_tags
-
+  tags = merge(
+    local.default_tags,
+    {
+      component = "db"
+    }
+  )
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/resource_group.tf
+++ b/terraform/environment/resource_group.tf
@@ -1,6 +1,6 @@
 resource "aws_resourcegroups_group" "environment" {
   name = local.environment
-
+  tags = local.default_tags
   resource_query {
     query = local.environment_resource_group_query
   }

--- a/terraform/environment/sqs.tf
+++ b/terraform/environment/sqs.tf
@@ -7,8 +7,12 @@ resource "aws_sqs_queue" "pdf_fifo_queue" {
   kms_master_key_id                 = "alias/aws/sqs"
   kms_data_key_reuse_period_seconds = "300"
   max_message_size                  = "262144"
-  tags                              = local.default_tags
-  depends_on                        = [aws_ecs_service.api, aws_iam_role.api_task_role, aws_iam_role.pdf_task_role]
+  tags = merge(
+    local.default_tags, {
+      component = "pdf"
+    }
+  )
+  depends_on = [aws_ecs_service.api, aws_iam_role.api_task_role, aws_iam_role.pdf_task_role]
 }
 
 resource "aws_sqs_queue_policy" "queue_policy" {

--- a/terraform/environment/vpc_data.sources.tf
+++ b/terraform/environment/vpc_data.sources.tf
@@ -18,7 +18,7 @@ data "aws_subnet_ids" "public" {
   }
 }
 
-module "whitelist" {
+module "allowed_ip_list" {
   source = "git@github.com:ministryofjustice/terraform-aws-moj-ip-whitelist.git"
 }
 


### PR DESCRIPTION
## Purpose

- To improve tagging on our AWS resources, fill any missing gaps.

Fixes LPAL-326

## Approach
- Tag all the "taggable" AWS resources in infra using `local.default_tags`
- Where possible, assign a component tag, to identify the group of items that go with a specific component of the service.
- Done at Account and Environment level where needed.
- Update Runbook tag with correct repo details.
- Rename outdated term in infra code.
- Also added WoW entry to PR template for tagging resources as a reminder.

## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] The product team have tested these changes
