### PR TITLE
LPAL-310 - Review/Change error messages so they are more meaningful & clear.

### DIFF
--- a/service-front/module/Application/view/application/authenticated/lpa/correspondent/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/correspondent/index.twig
@@ -13,7 +13,7 @@
         'Value is required and can\'t be empty': 'A language must be selected'
     },
     'correspondence' : {
-        'at-least-one-option-needs-to-be-selected' : 'Select at least one option'
+        'at-least-one-option-needs-to-be-selected' : 'Select how the correspondent would like to be contacted'
     }
 }) %}
 

--- a/service-front/module/Application/view/application/authenticated/lpa/fee-reduction/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/fee-reduction/index.twig
@@ -10,7 +10,7 @@
 {# Error messages #}
 {% set form = formErrorTextExchange(form, {
         'reductionOptions': {
-            'Value is required and can\'t be empty' : 'Choose one of the options'
+            'Value is required and can\'t be empty' : 'Select if the donor does or does not want to apply for a fee reduction'
         }
    })
 %}

--- a/service-front/module/Application/view/application/authenticated/lpa/life-sustaining/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/life-sustaining/index.twig
@@ -9,7 +9,7 @@
 {# Error messages #}
 {% set form = formErrorTextExchange(form, {
     'canSustainLife' : {
-        'Value is required and can\'t be empty' : 'Choose an option'
+        'Value is required and can\'t be empty' : 'Select if the donor gives or does not give their attorneys authority to consent to lift-sustaining treatment'
     }
 }) %}
 

--- a/service-front/module/Application/view/application/authenticated/lpa/who-are-you/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/who-are-you/index.twig
@@ -10,7 +10,7 @@
 {% if form %}
     {% set form = formErrorTextExchange(form, {
             'who': {
-                'cannot-be-blank' : 'Choose one of the options',
+                'cannot-be-blank' : 'Select who was using the service',
             }
        })
     %}


### PR DESCRIPTION
## Purpose

DAC_ambiguous_error_handling_issue2 (AA), p.63 DAC report
Error messages should clearly reflect the issue that needs to be resolved, e.g. after failing to select an option, the page didn't make it clear that the user had failed to select an option.

Fixes LPAL-310

## Approach

Updates error messages so they are more specific.

## Learning

https://design-system.service.gov.uk/components/error-message/

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] The product team have tested these changes
