### PR TITLE
Lpal 352 sanitize commit message for new slack orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,37 +106,38 @@ pr_build: &pr_build
             pdf_docker_build,
             seeding_docker_build,
           ]
-    - ecr_scan_results:
-         name: ecr_scan_results_development
-         filters: { branches: { ignore: [master] } }
-         requires:
-           [
-             front_docker_build,
-             admin_docker_build,
-             api_docker_build,
-             pdf_docker_build,
-             seeding_docker_build,
-           ]
+    # - ecr_scan_results:
+    #     name: ecr_scan_results_development
+    #     filters: { branches: { ignore: [master] } }
+    #     requires:
+    #       [
+    #         front_docker_build,
+    #         admin_docker_build,
+    #         api_docker_build,
+    #         pdf_docker_build,
+    #         seeding_docker_build,
+    #       ]
 
-    - infrastructure_and_deployment/seed_environment_databases:
-         name: dev_seed_environment_databases
-         filters: { branches: { ignore: [master] } }
-         requires: [dev_environment_apply_terraform]
+    # - infrastructure_and_deployment/seed_environment_databases:
+    #     name: dev_seed_environment_databases
+    #     filters: { branches: { ignore: [master] } }
+    #     requires: [dev_environment_apply_terraform]
 
-    - infrastructure_and_deployment/run_cypress_test:
-         name: run_cypress_test
-         filters: { branches: { ignore: [master] } }
-         requires: [dev_seed_environment_databases]
+    # - infrastructure_and_deployment/run_cypress_test:
+    #     name: run_cypress_test
+    #     filters: { branches: { ignore: [master] } }
+    #     requires: [dev_seed_environment_databases]
 
-    - infrastructure_and_deployment/run_functional_test:
-         name: run_functional_test
-         filters: { branches: { ignore: [master] } }
-         requires: [dev_seed_environment_databases]
+    # - infrastructure_and_deployment/run_functional_test:
+    #     name: run_functional_test
+    #     filters: { branches: { ignore: [master] } }
+    #     requires: [dev_seed_environment_databases]
 
     - slack_notify_domain:
         name: post_environment_domains
         filters: { branches: { ignore: [master] } }
-        requires: [run_functional_test, run_cypress_test]
+        #requires: [run_functional_test, run_cypress_test]
+        requires: [dev_environment_apply_terraform, dev_account_apply_terraform]
 
 
 path_to_live: &path_to_live
@@ -969,6 +970,9 @@ jobs:
             export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
             echo $TF_WORKSPACE
             scripts/pipeline/set_environment_variables/set_slack_env_vars.sh >> $BASH_ENV
+            echo environment_pipeline_tasks_config.json:
+            cat /tmp/environment_pipeline_tasks_config.json
+
             ~/project/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
 
       - slack/notify:
@@ -998,12 +1002,14 @@ jobs:
             export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
             echo $TF_WORKSPACE
             scripts/pipeline/set_environment_variables/set_slack_env_vars.sh >> $BASH_ENV
-
+            echo environment_pipeline_tasks_config.json:
+            cat /tmp/environment_pipeline_tasks_config.json
             ~/project/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
       - slack/notify:
           event: pass
           channel: 'C01BDM8T67J'
           template: SLACK_NOTIFY_PRODUCTION_RELEASE_TEMPLATE
+
   ecr_scan_results:
     docker:
       - image: circleci/python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,39 +106,38 @@ pr_build: &pr_build
             pdf_docker_build,
             seeding_docker_build,
           ]
-    # - ecr_scan_results:
-    #     name: ecr_scan_results_development
-    #     filters: { branches: { ignore: [master] } }
-    #     requires:
-    #       [
-    #         front_docker_build,
-    #         admin_docker_build,
-    #         api_docker_build,
-    #         pdf_docker_build,
-    #         seeding_docker_build,
-    #       ]
+    - ecr_scan_results:
+        name: ecr_scan_results_development
+        filters: { branches: { ignore: [master] } }
+        requires:
+          [
+            front_docker_build,
+            admin_docker_build,
+            api_docker_build,
+            pdf_docker_build,
+            seeding_docker_build,
+          ]
 
-    # - infrastructure_and_deployment/seed_environment_databases:
-    #     name: dev_seed_environment_databases
-    #     filters: { branches: { ignore: [master] } }
-    #     requires: [dev_environment_apply_terraform]
+    - infrastructure_and_deployment/seed_environment_databases:
+        name: dev_seed_environment_databases
+        filters: { branches: { ignore: [master] } }
+        requires: [dev_environment_apply_terraform]
 
-    # - infrastructure_and_deployment/run_cypress_test:
-    #     name: run_cypress_test
-    #     filters: { branches: { ignore: [master] } }
-    #     requires: [dev_seed_environment_databases]
+    - infrastructure_and_deployment/run_cypress_test:
+        name: run_cypress_test
+        filters: { branches: { ignore: [master] } }
+        requires: [dev_seed_environment_databases]
 
