### PR TITLE
LPAL-77 rework some cloudwatch alarms in environment.

### DIFF
--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -46,7 +46,7 @@ resource "aws_cloudwatch_metric_alarm" "admin_5xx_errors" {
 
 resource "aws_cloudwatch_log_metric_filter" "csrf_mistmatch_filter" {
   name           = "CSRFValuesMismatch"
-  pattern        = "{($.priorityName = \"ERR\") && ($.message = \"Mismatched CSRF provided\")}"
+  pattern        = "{($.priorityName = \"ERR\") && ($.message = \"Mismatched CSRF provided*\")}"
   log_group_name = data.aws_cloudwatch_log_group.online-lpa.name
 
   metric_transformation {
@@ -58,16 +58,16 @@ resource "aws_cloudwatch_log_metric_filter" "csrf_mistmatch_filter" {
 
 resource "aws_cloudwatch_metric_alarm" "front_csrf_mismatch_errors" {
   actions_enabled           = true
-  alarm_actions             = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  alarm_actions             = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
   alarm_description         = "CSRF Errors returned to front users for ${local.environment}"
   alarm_name                = "${local.environment} public front CSRF errors"
-  comparison_operator       = "GreaterThanThreshold"
-  datapoints_to_alarm       = 2
-  evaluation_periods        = 2
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  datapoints_to_alarm       = 1
+  evaluation_periods        = 1
   insufficient_data_actions = []
-  metric_name               = "${data.aws_cloudwatch_log_group.online-lpa.name}:csrf_mistmatch_filter"
+  metric_name               = "EventCount"
   namespace                 = "online-lpa/Cloudwatch"
-  ok_actions                = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  ok_actions                = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
   period                    = 60
   statistic                 = "Sum"
   tags                      = merge(local.default_tags, local.front_component_tag)
@@ -78,7 +78,7 @@ resource "aws_cloudwatch_metric_alarm" "front_csrf_mismatch_errors" {
 resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
   actions_enabled     = true
   alarm_name          = "${local.environment} pdf messages awaiting processing"
-  alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
   alarm_description   = "number of pdf requests in queue"
   namespace           = "AWS/SQS"
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -86,7 +86,7 @@ resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
   dimensions = {
     QueueName = aws_sqs_queue.pdf_fifo_queue.name
   }
-  ok_actions          = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  ok_actions          = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
   period              = 60
   evaluation_periods  = 1
   datapoints_to_alarm = 1

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -6,17 +6,18 @@ locals {
     username = local.account.aurora_enabled ? module.api_aurora[0].master_username : aws_db_instance.api[0].username
   }
 
-  opg_project               = "lpa"
-  account_name              = lookup(var.account_mapping, terraform.workspace, "development")
-  account                   = var.accounts[local.account_name]
-  environment               = terraform.workspace
-  cert_prefix_public_facing = local.environment == "production" ? "www." : "*."
-  cert_prefix_internal      = local.account_name == "production" ? "" : "*."
-  dns_namespace_env         = local.environment == "production" ? "" : "${local.environment}."
-  dns_namespace_env_public  = local.environment == "production" ? "www." : "${local.environment}."
-  track_from_date           = "2019-04-01"
-  front_dns                 = "front.lpa"
-  admin_dns                 = "admin.lpa"
+  opg_project                 = "lpa"
+  account_name                = lookup(var.account_mapping, terraform.workspace, "development")
+  account                     = var.accounts[local.account_name]
+  environment                 = terraform.workspace
+  cert_prefix_public_facing   = local.environment == "production" ? "www." : "*."
+  cert_prefix_internal        = local.account_name == "production" ? "" : "*."
+  dns_namespace_env           = local.environment == "production" ? "" : "${local.environment}."
+  dns_namespace_env_public    = local.environment == "production" ? "www." : "${local.environment}."
+  track_from_date             = "2019-04-01"
+  front_dns                   = "front.lpa"
+  admin_dns                   = "admin.lpa"
+  pager_duty_ops_service_name = "Make a Lasting Power of Attorney Ops Monitoring"
 
   mandatory_moj_tags = {
     business-unit = "OPG"

--- a/terraform/environment/pagerduty.tf
+++ b/terraform/environment/pagerduty.tf
@@ -21,19 +21,3 @@ resource "pagerduty_service_integration" "cloudwatch_integration_ops" {
   service = data.pagerduty_service.pagerduty_ops.id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
-
-
-resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription" {
-  topic_arn              = aws_sns_topic.cloudwatch_to_pagerduty.arn
-  protocol               = "https"
-  endpoint_auto_confirms = true
-  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration.integration_key}/enqueue"
-}
-
-
-resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription_ops" {
-  topic_arn              = aws_sns_topic.cloudwatch_to_pagerduty_ops.arn
-  protocol               = "https"
-  endpoint_auto_confirms = true
-  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration_ops.integration_key}/enqueue"
-}

--- a/terraform/environment/pagerduty.tf
+++ b/terraform/environment/pagerduty.tf
@@ -2,6 +2,10 @@ data "pagerduty_service" "pagerduty" {
   name = local.account.pagerduty_service_name
 }
 
+data "pagerduty_service" "pagerduty_ops" {
+  name = local.pager_duty_ops_service_name
+}
+
 data "pagerduty_vendor" "cloudwatch" {
   name = "Cloudwatch"
 }
@@ -12,8 +16,19 @@ resource "pagerduty_service_integration" "cloudwatch_integration" {
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 
+resource "pagerduty_service_integration" "cloudwatch_integration_ops" {
+  name    = "${data.pagerduty_vendor.cloudwatch.name} ${local.environment} Environment Ops"
+  service = data.pagerduty_service.pagerduty_ops.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}
+
 resource "aws_sns_topic" "cloudwatch_to_pagerduty" {
   name = "CloudWatch-to-PagerDuty-${local.environment}"
+}
+
+
+resource "aws_sns_topic" "cloudwatch_to_pagerduty_ops" {
+  name = "CloudWatch-to-PagerDuty-${local.environment}-Ops"
 }
 
 resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription" {
@@ -21,4 +36,12 @@ resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription" {
   protocol               = "https"
   endpoint_auto_confirms = true
   endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration.integration_key}/enqueue"
+}
+
+
+resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription_ops" {
+  topic_arn              = aws_sns_topic.cloudwatch_to_pagerduty_ops.arn
+  protocol               = "https"
+  endpoint_auto_confirms = true
+  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration_ops.integration_key}/enqueue"
 }

--- a/terraform/environment/pagerduty.tf
+++ b/terraform/environment/pagerduty.tf
@@ -22,14 +22,6 @@ resource "pagerduty_service_integration" "cloudwatch_integration_ops" {
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 
-resource "aws_sns_topic" "cloudwatch_to_pagerduty" {
-  name = "CloudWatch-to-PagerDuty-${local.environment}"
-}
-
-
-resource "aws_sns_topic" "cloudwatch_to_pagerduty_ops" {
-  name = "CloudWatch-to-PagerDuty-${local.environment}-Ops"
-}
 
 resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription" {
   topic_arn              = aws_sns_topic.cloudwatch_to_pagerduty.arn

--- a/terraform/environment/sns.tf
+++ b/terraform/environment/sns.tf
@@ -1,0 +1,10 @@
+resource "aws_sns_topic" "cloudwatch_to_pagerduty" {
+  name = "CloudWatch-to-PagerDuty-${local.environment}"
+  tags = merge(local.default_tags, local.shared_component_tag)
+}
+
+
+resource "aws_sns_topic" "cloudwatch_to_pagerduty_ops" {
+  name = "CloudWatch-to-PagerDuty-${local.environment}-Ops"
+  tags = merge(local.default_tags, local.shared_component_tag)
+}

--- a/terraform/environment/sns.tf
+++ b/terraform/environment/sns.tf
@@ -3,8 +3,21 @@ resource "aws_sns_topic" "cloudwatch_to_pagerduty" {
   tags = merge(local.default_tags, local.shared_component_tag)
 }
 
-
 resource "aws_sns_topic" "cloudwatch_to_pagerduty_ops" {
   name = "CloudWatch-to-PagerDuty-${local.environment}-Ops"
   tags = merge(local.default_tags, local.shared_component_tag)
+}
+
+resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription" {
+  topic_arn              = aws_sns_topic.cloudwatch_to_pagerduty.arn
+  protocol               = "https"
+  endpoint_auto_confirms = true
+  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration.integration_key}/enqueue"
+}
+
+resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription_ops" {
+  topic_arn              = aws_sns_topic.cloudwatch_to_pagerduty_ops.arn
+  protocol               = "https"
+  endpoint_auto_confirms = true
+  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration_ops.integration_key}/enqueue"
 }


### PR DESCRIPTION
## Purpose

- To reassign some of the cloudwatch alarms to new Ops based pagerduty.
- To fix and tweak existing cloudwatch alarms.

Fixes LPAL-77

## Approach
- change the sns topic for relevant alarms
- add integration at environment level for Ops pagerduty.
- fix faulty CSRF alarm and reduce threshold / sampling
- refactor to place SNS in it's own file

## Learning
- N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] The product team have tested these changes
