### PR TITLE
LPAL-394 Exclude @Statuses from cypress test suite in path_to_live

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ path_to_live: &path_to_live
 
     - infrastructure_and_deployment/run_cypress_test:
         name: preprod_test_cypress_remaining_tests
-        cypress_tags: "not @SignUp and not @CreateLpa and not @StitchedHW and not @StitchedPF"
+        cypress_tags: "not @SignUp and not @CreateLpa and not @StitchedHW and not @StitchedPF and not @Statuses"
         workspace: preproduction
         filters: { branches: { only: [master] } }
         requires: [preprod_seed_environment_databases]


### PR DESCRIPTION
## Purpose

Fixes [LPAL-394](https://opgtransform.atlassian.net/browse/LPAL-394)

## Approach

Add exclusion for the @Statuses cypress test tag, as these tests only work in dev right now.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
