### PR TITLE
Elasticache Cloudwatch alarms

### DIFF
--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -46,3 +46,49 @@ resource "aws_cloudwatch_metric_alarm" "account_breakglass_login_alarm" {
   threshold           = 1
   treat_missing_data  = "notBreaching"
 }
+
+
+# elasticache cloudwatch alerts
+resource "aws_cloudwatch_metric_alarm" "elasticache_high_cpu_utilization" {
+  for_each                  = toset(aws_elasticache_replication_group.front_cache.member_clusters)
+  actions_enabled           = true
+  alarm_actions             = [aws_sns_topic.cloudwatch_to_slack_elasticache_alerts.arn]
+  alarm_description         = "High CPU usage on ${lower(each.value)}"
+  alarm_name                = "High CPU Utilization on ${lower(each.value)}"
+  comparison_operator       = "GreaterThanThreshold"
+  datapoints_to_alarm       = 2
+  evaluation_periods        = 2
+  insufficient_data_actions = []
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/ElastiCache"
+  ok_actions                = [aws_sns_topic.cloudwatch_to_slack_elasticache_alerts.arn]
+  period                    = "60"
+  statistic                 = "Average"
+  threshold                 = 90
+  treat_missing_data        = "notBreaching"
+  dimensions = {
+    CacheClusterId = each.value
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_high_swap_utilization" {
+  for_each                  = toset(aws_elasticache_replication_group.front_cache.member_clusters)
+  actions_enabled           = true
+  alarm_actions             = [aws_sns_topic.cloudwatch_to_slack_elasticache_alerts.arn]
+  alarm_description         = "High swap mem usage on ${lower(each.value)}"
+  alarm_name                = "High swap mem Utilization on ${lower(each.value)}"
+  comparison_operator       = "GreaterThanThreshold"
+  datapoints_to_alarm       = 2
+  evaluation_periods        = 2
+  insufficient_data_actions = []
+  metric_name               = "SwapUsage"
+  namespace                 = "AWS/ElastiCache"
+  ok_actions                = [aws_sns_topic.cloudwatch_to_slack_elasticache_alerts.arn]
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = 50000000
+  treat_missing_data        = "notBreaching"
+  dimensions = {
+    CacheClusterId = each.value
+  }
+}

--- a/terraform/account/pagerduty.tf
+++ b/terraform/account/pagerduty.tf
@@ -18,3 +18,10 @@ resource "aws_sns_topic_subscription" "cloudwatch_breakglass_alerts_sns_subscrip
   endpoint_auto_confirms = true
   endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration.integration_key}/enqueue"
 }
+
+resource "aws_sns_topic_subscription" "cloudwatch_elasticache_alerts_sns_subscription" {
+  topic_arn              = aws_sns_topic.cloudwatch_to_slack_elasticache_alerts.arn
+  protocol               = "https"
+  endpoint_auto_confirms = true
+  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration.integration_key}/enqueue"
+}

--- a/terraform/account/sns.tf
+++ b/terraform/account/sns.tf
@@ -2,3 +2,8 @@ resource "aws_sns_topic" "cloudwatch_to_slack_breakglass_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-Breakglass-alert"
   tags = merge(local.default_tags, local.shared_component_tag)
 }
+
+resource "aws_sns_topic" "cloudwatch_to_slack_elasticache_alerts" {
+  name = "CloudWatch-to-PagerDuty-${local.account_name}-elasticache-alert"
+  tags = merge(local.default_tags, local.front_component_tag)
+}


### PR DESCRIPTION
## Purpose

to add utilization alarms for Elasticache

Fixes LPAL-367

## Approach

- Create account level alerts for CPU and Swap Utilization
- Pagerduty integration for Elasticache
- create SNS topic

## Learning

See UaL example: https://github.com/ministryofjustice/opg-use-an-lpa/blob/796c8367c9fba7559de3b26c6a8933c6f1337b07/terraform/account/cloudwatch_alarms.tf

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
