### PR TITLE
pin composer to 2.0.14 in docker files

### DIFF
--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:latest AS composer
+FROM composer:2.0.14 AS composer
 
 COPY service-admin/composer.json /app/composer.json
 COPY service-admin/composer.lock /app/composer.lock

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:latest AS composer
+FROM composer:2.0.14 AS composer
 
 COPY service-api/composer.json /app/composer.json
 COPY service-api/composer.lock /app/composer.lock

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:latest AS composer
+FROM composer:2.0.14 AS composer
 
 COPY service-front/composer.json /app/composer.json
 COPY service-front/composer.lock /app/composer.lock

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:latest AS composer
+FROM composer:2.0.14 AS composer
 
 COPY service-pdf/composer.json /app/composer.json
 COPY service-pdf/composer.lock /app/composer.lock

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:latest AS composer
+FROM composer:2.0.14 AS composer
 
 COPY tests/composer.json /app/composer.json
 COPY tests/composer.lock /app/composer.lock


### PR DESCRIPTION
## Purpose

Composer 2.1 was released, which broak phpunit in an unexpected way. this pin is a workaround until the fix is made for this specific issue.

Break-fix

## Approach
pin dockerfile to `composer:2.0.14`

## Learning

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
