### PR TITLE
LPAL-357 Remove Guidance.feature scenarios which regularly fail

### DIFF
--- a/cypress/integration/Guidance.feature
+++ b/cypress/integration/Guidance.feature
@@ -3,33 +3,6 @@ Feature: Guidance
 
   I want to be able to read guidance about how to use the tool
 
-  # screen width must be > 640, otherwise help displays in main window
-  # rather than an overlay; see moj.help-system.js, which switches off
-  # JS links when on a mobile width screen
-
-  # after opening help, tab takes user into content not menu
-  @focus
-  Scenario: Tab navigation in guidance moves from content into menu (LPAL-247)
-    Given I log in as appropriate test user
-    And I am using a viewport greater than 640 pixels wide
-    When I visit "/home"
-    And I click "guidance"
-    And I wait for focus on "popup-close"
-    And I press tab
-    Then I am focused on "donor-link"
-
-  # shift focus back to content after clicking topic link
-  @focus
-  Scenario: After clicking guidance topic, focus is in help content (LPAL-247)
-    Given I log in as appropriate test user
-    And I am using a viewport greater than 640 pixels wide
-    When I visit "/home"
-    And I click "guidance"
-    And I wait for focus on "popup-close"
-    And I click "preferences-and-instructions-nav-link"
-    And I press tab
-    Then I am focused on "replacement-attorneys-link"
-
   # as we can't zoom the browser from JavaScript, instead make the browser
   # viewport really narrow to force elements to overflow
   @focus


### PR DESCRIPTION
## Purpose

https://opgtransform.atlassian.net/browse/LPAL-357

Fixes LPAL-357

## Approach

Remove the scenarios. They can always be retrieved later if necessary. I'd suggest only doing this if we can replace all the tab emulation with something native to cypress.

## Learning

cypress may or may not support this natively at some point

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have removed tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
