### PR TITLE
LPAL-267 Prevent ini_set errors from /ping/json endpoint

### DIFF
--- a/service-front/module/Application/config/module.config.php
+++ b/service-front/module/Application/config/module.config.php
@@ -16,6 +16,7 @@ return [
     'controllers' => [
         'factories' => [
             'DynamoDbController' => 'Application\Controller\Console\DynamoDbControllerFactory',
+            'PingController' => 'Application\ControllerFactory\PingControllerFactory',
         ],
         'abstract_factories' => [
             'Application\ControllerFactory\ControllerAbstractFactory'

--- a/service-front/module/Application/config/module.routes.php
+++ b/service-front/module/Application/config/module.routes.php
@@ -297,7 +297,7 @@ return [
                 'options' => [
                     'route'    => '/ping',
                     'defaults' => [
-                        'controller' => 'General\PingController',
+                        'controller' => 'PingController',
                         'action'     => 'index',
                     ],
                 ],

--- a/service-front/module/Application/src/Controller/General/PingController.php
+++ b/service-front/module/Application/src/Controller/General/PingController.php
@@ -1,16 +1,13 @@
 <?php
 
 namespace Application\Controller\General;
-// Work around due to issues with code base, unless in place this displays warnings when endpoint it accessed
-// Ticket has been created in the backlog to address this LPAL-267
-error_reporting(E_ERROR);
 
 use Application\Model\Service\System\Status;
 use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
-use Application\Controller\AbstractBaseController;
+use Laminas\Mvc\Controller\AbstractActionController;
 
-class PingController extends AbstractBaseController
+class PingController extends AbstractActionController
 {
     /**
      * @var Status
@@ -18,59 +15,38 @@ class PingController extends AbstractBaseController
     private $statusService;
 
     public function indexAction(){
-
         $result = $this->statusService->check();
+        return new ViewModel(['status'=>$result]);
+    }
 
-        return new ViewModel( [ 'status'=>$result ] );
-
+    public function jsonAction() {
+        $result = $this->statusService->check();
+        $result['tag'] = $this->config['version']['tag'];
+        return new JsonModel($result);
     }
 
     /**
      * Endpoint for the AWS ELB.
      * All we're checking is that PHP can be called and a 200 returned.
      */
-    //This method contains calls that can't be mocked so ignoring until this code is refactored
-    // @codeCoverageIgnoreStart
-    public function elbAction(){
-
+    public function elbAction() {
         $response = $this->getResponse();
-
-        //---
-
-        // Include a sanity check on ssl certs
 
         $path = '/etc/ssl/certs/b204d74a.0';
 
-        if( !is_link($path) | !is_readable($path) || !is_link($path) || empty(file_get_contents($path)) ){
+        if (!is_link($path) | !is_readable($path) || !is_link($path) || empty(file_get_contents($path))){
 
             $response->setStatusCode(500);
             $response->setContent('Sad face');
-
-        } else {
-
+        }
+        else {
             $response->setContent('Happy face');
-
         }
 
-        //---
-
         return $response;
-
-    } // function
-    // @codeCoverageIgnoreEnd
-
-    public function jsonAction(){
-
-        $result = $this->statusService->check();
-
-        $result['tag'] = $this->config()['version']['tag'];
-
-        return new JsonModel( $result );
-
     }
 
-    public function pingdomAction(){
-
+    public function pingdomAction() {
         $start = round(microtime(true) * 1000);
 
         $response = new \Laminas\Http\Response();
@@ -78,18 +54,15 @@ class PingController extends AbstractBaseController
 
         $xml = simplexml_load_string("<?xml version='1.0' ?><pingdom_http_custom_check><status></status><response_time></response_time></pingdom_http_custom_check>");
 
-        //---
-
         $result = $this->statusService->check();
 
-        if( $result['ok'] == true ){
+        if ($result['ok'] == true) {
             $xml->status = 'OK';
-        } else {
+        }
+        else {
             $response->setStatusCode(500);
             $xml->status = 'ERROR';
         }
-
-        //---
 
         $end = round(microtime(true) * 1000);
 
@@ -98,11 +71,15 @@ class PingController extends AbstractBaseController
         $response->setContent($xml->asXML());
 
         return $response;
-
     }
 
     public function setStatusService(Status $statusService)
     {
         $this->statusService = $statusService;
+    }
+
+    public function setConfig(array $config)
+    {
+        $this->config = $config;
     }
 } // class

--- a/service-front/module/Application/src/ControllerFactory/ControllerAbstractFactory.php
+++ b/service-front/module/Application/src/ControllerFactory/ControllerAbstractFactory.php
@@ -104,7 +104,6 @@ class ControllerAbstractFactory implements AbstractFactoryInterface
     public function canCreate(ContainerInterface $container, $requestedName)
     {
         $controllerName = $this->getControllerName($requestedName);
-
         return (class_exists($controllerName) && is_subclass_of($controllerName, AbstractBaseController::class));
     }
 

--- a/service-front/module/Application/src/ControllerFactory/PingControllerFactory.php
+++ b/service-front/module/Application/src/ControllerFactory/PingControllerFactory.php
@@ -1,0 +1,23 @@
+<?php
+namespace Application\ControllerFactory;
+
+use Application\Controller\General\PingController;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+
+class PingControllerFactory implements FactoryInterface
+{
+    /**
+     * Create a PingController
+     *
+     * @param  ContainerInterface $container
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = NULL)
+    {
+        $controller = new PingController();
+        $controller->setStatusService($container->get('SiteStatus'));
+        $controller->setConfig($container->get('config'));
+        return $controller;
+    }
+}

--- a/service-front/module/Application/tests/Controller/General/PingControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/PingControllerTest.php
@@ -6,12 +6,13 @@ use Application\Controller\General\PingController;
 use Application\Model\Service\System\Status;
 use ApplicationTest\Controller\AbstractControllerTest;
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
 use Laminas\Http\Response;
 use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
 
-class PingControllerTest extends AbstractControllerTest
+class PingControllerTest extends MockeryTestCase
 {
     /**
      * @var MockInterface|Status
@@ -74,20 +75,21 @@ class PingControllerTest extends AbstractControllerTest
         'iterations' => 6,
     );
 
-    protected function getController(string $controllerName)
+    protected function getController()
     {
         /** @var PingController $controller */
-        $controller = parent::getController($controllerName);
+        $controller = new PingController();
 
         $this->status = Mockery::mock(Status::class);
         $controller->setStatusService($this->status);
+        $controller->setConfig(['version' => ['tag' => '1.2.3.4-test']]);
 
         return $controller;
     }
 
     public function testIndexAction()
     {
-        $controller = $this->getController(PingController::class);
+        $controller = $this->getController();
 
         $this->status->shouldReceive('check')->andReturn($this->checkResultOk)->once();
 
@@ -101,7 +103,7 @@ class PingControllerTest extends AbstractControllerTest
 
     public function testJsonAction()
     {
-        $controller = $this->getController(PingController::class);
+        $controller = $this->getController();
 
         $this->status->shouldReceive('check')->andReturn($this->checkResultOk)->once();
 
@@ -115,7 +117,7 @@ class PingControllerTest extends AbstractControllerTest
 
     public function testPingdomActionOk()
     {
-        $controller = $this->getController(PingController::class);
+        $controller = $this->getController();
 
         $this->status->shouldReceive('check')->andReturn($this->checkResultOk)->once();
 
@@ -129,7 +131,7 @@ class PingControllerTest extends AbstractControllerTest
 
     public function testPingdomActionError()
     {
-        $controller = $this->getController(PingController::class);
+        $controller = $this->getController();
 
         $checkResultError = $this->checkResultOk;
         $checkResultError['ok'] = false;


### PR DESCRIPTION
## Purpose

Errors were occurring due to some session handling nonsense
going on in the AbstractControllerFactory.

By extending the AbstractActionController from Laminas directly
to give us the PingController (we don't need the other machinery
which comes with the AbstractBaseController after all), we can
remove a lot of complexity and create a controller which doesn't
need sessions.

This gets rid of the ini_set exceptions from /ping/json because
we no longer have session stuff going on.

Fixes LPAL-267

## Approach

Reduce complexity of PingController, which doesn't need session machinery.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
