### PR TITLE
LPAL-77-fix-alarm-settings

### DIFF
--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -32,11 +32,11 @@ resource "aws_cloudwatch_metric_alarm" "account_breakglass_login_alarm" {
   actions_enabled     = true
   alarm_name          = "${local.account_name} breakglass console login check"
   alarm_actions       = [aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn]
+  ok_actions          = [aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn]
   alarm_description   = "number of breakglass attempts"
   namespace           = "online-lpa/Cloudtrail"
   metric_name         = "EventCount"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  ok_actions          = [aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn]
   period              = 60
   evaluation_periods  = 1
   datapoints_to_alarm = 1

--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -16,6 +16,7 @@ data "aws_cloudwatch_log_group" "cloudtrail" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "breakglass_metric" {
+  count          = local.account.is_production ? 1 : 0
   name           = "BreakGlassConsoleLogin"
   pattern        = "{ ($.eventType = \"AwsConsoleSignIn\") && ($.userIdentity.arn = \"arn:aws:sts::${local.account_id}:assumed-role/breakglass/*\") }"
   log_group_name = data.aws_cloudwatch_log_group.cloudtrail.name
@@ -28,6 +29,7 @@ resource "aws_cloudwatch_log_metric_filter" "breakglass_metric" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "account_breakglass_login_alarm" {
+  count               = local.account.is_production ? 1 : 0
   actions_enabled     = true
   alarm_name          = "${local.account_name} breakglass console login check"
   alarm_actions       = [aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn]

--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -27,7 +27,6 @@ resource "aws_cloudwatch_log_metric_filter" "breakglass_metric" {
   }
 }
 
-
 resource "aws_cloudwatch_metric_alarm" "account_breakglass_login_alarm" {
   actions_enabled     = true
   alarm_name          = "${local.account_name} breakglass console login check"

--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -17,7 +17,7 @@ data "aws_cloudwatch_log_group" "cloudtrail" {
 
 resource "aws_cloudwatch_log_metric_filter" "breakglass_metric" {
   name           = "BreakGlassConsoleLogin"
-  pattern        = "{ $.userIdentity.arn = \"arn:aws:sts::${local.account_id}:assumed-role/breakglass/*\"  && $.eventType = \"AwsConsoleSignIn\" }"
+  pattern        = "{ ($.eventType = \"AwsConsoleSignIn\") && ($.userIdentity.arn = \"arn:aws:sts::${local.account_id}:assumed-role/breakglass/*\") }"
   log_group_name = data.aws_cloudwatch_log_group.cloudtrail.name
 
   metric_transformation {
@@ -34,8 +34,8 @@ resource "aws_cloudwatch_metric_alarm" "account_breakglass_login_alarm" {
   alarm_actions       = [aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn]
   alarm_description   = "number of breakglass attempts"
   namespace           = "online-lpa/Cloudtrail"
-  metric_name         = "BreakGlassConsoleLogin"
-  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "EventCount"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
   ok_actions          = [aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn]
   period              = 60
   evaluation_periods  = 1

--- a/terraform/account/pagerduty.tf
+++ b/terraform/account/pagerduty.tf
@@ -7,14 +7,12 @@ data "pagerduty_vendor" "cloudwatch" {
 }
 
 resource "pagerduty_service_integration" "cloudwatch_integration" {
-  count   = local.account_name == "development" ? 1 : 0
   name    = "${data.pagerduty_vendor.cloudwatch.name} ${local.account_name} Account Ops"
   service = data.pagerduty_service.pagerduty.id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 
 resource "aws_sns_topic_subscription" "cloudwatch_breakglass_alerts_sns_subscription" {
-  count                  = local.account_name == "development" ? 1 : 0
   topic_arn              = aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn
   protocol               = "https"
   endpoint_auto_confirms = true

--- a/terraform/account/pagerduty.tf
+++ b/terraform/account/pagerduty.tf
@@ -16,5 +16,5 @@ resource "aws_sns_topic_subscription" "cloudwatch_breakglass_alerts_sns_subscrip
   topic_arn              = aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn
   protocol               = "https"
   endpoint_auto_confirms = true
-  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration[0].integration_key}/enqueue"
+  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration.integration_key}/enqueue"
 }

--- a/terraform/account/sns.tf
+++ b/terraform/account/sns.tf
@@ -1,3 +1,4 @@
 resource "aws_sns_topic" "cloudwatch_to_slack_breakglass_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-Breakglass-alert"
+  tags = merge(local.default_tags, local.shared_component_tag)
 }


### PR DESCRIPTION
## Purpose

AWS ACCOUNT LEVEL CHANGE

to fix issues with the cloudwatch alarm for breakglass alerts.
to ensure we only alert in production for this.

Fixes LPAL-77

## Approach

- Fix metric name and filter
- Remove dev only restriction to pagerduty ops service
- Apply prod only restriction to the alarm and metric
- formatting 

## Learning

- cloudwatch metric filters: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/MonitoringLogData.html

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] The product team have tested these changes
