### PR TITLE
LPAL-336 Adds Elasticache as an account level resource

### DIFF
--- a/terraform/account/elasticache.tf
+++ b/terraform/account/elasticache.tf
@@ -1,0 +1,29 @@
+resource "aws_security_group" "redis_cache_service" {
+  name   = "redis-cache-service"
+  vpc_id = aws_default_vpc.default.id
+  tags   = local.front_component_tag
+}
+
+resource "aws_elasticache_subnet_group" "private_subnets" {
+  name       = "private-subnets"
+  subnet_ids = aws_subnet.private[*].id
+}
+
+
+resource "aws_elasticache_replication_group" "redis_cache" {
+  replication_group_id          = "redis-cache-replication-group"
+  replication_group_description = "redis cache replication group"
+  parameter_group_name          = "default.redis5.0"
+  engine                        = "redis"
+  engine_version                = "5.0.6"
+  node_type                     = "cache.t2.micro"
+  number_cache_clusters         = 2
+  transit_encryption_enabled    = true
+  at_rest_encryption_enabled    = true
+  automatic_failover_enabled    = true
+
+  subnet_group_name  = aws_elasticache_subnet_group.private_subnets.name
+  security_group_ids = [aws_security_group.redis_cache_service.id]
+
+  tags = local.front_component_tag
+}

--- a/terraform/account/elasticache.tf
+++ b/terraform/account/elasticache.tf
@@ -25,5 +25,5 @@ resource "aws_elasticache_replication_group" "redis_cache" {
   subnet_group_name  = aws_elasticache_subnet_group.private_subnets.name
   security_group_ids = [aws_security_group.redis_cache_service.id]
 
-  tags = local.front_component_tag
+  tags = merge(local.default_tags, local.front_component_tag)
 }


### PR DESCRIPTION
## Purpose

Part 1 of
https://opgtransform.atlassian.net/browse/LPAL-336?atlOrigin=eyJpIjoiMGJjZDk3ODdlYmIwNGNlZTg1MjkwMTVmZjY4MmFhZGEiLCJwIjoiaiJ9

Fixes LPAL-336

## Approach

Replaces DynamoDB with Redis, adds in the required inf first before connecting this up to the app

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [x] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
