### PR TITLE
pin to 7.4.16 with a view to removing once issue in next release is resolved

### DIFF
--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -5,7 +5,7 @@ COPY service-admin/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7.4-fpm-alpine3.12
+FROM php:7.4.16-fpm-alpine3.12
 
 RUN apk add --update --no-cache icu
 

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -5,7 +5,7 @@ COPY service-api/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7.4-fpm-alpine3.12
+FROM php:7.4.16-fpm-alpine3.12
 
 # Postgres lib needs to remain in the container
 RUN apk add --update --no-cache postgresql-libs

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -5,7 +5,7 @@ COPY service-front/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7-fpm-alpine3.12
+FROM php:7.4.16-fpm-alpine3.12
 
 RUN apk add --update --no-cache icu
 

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -5,7 +5,7 @@ COPY service-pdf/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7-cli-alpine3.12
+FROM php:7.4.16-cli-alpine3.12
 
 RUN apk update \
     && apk add --no-cache openjdk8-jre gcc make musl-dev pkgconfig bash\

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,7 +5,7 @@ COPY tests/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7.4-cli
+FROM php:7.4.16-cli
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=linux


### PR DESCRIPTION
## Purpose

due to an issue with Doctrine and PHP in 7.4.18, we need to pin our PHP version to a last known good - 7.4.16.


## Approach

pin docker files to a fixed version of PHP

## Learning

relates to https://bugs.php.net/bug.php?id=81002 

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
