### PR TITLE
LPA-400 Allow registration date to be used to estimate expected arrival date of LPA response

### DIFF
--- a/cypress/integration/Statuses.feature
+++ b/cypress/integration/Statuses.feature
@@ -26,7 +26,7 @@ Feature: Status display for LPAs
         And the LPA with ID "54171193342" should display with status "Checking"
 
         # receipt date and registration date, Registered status on Sirius, no dispatch date
-        And the LPA with ID "68582508781" should display with status "Checking"
+        And the LPA with ID "68582508781" should display with status "Processed"
 
         # receipt date and rejected date
         And the LPA with ID "88668805824" should display with status "Processed"
@@ -68,13 +68,16 @@ Feature: Status display for LPAs
         And the LPA status is shown as "Checking"
 
     @focus
-    Scenario: A registered LPA with no dispatch date displays as "Checking" on its status page (LPAL-92)
+    Scenario: A registered LPA with no dispatch date displays as "Processed" on its status page with registration date + 15 working days on its status page (LPAL-92)
         Given I log in as appropriate test user
         When I am taken to the dashboard page
         And I click on the view message link for LPA with ID "68582508781"
         Then I am taken to the detail page for LPA with ID "68582508781"
         And I see "A685 8250 8781" in the page text
-        And the LPA status is shown as "Checking"
+        And the LPA status is shown as "Processed"
+
+        # registration date is 04/03/2021
+        And the date by which the LPA should be received is shown as "25/03/21"
 
     @focus
     Scenario: A registered and dispatched LPA displays as "Processed" with dispatch date + 15 working days on its status page (LPAL-92)

--- a/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
+++ b/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
@@ -197,15 +197,6 @@ class Service extends AbstractService
         if (isset($responseBody['status'])) {
             $status = self::SIRIUS_STATUS_TO_LPA[$responseBody['status']];
 
-            // We change the status manually to "checking" if the LPA
-            // is registered but has no dispatch date set yet; the logic
-            // in our front end assumes a "processed" LPA will have a dispatch,
-            // rejected, invalid or withdrawn date (registration date is now
-            // ignored), so we shouldn't treat a registered LPA without one
-            // of these dates as "processed"
-            if (!isset($responseBody['dispatchDate']) && $responseBody['status'] === 'Registered') {
-                $status = Lpa::SIRIUS_PROCESSING_STATUS_CHECKING;
-            }
 
             // We manually change status to "Processed" if it is "Returned",
             // as service-front wants "Processed" rather than "Returned" (LPAL-92)

--- a/service-front/module/Application/src/Controller/Authenticated/Lpa/StatusController.php
+++ b/service-front/module/Application/src/Controller/Authenticated/Lpa/StatusController.php
@@ -51,7 +51,7 @@ class StatusController extends AbstractLpaController
         // Return the rejected, invalid, withdrawn or dispatch date
         // (whichever is latest). NB dates are strings at this point.
         $processedDate = null;
-        $dateFields = ['rejected', 'withdrawn', 'invalid', 'dispatch'];
+        $dateFields = ['rejected', 'withdrawn', 'invalid', 'dispatch', 'registration'];
         for ($i = 0; $i < count($dateFields); $i++) {
             $metadataField = 'application-' . $dateFields[$i] . '-date';
             if (isset($metadata[$metadataField])) {


### PR DESCRIPTION
## Purpose

Fixes [LPAL-400](https://opgtransform.atlassian.net/browse/LPAL-400)

## Approach

Use registration date where dispatch date is not set for a registered LPA.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
