### PR TITLE
Lpal 125 reconfigure application logs + minor additional tagging and cleanup.

### DIFF
--- a/scripts/pipeline/start_seeding_task/ecs_start_seeding_task.py
+++ b/scripts/pipeline/start_seeding_task/ecs_start_seeding_task.py
@@ -163,23 +163,23 @@ class ECSMonitor:
         # retrieve logstreeam for the seeding task started
         # formats and prints simple log output
         log_events = self.aws_logs_client.get_log_events(
-            logGroupName='online-lpa',
+            logGroupName=f"{self.environment}_application_logs",
             logStreamName=self.logStreamName,
             nextToken=self.nextForwardToken,
             startFromHead=False
         )
         for event in log_events['events']:
-            print('timestamp: {0}: message: {1}'.format(
-                event['timestamp'], event['message']))
+            print(f"timestamp: {event['timestamp']}: message: {event['message']}")
         self.nextForwardToken = log_events['nextForwardToken']
 
     def print_task_logs(self):
         # lifecycle for getting log streams
         # get logs while task is running
         # after task finishes, print remaining logs
-        self.logStreamName = '{}.seeding.online-lpa/app/{}'.format(self.environment,
-                                                                   self.seeding_task.rsplit('/', 1)[-1])
-        print("Streaming logs for logstream: ".format(self.logStreamName))
+        seeding_task_split = self.seeding_task.rsplit('/', 1)[-1]
+        self.logStreamName = f"{self.environment}.seeding.online-lpa/app/{seeding_task_split}"
+
+        print(f"Streaming logs for logstream: {self.logStreamName}")
 
         self.nextForwardToken = 'f/0'
 

--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -44,38 +44,6 @@ resource "aws_cloudwatch_metric_alarm" "admin_5xx_errors" {
   treat_missing_data        = "notBreaching"
 }
 
-/* resource "aws_cloudwatch_log_metric_filter" "csrf_mistmatch_filter" {
-  name           = "CSRFValuesMismatch"
-  pattern        = "{($.priorityName = \"ERR\") && ($.message = \"Mismatched CSRF provided*\")}"
-  log_group_name = data.aws_cloudwatch_log_group.online-lpa.name
-
-  metric_transformation {
-    name      = "EventCount"
-    namespace = "online-lpa/Cloudwatch"
-    value     = "1"
-  }
-} */
-
-# disable as not required right now.
-/*resource "aws_cloudwatch_metric_alarm" "front_csrf_mismatch_errors" {
-  actions_enabled           = true
-  alarm_actions             = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
-  alarm_description         = "CSRF Errors returned to front users for ${local.environment}"
-  alarm_name                = "${local.environment} public front CSRF errors"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  datapoints_to_alarm       = 1
-  evaluation_periods        = 1
-  insufficient_data_actions = []
-  metric_name               = "EventCount"
-  namespace                 = "online-lpa/Cloudwatch"
-  ok_actions                = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
-  period                    = 60
-  statistic                 = "Sum"
-  tags                      = merge(local.default_tags, local.front_component_tag)
-  threshold                 = 10
-  treat_missing_data        = "notBreaching"
-}*/
-
 resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
   actions_enabled     = true
   alarm_name          = "${local.environment} pdf messages awaiting processing"

--- a/terraform/environment/cloudwatch_logs.tf
+++ b/terraform/environment/cloudwatch_logs.tf
@@ -1,0 +1,11 @@
+resource "aws_cloudwatch_log_group" "application_logs" {
+  name              = "${local.environment}_application_logs"
+  retention_in_days = local.account.log_retention_in_days
+
+  tags = merge(
+    local.default_tags,
+    {
+      "Name" = "${local.environment}_application_logs"
+    },
+  )
+}