-    # - infrastructure_and_deployment/run_functional_test:
-    #     name: run_functional_test
-    #     filters: { branches: { ignore: [master] } }
-    #     requires: [dev_seed_environment_databases]
+    - infrastructure_and_deployment/run_functional_test:
+        name: run_functional_test
+        filters: { branches: { ignore: [master] } }
+        requires: [dev_seed_environment_databases]
 
     - slack_notify_domain:
         name: post_environment_domains
         filters: { branches: { ignore: [master] } }
-        #requires: [run_functional_test, run_cypress_test]
-        requires: [dev_environment_apply_terraform, dev_account_apply_terraform]
-
+        requires: [run_functional_test, run_cypress_test]
+        #requires: [dev_environment_apply_terraform, dev_account_apply_terraform]
 
 path_to_live: &path_to_live
   jobs:
@@ -970,14 +969,11 @@ jobs:
             export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
             echo $TF_WORKSPACE
             scripts/pipeline/set_environment_variables/set_slack_env_vars.sh >> $BASH_ENV
-            echo environment_pipeline_tasks_config.json:
-            cat /tmp/environment_pipeline_tasks_config.json
-
             ~/project/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
 
       - slack/notify:
           event: pass
-          channel: 'C01BKBWGWTY'
+          channel: "C01BKBWGWTY"
           template: SLACK_POST_ENVIRONMENT_DOMAIN_TEMPLATE
 
   slack_notify_production_release:
@@ -1002,12 +998,10 @@ jobs:
             export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
             echo $TF_WORKSPACE
             scripts/pipeline/set_environment_variables/set_slack_env_vars.sh >> $BASH_ENV
-            echo environment_pipeline_tasks_config.json:
-            cat /tmp/environment_pipeline_tasks_config.json
             ~/project/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
       - slack/notify:
           event: pass
-          channel: 'C01BDM8T67J'
+          channel: "C01BDM8T67J"
           template: SLACK_NOTIFY_PRODUCTION_RELEASE_TEMPLATE
 
   ecr_scan_results:

--- a/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
@@ -41,7 +41,7 @@ generate_slack_notify_production_release()
                     [
                         {
                             "type": "plain_text",
-                            "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: ${COMMIT_MESSAGE}"
+                            "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: ${COMMIT_MESSAGE//$'\n'/\\n}"
                         }
                     ]
                 }

--- a/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
@@ -1,9 +1,7 @@
 #! /bin/bash
     # needed as circleci did not santize the input for json properly.
     SANITISED_COMMIT_MESSAGE=$(echo "${COMMIT_MESSAGE//$'\n'/\\\n}"  | sed 's/"/\\"/g')
-    #| sed 's/`/\\`/g | sed 's/'\''/\\'\''/g'
-    echo  SANITISED_COMMIT_MESSAGE
-    echo ${SANITISED_COMMIT_MESSAGE}
+
 generate_slack_notify_production_release()
 {
     cat <<EOF
@@ -58,8 +56,6 @@ EOF
 }
 
 generate_slack_notify_production_release > /tmp/slack_notify_production_release.json
-
 echo message sent:
 cat /tmp/slack_notify_production_release.json
-
 echo 'export SLACK_NOTIFY_PRODUCTION_RELEASE_TEMPLATE=$(cat /tmp/slack_notify_production_release.json)' >> $BASH_ENV

--- a/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
@@ -1,4 +1,9 @@
 #! /bin/bash
+    # needed as circleci did not santize the input for json properly.
+    SANITISED_COMMIT_MESSAGE=$(echo "${COMMIT_MESSAGE//$'\n'/\\\n}"  | sed 's/"/\\"/g')
+    #| sed 's/`/\\`/g | sed 's/'\''/\\'\''/g'
+    echo  SANITISED_COMMIT_MESSAGE
+    echo ${SANITISED_COMMIT_MESSAGE}
 generate_slack_notify_production_release()
 {
     cat <<EOF
@@ -40,7 +45,7 @@ generate_slack_notify_production_release()
                     "elements":
                     [
                         {
-                            "type": "plain_text",
+                            "type": "mrkdwn",
                             "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: ${COMMIT_MESSAGE//$'\n'/\\n}"
                         }
                     ]

--- a/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
@@ -44,7 +44,7 @@ generate_slack_notify_production_release()
                     [
                         {
                             "type": "mrkdwn",
-                            "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: ${COMMIT_MESSAGE//$'\n'/\\n}"
+                            "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: ${SANITISED_COMMIT_MESSAGE}"
                         }
                     ]
                 }

--- a/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
@@ -44,7 +44,7 @@ generate_post_environment_domains()
                 [
                     {
                         "type": "plain_text",
-                        "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: ${COMMIT_MESSAGE}"
+                        "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: ${COMMIT_MESSAGE//$'\n'/\\n}"
                     }
                 ]
             }

