### PR TITLE
Urgent rework autoscale to prevent  object not found errors

### DIFF
--- a/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
+++ b/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
@@ -30,6 +30,7 @@ do
       echo "cleaning up workspace $workspace..."
       terraform workspace select $workspace
       terraform init
+      terraform refresh
       terraform destroy -auto-approve
       terraform workspace select default
       terraform workspace delete $workspace

--- a/terraform/environment/autoscaling.tf
+++ b/terraform/environment/autoscaling.tf
@@ -30,3 +30,14 @@ module "pdf_ecs_autoscaling" {
   ecs_task_autoscaling_maximum     = local.account.autoscaling.pdf.maximum
   tags                             = merge(local.default_tags, local.pdf_component_tag)
 }
+
+module "admin_ecs_autoscaling" {
+  source                           = "./modules/ecs_autoscaling"
+  environment                      = local.environment
+  aws_ecs_cluster_name             = aws_ecs_cluster.online-lpa.name
+  aws_ecs_service_name             = aws_ecs_service.admin.name
+  ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn
+  ecs_task_autoscaling_minimum     = 1
+  ecs_task_autoscaling_maximum     = 1
+  tags                             = merge(local.default_tags, local.pdf_component_tag)
+}

--- a/terraform/environment/ecs_hibernation.tf
+++ b/terraform/environment/ecs_hibernation.tf
@@ -9,19 +9,22 @@ module "dev_weekdays" {
     tostring(aws_ecs_service.admin.name) = {
       scale_down_to = 0
       scale_up_to   = local.account.autoscaling.admin.maximum
+      target        = module.admin_ecs_autoscaling.appautoscaling_target
     }
     tostring(aws_ecs_service.api.name) = {
       scale_down_to = 0
       scale_up_to   = local.account.autoscaling.api.maximum
+      target        = module.api_ecs_autoscaling.appautoscaling_target
     }
     tostring(aws_ecs_service.front.name) = {
       scale_down_to = 0
       scale_up_to   = local.account.autoscaling.front.maximum
+      target        = module.front_ecs_autoscaling.appautoscaling_target
     }
     tostring(aws_ecs_service.pdf.name) = {
       scale_down_to = 0
       scale_up_to   = local.account.autoscaling.pdf.maximum
+      target        = module.pdf_ecs_autoscaling.appautoscaling_target
     }
   }
-  depends_on = [module.api_ecs_autoscaling, module.pdf_ecs_autoscaling, module.front_ecs_autoscaling]
 }

--- a/terraform/environment/modules/ecs_autoscaling/variables.tf
+++ b/terraform/environment/modules/ecs_autoscaling/variables.tf
@@ -69,3 +69,12 @@ variable "tags" {
   description = "the AWS tags to apply to the resources in ths module."
   type        = map(any)
 }
+
+output "appautoscaling_target" {
+  description = "returns the autoscaling target for other scaling operations to use"
+  value = {
+    service_namespace  = aws_appautoscaling_target.ecs_service.service_namespace
+    resource_id        = aws_appautoscaling_target.ecs_service.resource_id
+    scalable_dimension = aws_appautoscaling_target.ecs_service.scalable_dimension
+  }
+}

--- a/terraform/environment/modules/ecs_scheduled_scaling/main.tf
+++ b/terraform/environment/modules/ecs_scheduled_scaling/main.tf
@@ -2,23 +2,12 @@ data "aws_iam_role" "ecs_autoscaling_service_role" {
   name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
 }
 
-
-resource "aws_appautoscaling_target" "ecs_service_scheduled" {
-  for_each           = var.service_config
-  min_capacity       = 1
-  max_capacity       = each.value.scale_up_to
-  resource_id        = "service/${var.ecs_cluster_name}/${each.key}"
-  role_arn           = data.aws_iam_role.ecs_autoscaling_service_role.arn
-  scalable_dimension = "ecs:service:DesiredCount"
-  service_namespace  = "ecs"
-}
-
 resource "aws_appautoscaling_scheduled_action" "trigger_scale_up" {
   for_each           = var.service_config
   name               = "${var.name}-ecs-scale-up-${each.key}-${terraform.workspace}"
-  service_namespace  = aws_appautoscaling_target.ecs_service_scheduled[each.key].service_namespace
-  resource_id        = aws_appautoscaling_target.ecs_service_scheduled[each.key].resource_id
-  scalable_dimension = aws_appautoscaling_target.ecs_service_scheduled[each.key].scalable_dimension
+  service_namespace  = each.value.target.service_namespace
+  resource_id        = each.value.target.resource_id
+  scalable_dimension = each.value.target.scalable_dimension
   schedule           = var.scale_up_time
 
   scalable_target_action {
@@ -30,9 +19,9 @@ resource "aws_appautoscaling_scheduled_action" "trigger_scale_up" {
 resource "aws_appautoscaling_scheduled_action" "trigger_scale_down" {
   for_each           = var.service_config
   name               = "${var.name}-ecs-scale-down-${each.key}-${terraform.workspace}"
-  service_namespace  = aws_appautoscaling_target.ecs_service_scheduled[each.key].service_namespace
-  resource_id        = aws_appautoscaling_target.ecs_service_scheduled[each.key].resource_id
-  scalable_dimension = aws_appautoscaling_target.ecs_service_scheduled[each.key].scalable_dimension
+  service_namespace  = each.value.target.service_namespace
+  resource_id        = each.value.target.resource_id
+  scalable_dimension = each.value.target.scalable_dimension
   schedule           = var.scale_down_time
 
   # AutoScaling actions need to be executed serially

--- a/terraform/environment/modules/ecs_scheduled_scaling/variables.tf
+++ b/terraform/environment/modules/ecs_scheduled_scaling/variables.tf
@@ -23,5 +23,6 @@ variable "service_config" {
     object({
       scale_down_to = number
       scale_up_to   = number
+      target        = map(any)
   }))
 }


### PR DESCRIPTION
## Purpose

Dev workspace cleanup failing due to issues with trying to delete the appautoscale target twice. 
This is now an output variable from autoscale module, so that the schedule scale can use this value instead, and will no longer cause an issue.

Without this we have dangling terraform workspaces, which were building up. 

## Approach

- added an output var to the autoscale to get the required values target
- reworked the scheduled module to take the target values required from the autoscale module.

## Learning

- terraform output values: https://www.terraform.io/docs/language/values/outputs.html
- aws appautoscaling target TF https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