--- a/terraform/environment/cloudwatch_logs.tf
+++ b/terraform/environment/cloudwatch_logs.tf
@@ -4,6 +4,7 @@ resource "aws_cloudwatch_log_group" "application_logs" {
 
   tags = merge(
     local.default_tags,
+    local.shared_component_tag,
     {
       "Name" = "${local.environment}_application_logs"
     },

--- a/terraform/environment/ecs_admin.tf
+++ b/terraform/environment/ecs_admin.tf
@@ -151,7 +151,7 @@ locals {
       "logConfiguration" : {
         "logDriver" : "awslogs",
         "options" : {
-          "awslogs-group" : data.aws_cloudwatch_log_group.online-lpa.name,
+          "awslogs-group" : aws_cloudwatch_log_group.application_logs.name,
           "awslogs-region" : "eu-west-1",
           "awslogs-stream-prefix" : "${local.environment}.admin-web.online-lpa"
         }
@@ -183,7 +183,7 @@ locals {
       "logConfiguration" : {
         "logDriver" : "awslogs",
         "options" : {
-          "awslogs-group" : data.aws_cloudwatch_log_group.online-lpa.name,
+          "awslogs-group" : aws_cloudwatch_log_group.application_logs.name,
           "awslogs-region" : "eu-west-1",
           "awslogs-stream-prefix" : "${local.environment}.admin-app.online-lpa"
         }

--- a/terraform/environment/ecs_admin.tf
+++ b/terraform/environment/ecs_admin.tf
@@ -8,6 +8,7 @@ resource "aws_ecs_service" "admin" {
   desired_count    = local.account.autoscaling.admin.minimum
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
+  propagate_tags   = "TASK_DEFINITION"
 
   network_configuration {
     security_groups  = [aws_security_group.admin_ecs_service.id]

--- a/terraform/environment/ecs_api.tf
+++ b/terraform/environment/ecs_api.tf
@@ -8,7 +8,7 @@ resource "aws_ecs_service" "api" {
   desired_count    = local.account.autoscaling.api.minimum
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
-
+  propagate_tags   = "TASK_DEFINITION"
   network_configuration {
     security_groups = [
       aws_security_group.api_ecs_service.id,

--- a/terraform/environment/ecs_api.tf
+++ b/terraform/environment/ecs_api.tf
@@ -9,6 +9,7 @@ resource "aws_ecs_service" "api" {
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
   propagate_tags   = "TASK_DEFINITION"
+
   network_configuration {
     security_groups = [
       aws_security_group.api_ecs_service.id,

--- a/terraform/environment/ecs_api.tf
+++ b/terraform/environment/ecs_api.tf
@@ -241,7 +241,7 @@ locals {
       "logConfiguration" : {
         "logDriver" : "awslogs",
         "options" : {
-          "awslogs-group" : data.aws_cloudwatch_log_group.online-lpa.name,
+          "awslogs-group" : aws_cloudwatch_log_group.application_logs.name,
           "awslogs-region" : "eu-west-1",
           "awslogs-stream-prefix" : "${local.environment}.api-web.online-lpa"
         }
@@ -273,7 +273,7 @@ locals {
       "logConfiguration" : {
         "logDriver" : "awslogs",
         "options" : {
-          "awslogs-group" : data.aws_cloudwatch_log_group.online-lpa.name,
+          "awslogs-group" : aws_cloudwatch_log_group.application_logs.name,
           "awslogs-region" : "eu-west-1",
           "awslogs-stream-prefix" : "${local.environment}.api-app.online-lpa"
         }

--- a/terraform/environment/ecs_front.tf
+++ b/terraform/environment/ecs_front.tf
@@ -8,6 +8,7 @@ resource "aws_ecs_service" "front" {
   desired_count    = local.account.autoscaling.front.minimum
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
+  propagate_tags   = "TASK_DEFINITION"
 
   network_configuration {
     security_groups  = [aws_security_group.front_ecs_service.id]

--- a/terraform/environment/ecs_front.tf
+++ b/terraform/environment/ecs_front.tf
@@ -165,7 +165,7 @@ locals {
     "logConfiguration" : {
       "logDriver" : "awslogs",
       "options" : {
-        "awslogs-group" : data.aws_cloudwatch_log_group.online-lpa.name,
+        "awslogs-group" : aws_cloudwatch_log_group.application_logs.name,
         "awslogs-region" : "eu-west-1",
         "awslogs-stream-prefix" : "${local.environment}.front-web.online-lpa"
       }
@@ -197,7 +197,7 @@ locals {
       "logConfiguration" : {
         "logDriver" : "awslogs",
         "options" : {
-          "awslogs-group" : data.aws_cloudwatch_log_group.online-lpa.name,
+          "awslogs-group" : aws_cloudwatch_log_group.application_logs.name,
           "awslogs-region" : "eu-west-1",
           "awslogs-stream-prefix" : "${local.environment}.front-app.online-lpa"
         }

--- a/terraform/environment/ecs_pdf.tf
+++ b/terraform/environment/ecs_pdf.tf
@@ -166,7 +166,7 @@ locals {
       "logConfiguration" : {
         "logDriver" : "awslogs",
         "options" : {
-          "awslogs-group" : data.aws_cloudwatch_log_group.online-lpa.name,
+          "awslogs-group" : aws_cloudwatch_log_group.application_logs.name,
           "awslogs-region" : "eu-west-1",
           "awslogs-stream-prefix" : "${local.environment}.pdf-app.online-lpa"
         }

--- a/terraform/environment/ecs_pdf.tf
+++ b/terraform/environment/ecs_pdf.tf
@@ -8,6 +8,7 @@ resource "aws_ecs_service" "pdf" {
   desired_count    = local.account.autoscaling.pdf.minimum
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
+  propagate_tags   = "TASK_DEFINITION"
 
   network_configuration {
     security_groups  = [aws_security_group.pdf_ecs_service.id]

--- a/terraform/environment/ecs_seeding.tf
+++ b/terraform/environment/ecs_seeding.tf
@@ -73,7 +73,7 @@ locals {
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-            "awslogs-group": "${data.aws_cloudwatch_log_group.online-lpa.name}",
+            "awslogs-group": "${aws_cloudwatch_log_group.application_logs.name}",
             "awslogs-region": "eu-west-1",
             "awslogs-stream-prefix": "${local.environment}.seeding.online-lpa"
         }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -21,6 +21,7 @@
       "skip_final_snapshot" : true,
       "psql_engine_version": "10.13",
       "psql_parameter_group_family": "postgres10",
+      "log_retention_in_days": 7,
       "autoscaling": {
         "front": {
           "minimum": 1,
@@ -56,6 +57,7 @@
       "skip_final_snapshot" : true,
       "psql_engine_version": "10.13",
       "psql_parameter_group_family": "postgres10",
+      "log_retention_in_days": 7,
       "autoscaling": {
         "front": {
           "minimum": 1,
@@ -91,6 +93,7 @@
       "skip_final_snapshot" : false,
       "psql_engine_version": "10.13",
       "psql_parameter_group_family": "postgres10",
+      "log_retention_in_days": 120,
       "autoscaling": {
         "front": {
           "minimum": 3,

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -25,6 +25,7 @@ variable "accounts" {
       aurora_instance_count       = number
       deletion_protection         = bool
       always_on                   = bool
+      log_retention_in_days       = number
       autoscaling = object({
         front = object({
           minimum = number


### PR DESCRIPTION
## Purpose

- Change the log groups to be per environment. this would make it easier to investigate.
- Also improve tagging as this was not present at task level.

Fixes LPAL-125

## Approach

- Change from account level `online-lpa` log group to `${local.environment}_application_logs` on ECS containers
- We'll keep the account level one for historic purposes
- Tag propagation on tasks (noticed this as missing)
- Remove commented CSRF cloudwatch alarm and filter
- seeding Python scripts changed to accommodate new log group.

## Learning
- python f' strings: https://realpython.com/python-f-strings/
- tag propagation - you can choose propagate from `TASK_DEFINITION` or `SERVICE`; some resources: 
   - https://docs.aws.amazon.com/whitepapers/latest/tagging-best-practices/propagate-tag-values-across-related-resources.html
    - https://stackoverflow.com/questions/62567721/aws-tags-on-ecs-tasks-not-being-inherited
    - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#propagate_tags
    
## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [x] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