--- a/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
@@ -1,9 +1,7 @@
 #! /bin/bash
     # needed as circleci did not santize the input for json properly.
     SANITISED_COMMIT_MESSAGE=$(echo "${COMMIT_MESSAGE//$'\n'/\\\n}"  | sed 's/"/\\""/g')
-    #| sed 's/`/\\`/g | sed 's/'\''/\\'\''/g'
-    echo  SANITISED_COMMIT_MESSAGE
-    echo ${SANITISED_COMMIT_MESSAGE}
+
 generate_post_environment_domains()
 {
 
@@ -65,10 +63,6 @@ EOF
 }
 
 generate_post_environment_domains > /tmp/post_environment_domains.json
-
-
-
 echo message sent:
 cat /tmp/post_environment_domains.json
-
 echo 'export SLACK_POST_ENVIRONMENT_DOMAIN_TEMPLATE=$(cat /tmp/post_environment_domains.json)' >> $BASH_ENV

--- a/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
@@ -1,61 +1,72 @@
 #! /bin/bash
+    # needed as circleci did not santize the input for json properly.
+    SANITISED_COMMIT_MESSAGE=$(echo "${COMMIT_MESSAGE//$'\n'/\\\n}"  | sed 's/"/\\""/g')
+    #| sed 's/`/\\`/g | sed 's/'\''/\\'\''/g'
+    echo  SANITISED_COMMIT_MESSAGE
+    echo ${SANITISED_COMMIT_MESSAGE}
 generate_post_environment_domains()
 {
+
+
+    # needed as circleci did not santize the input for json properly.
     cat <<EOF
 {
     "blocks": [],
-    "attachments": [
-    {
-        "color": "#508c18",
-        "blocks":
-        [
-            {
-                "type": "header",
-                "text": {
-                "type": "plain_text",
-                "text": "Online LPA Development Environment Ready",
-                "emoji": false
-                }
-            },
-            {
-                "type": "section",
-                "text": {
-                "type": "mrkdwn",
-                "text": "public facing url: <https://${PUBLIC_FACING_DOMAIN}/home>"
-                }
-            },
-            {
-                "type": "section",
-                "text": {
-                "type": "mrkdwn",
-                "text": "front url: <https://${FRONT_DOMAIN}>"
-                }
-            },
-            {
-                "type": "section",
-                "text": {
-                "type": "mrkdwn",
-                "text": "admin url: <https://${ADMIN_DOMAIN}>"
-                }
-            },
-            {
-                "type": "context",
-                "elements":
-                [
-                    {
-                        "type": "plain_text",
-                        "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: ${COMMIT_MESSAGE//$'\n'/\\n}"
+    "attachments":
+    [
+        {
+            "color": "#508c18",
+            "blocks":
+            [
+                {
+                    "type": "header",
+                    "text": {
+                    "type": "plain_text",
+                    "text": "Online LPA Development Environment Ready",
+                    "emoji": false
                     }
-                ]
-            }
-        ]
-    }
+                },
+                {
+                    "type": "section",
+                    "text": {
+                    "type": "mrkdwn",
+                    "text": "public facing url: <https://${PUBLIC_FACING_DOMAIN}/home>"
+                    }
+                },
+                {
+                    "type": "section",
+                    "text": {
+                    "type": "mrkdwn",
+                    "text": "front url: <https://${FRONT_DOMAIN}>"
+                    }
+                },
+                {
+                    "type": "section",
+                    "text": {
+                    "type": "mrkdwn",
+                    "text": "admin url: <https://${ADMIN_DOMAIN}>"
+                    }
+                },
+                {
+                    "type": "context",
+                    "elements":
+                    [
+                        {
+                            "type": "mrkdwn",
+                            "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: ${SANITISED_COMMIT_MESSAGE}"
+                        }
+                    ]
+                }
+            ]
+        }
     ]
 }
 EOF
 }
 
 generate_post_environment_domains > /tmp/post_environment_domains.json
+
+
 
 echo message sent:
 cat /tmp/post_environment_domains.json


### PR DESCRIPTION
## Purpose

- Variables need substitution if they contain multiline strings, and replaced with the literal `\n`
- On top of this, we also needed to properly escape double quotes as this was messing up the orb.

Fixes LPAL-352

## Approach

- add substitution to `${COMMIT_MESSAGE}` to replace actual end of lines with  a `\n` literal. This is handled better by JQ and the new slack orb.
- use `sed` to escape double quotes in the above  env var. 

## Learning

- bash variable substitution and removal of new lines: https://stackoverflow.com/questions/19345872/how-to-remove-a-newline-from-a-string-in-bash
- `sed`
Had to take the source of the Orb and place it inline to find the issue with debug statements. This took a fair bit of experimentation to get to work.  
I've raised bugs on the orb for the first issue as i think it needs a bit of work.
- https://github.com/CircleCI-Public/slack-orb/issues/261
- 

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
