### PR TITLE
LPAL-352 - revisit issue with slack notifications

### DIFF
--- a/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
@@ -54,7 +54,7 @@ generate_slack_notify_production_release()
                     [
                         {
                             "type": "mrkdwn",
-                            "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: ${SANITISED_COMMIT_MESSAGE}"
+                            "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: $SANITISED_COMMIT_MESSAGE"
                         }
                     ]
                 }

--- a/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
@@ -6,7 +6,6 @@
 
     SANITISED_COMMIT_MESSAGE=$(echo "$COMMIT_MESSAGE" |
         sed 's/"/\\""/g'            |   # escape quotes
-         sed 's/*/-/g'              |   # replace asterisks with dash
          awk '{printf "%s\\n", $0}')    #replace newlines with literals.
 
     echo "sanitised commit:"

--- a/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
@@ -1,16 +1,16 @@
 #! /bin/bash
     echo "COMMIT_MESSAGE:"
 
-    echo ${COMMIT_MESSAGE}
+    echo "$COMMIT_MESSAGE"
     # needed as circleci did not santize the input for json properly.
 
     SANITISED_COMMIT_MESSAGE=$(echo "$COMMIT_MESSAGE" |
         sed 's/"/\\""/g'            |   # escape quotes
+         sed 's/*/-/g'              |   # replace asterisks with dash
          awk '{printf "%s\\n", $0}')    #replace newlines with literals.
 
     echo "sanitised commit:"
     echo "${SANITISED_COMMIT_MESSAGE}"
-
 
 generate_slack_notify_production_release()
 {

--- a/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
@@ -11,6 +11,7 @@
     echo "sanitised commit:"
     echo "${SANITISED_COMMIT_MESSAGE}"
 
+
 generate_slack_notify_production_release()
 {
     cat <<EOF

--- a/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_notify_production_release.sh
@@ -4,7 +4,7 @@
     echo ${COMMIT_MESSAGE}
     # needed as circleci did not santize the input for json properly.
 
-    SANITISED_COMMIT_MESSAGE=$(echo "${COMMIT_MESSAGE}" |
+    SANITISED_COMMIT_MESSAGE=$(echo "$COMMIT_MESSAGE" |
         sed 's/"/\\""/g'            |   # escape quotes
          sed 's/*/-/g'              |   # replace asterisks with dash
          awk '{printf "%s\\n", $0}')    #replace newlines with literals.

--- a/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
@@ -5,6 +5,7 @@
     # needed as circleci did not santize the input for json properly.
     SANITISED_COMMIT_MESSAGE=$(echo "$COMMIT_MESSAGE" |
         sed 's/"/\\""/g'            |   # escape quotes
+         sed 's/*/-/g'              |   # replace asterisks with dash
          awk '{printf "%s\\n", $0}')    # replace newlines with literals.
 
     echo "sanitised commit:"

--- a/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
@@ -5,7 +5,6 @@
     # needed as circleci did not santize the input for json properly.
     SANITISED_COMMIT_MESSAGE=$(echo "$COMMIT_MESSAGE" |
         sed 's/"/\\""/g'            |   # escape quotes
-         sed 's/*/-/g'              |   # replace asterisks with dash
          awk '{printf "%s\\n", $0}')    # replace newlines with literals.
 
     echo "sanitised commit:"

--- a/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_post_environment_domains.sh
@@ -1,15 +1,15 @@
 #! /bin/bash
     echo "COMMIT_MESSAGE:"
 
-    echo ${COMMIT_MESSAGE}
+    echo "$COMMIT_MESSAGE"
     # needed as circleci did not santize the input for json properly.
-    SANITISED_COMMIT_MESSAGE=$(echo "${COMMIT_MESSAGE}" |
+    SANITISED_COMMIT_MESSAGE=$(echo "$COMMIT_MESSAGE" |
         sed 's/"/\\""/g'            |   # escape quotes
          sed 's/*/-/g'              |   # replace asterisks with dash
          awk '{printf "%s\\n", $0}')    # replace newlines with literals.
 
     echo "sanitised commit:"
-    echo "${SANITISED_COMMIT_MESSAGE}"
+    echo "$SANITISED_COMMIT_MESSAGE"
 
 generate_post_environment_domains()
 {
@@ -58,7 +58,7 @@ generate_post_environment_domains()
                     [
                         {
                             "type": "mrkdwn",
-                            "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: ${SANITISED_COMMIT_MESSAGE}"
+                            "text": "by user: ${CIRCLE_USERNAME} - branch: ${CIRCLE_BRANCH} - Commit Message: $SANITISED_COMMIT_MESSAGE"
                         }
                     ]
                 }


### PR DESCRIPTION

## Purpose

revisit the slack issue where it fails to send. 

Fixes LPAL-352 (hopefully)

## Approach

remove variable expansion braces from `$COMMIT_MESSAGE` env var and associated sanitization.

## Learning

Var expansion not compatible with orb.

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
