### PR TITLE
LPAL-346 prevent repetition of a11y checks

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,7 +36,10 @@ Cypress.Commands.add("visitWithChecks", (url) => {
     cy.document().then(docStr => {
         expect(docStr.documentElement.innerHTML).not.to.contain("Oops", "CSRF token mismatch problem detected");
     });
-    cy.OPGCheckA11y();
+    if (!Cypress.env("a11yCheckedPages").has(url)) {
+        cy.OPGCheckA11y();
+        Cypress.env("a11yCheckedPages").add(url);
+    }
 });
 
 Cypress.Commands.add("visitWithChecks", (url) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -33,17 +33,6 @@ Cypress.Commands.add("runPythonApiCommand", (pythonCommand) => {
 
 Cypress.Commands.add("visitWithChecks", (url) => {
     cy.visit(url);
-    cy.document().then(docStr => {
-        expect(docStr.documentElement.innerHTML).not.to.contain("Oops", "CSRF token mismatch problem detected");
-    });
-    if (!Cypress.env("a11yCheckedPages").has(url)) {
-        cy.OPGCheckA11y();
-        Cypress.env("a11yCheckedPages").add(url);
-    }
-});
-
-Cypress.Commands.add("visitWithChecks", (url) => {
-    cy.visit(url);
     cy.document().then(doc => {
         expect(doc.documentElement.innerHTML).not.to.contain("Oops", "CSRF token mismatch problem detected");
 
@@ -55,7 +44,10 @@ Cypress.Commands.add("visitWithChecks", (url) => {
             expect(title.text).to.contain(heading.textContent.trim());
         }
     });
-    cy.OPGCheckA11y();
+    if (!Cypress.env("a11yCheckedPages").has(url)) {
+        cy.OPGCheckA11y();
+        Cypress.env("a11yCheckedPages").add(url);
+    }
 });
 
 // window: DOM window instance

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -31,3 +31,4 @@ var adminUrl = Cypress.env("adminUrl");
 if (adminUrl === undefined) {
     Cypress.env("adminUrl","https://localhost:7003");
 }
+Cypress.env("a11yCheckedPages", new Set());


### PR DESCRIPTION
## Purpose

_LPAL-346 prevent a11y check from being run multiple times on same page _

Fixes LPAL-####

## Approach

_Create an empty Set on cypress startup, when doing a11y check ensure url not already in set, run check and add url to set_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
