### PR TITLE
Lpal 314 dev scale down ooh

### DIFF
--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -44,7 +44,7 @@ resource "aws_cloudwatch_metric_alarm" "admin_5xx_errors" {
   treat_missing_data        = "notBreaching"
 }
 
-resource "aws_cloudwatch_log_metric_filter" "csrf_mistmatch_filter" {
+/* resource "aws_cloudwatch_log_metric_filter" "csrf_mistmatch_filter" {
   name           = "CSRFValuesMismatch"
   pattern        = "{($.priorityName = \"ERR\") && ($.message = \"Mismatched CSRF provided*\")}"
   log_group_name = data.aws_cloudwatch_log_group.online-lpa.name
@@ -54,7 +54,7 @@ resource "aws_cloudwatch_log_metric_filter" "csrf_mistmatch_filter" {
     namespace = "online-lpa/Cloudwatch"
     value     = "1"
   }
-}
+} */
 
 # disable as not required right now.
 /*resource "aws_cloudwatch_metric_alarm" "front_csrf_mismatch_errors" {

--- a/terraform/environment/ecs_hibernation.tf
+++ b/terraform/environment/ecs_hibernation.tf
@@ -1,0 +1,26 @@
+module "dev_weekdays" {
+  count            = local.account_name == "development" ? 1 : 0
+  source           = "./modules/ecs_scheduled_scaling"
+  name             = "daytime"
+  ecs_cluster_name = aws_ecs_cluster.online-lpa.name
+  scale_down_time  = "cron(00 19 ? * MON-FRI *)"
+  scale_up_time    = "cron(30 06 ? * MON-FRI *)"
+  service_config = {
+    tostring(aws_ecs_service.admin.name) = {
+      scale_down_to = 0
+      scale_up_to   = local.account.autoscaling.admin.maximum
+    }
+    tostring(aws_ecs_service.api.name) = {
+      scale_down_to = 0
+      scale_up_to   = local.account.autoscaling.api.maximum
+    }
+    tostring(aws_ecs_service.front.name) = {
+      scale_down_to = 0
+      scale_up_to   = local.account.autoscaling.front.maximum
+    }
+    tostring(aws_ecs_service.pdf.name) = {
+      scale_down_to = 0
+      scale_up_to   = local.account.autoscaling.pdf.maximum
+    }
+  }
+}

--- a/terraform/environment/modules/ecs_scheduled_scaling/main.tf
+++ b/terraform/environment/modules/ecs_scheduled_scaling/main.tf
@@ -1,0 +1,42 @@
+data "aws_iam_role" "ecs_autoscaling_service_role" {
+  name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
+}
+
+
+resource "aws_appautoscaling_target" "ecs_service_scheduled" {
+  for_each           = var.service_config
+  min_capacity       = 1
+  max_capacity       = each.value.scale_up_to
+  resource_id        = "service/${var.ecs_cluster_name}/${each.key}"
+  role_arn           = data.aws_iam_role.ecs_autoscaling_service_role.arn
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_scheduled_action" "trigger_scale_up" {
+  for_each           = var.service_config
+  name               = "${var.name}-ecs-scale-up-${each.key}-${terraform.workspace}"
+  service_namespace  = aws_appautoscaling_target.ecs_service_scheduled[each.key].service_namespace
+  resource_id        = aws_appautoscaling_target.ecs_service_scheduled[each.key].resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_service_scheduled[each.key].scalable_dimension
+  schedule           = var.scale_up_time
+
+  scalable_target_action {
+    min_capacity = 1
+    max_capacity = each.value.scale_up_to
+  }
+}
+
+resource "aws_appautoscaling_scheduled_action" "trigger_scale_down" {
+  for_each           = var.service_config
+  name               = "${var.name}-ecs-scale-down-${each.key}-${terraform.workspace}"
+  service_namespace  = aws_appautoscaling_target.ecs_service_scheduled[each.key].service_namespace
+  resource_id        = aws_appautoscaling_target.ecs_service_scheduled[each.key].resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_service_scheduled[each.key].scalable_dimension
+  schedule           = var.scale_down_time
+
+  scalable_target_action {
+    min_capacity = each.value.scale_down_to
+    max_capacity = each.value.scale_down_to
+  }
+}

--- a/terraform/environment/modules/ecs_scheduled_scaling/variables.tf
+++ b/terraform/environment/modules/ecs_scheduled_scaling/variables.tf
@@ -1,0 +1,27 @@
+variable "ecs_cluster_name" {
+  description = "Name of the ECS Cluster"
+  type        = string
+}
+
+variable "name" {
+  description = "Schedule name if running multiple schedules"
+  type        = string
+  default     = "hibernation"
+}
+
+variable "scale_down_time" {
+  description = "Cron formatted value for scale down trigger"
+}
+
+variable "scale_up_time" {
+  description = "Cron formatted value for scale up trigger"
+}
+
+variable "service_config" {
+  description = "Map of services and task scale down to and up to when regually scaled."
+  type = map(
+    object({
+      scale_down_to = number
+      scale_up_to   = number
+  }))
+}

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -34,7 +34,7 @@ module "api_aurora" {
   count                         = local.account.aurora_enabled ? 1 : 0
   aurora_serverless             = local.account.aurora_serverless
   account_id                    = data.aws_caller_identity.current.account_id
-  apply_immediately             = ! local.account.deletion_protection
+  apply_immediately             = !local.account.deletion_protection
   cluster_identifier            = "api2"
   db_subnet_group_name          = "data-persistence-subnet-default"
   deletion_protection           = local.account.deletion_protection
@@ -47,7 +47,7 @@ module "api_aurora" {
   instance_class                = "db.t3.medium"
   kms_key_id                    = data.aws_kms_key.rds.arn
   replication_source_identifier = local.account.always_on ? aws_db_instance.api[0].arn : ""
-  skip_final_snapshot           = ! local.account.deletion_protection
+  skip_final_snapshot           = !local.account.deletion_protection
   vpc_security_group_ids        = [aws_security_group.rds-api.id]
   tags                          = merge(local.default_tags, local.db_component_tag)
 }

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -34,7 +34,7 @@ module "api_aurora" {
   count                         = local.account.aurora_enabled ? 1 : 0
   aurora_serverless             = local.account.aurora_serverless
   account_id                    = data.aws_caller_identity.current.account_id
-  apply_immediately             = !local.account.deletion_protection
+  apply_immediately             = ! local.account.deletion_protection
   cluster_identifier            = "api2"
   db_subnet_group_name          = "data-persistence-subnet-default"
   deletion_protection           = local.account.deletion_protection
@@ -47,7 +47,7 @@ module "api_aurora" {
   instance_class                = "db.t3.medium"
   kms_key_id                    = data.aws_kms_key.rds.arn
   replication_source_identifier = local.account.always_on ? aws_db_instance.api[0].arn : ""
-  skip_final_snapshot           = !local.account.deletion_protection
+  skip_final_snapshot           = ! local.account.deletion_protection
   vpc_security_group_ids        = [aws_security_group.rds-api.id]
   tags                          = merge(local.default_tags, local.db_component_tag)
 }


### PR DESCRIPTION
## Purpose

to scale down our dev instances outside peak hours, and at weekends

Fixes LPAL-314

## Approach

- add module to do schedule scaling
- configure schedule and min maxes as needed. only dev has this.

## Learning
## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
