### PR TITLE
LPAL-175 Admin page: existing system message can't be removed

### DIFF
--- a/cypress/integration/Admin.feature
+++ b/cypress/integration/Admin.feature
@@ -43,6 +43,43 @@ Feature: Admin
     And I click "submit-button"
     And I see "System message removed" in the page text
 
+  Scenario: Set and remove a system message on user facing site consecutively
+    Given I visit the admin sign-in page
+    And I log in to admin
+    And I click "system-message-link"
+    Then I am taken to the system message page
+
+    # set message to display on front end
+    When I type "Your pizza is burning" into "message"
+    And I click "submit-button"
+    And I see "System message set" in the page text
+
+    # remove message to display on front end
+    Then I clear the value in "message"
+    And I click "submit-button"
+    And I see "System message removed" in the page text
+
+    # set message to display on front end
+    When I type "Your pizza is burning" into "message"
+    And I click "submit-button"
+    And I see "System message set" in the page text
+
+    # remove message to display on front end
+    Then I clear the value in "message"
+    And I click "submit-button"
+    And I see "System message removed" in the page text
+
+  Scenario: Try to set empty message on system message
+    Given I visit the admin sign-in page
+    And I log in to admin
+    And I click "system-message-link"
+    Then I am taken to the system message page
+
+    # set message to display on front end
+    When I type " " into "message"
+    And I click "submit-button"
+    And I see "No system message has been set" in the page text
+
   @focus
   Scenario: View feedback sent to the service
     Given I visit the admin sign-in page

--- a/service-admin/src/App/src/Handler/SystemMessageHandler.php
+++ b/service-admin/src/App/src/Handler/SystemMessageHandler.php
@@ -41,22 +41,23 @@ class SystemMessageHandler extends AbstractHandler
 
         if ($request->getMethod() == 'POST') {
             $form->setData($request->getParsedBody());
+            $newMessage = $form->get('message')->getValue();
 
-            if ($form->isValid()) {
-                $newMessage = $form->get('message')->getValue();
-                $confirmMessage = 'System message set';
+            $confirmMessage = "No system message has been set";
 
-                if (empty($newMessage)) {
-                    $this->cache->removeItem('system-message');
-                    $confirmMessage = 'System message removed';
-                } else {
+            if (empty($newMessage) && !is_null($this->cache->getItem('system-message'))) {
+                $this->cache->removeItem('system-message');
+                $confirmMessage = 'System message removed';
+            } else {
+                if ($form->isValid()) {
                     $this->cache->setItem('system-message', $newMessage);
+                    $confirmMessage = 'System message set';
                 }
-
-                $this->setFlashInfoMessage($request, $confirmMessage);
-
-                return $this->redirectToRoute('system.message');
             }
+
+            $this->setFlashInfoMessage($request, $confirmMessage);
+
+            return $this->redirectToRoute('system.message');
         } else {
             $currentMessage = $this->cache->getItem('system-message');
 

--- a/service-admin/src/App/src/Handler/SystemMessageHandler.php
+++ b/service-admin/src/App/src/Handler/SystemMessageHandler.php
@@ -48,8 +48,8 @@ class SystemMessageHandler extends AbstractHandler
             if (empty($newMessage) && !is_null($this->cache->getItem('system-message'))) {
                 $this->cache->removeItem('system-message');
                 $confirmMessage = 'System message removed';
-            } else {
-                if ($form->isValid()) {
+
+            } elseif ($form->isValid() && !empty($newMessage)) {
                     $this->cache->setItem('system-message', $newMessage);
                     $confirmMessage = 'System message set';
                 }

--- a/service-admin/src/App/src/Handler/SystemMessageHandler.php
+++ b/service-admin/src/App/src/Handler/SystemMessageHandler.php
@@ -50,9 +50,8 @@ class SystemMessageHandler extends AbstractHandler
                 $confirmMessage = 'System message removed';
 
             } elseif ($form->isValid() && !empty($newMessage)) {
-                    $this->cache->setItem('system-message', $newMessage);
-                    $confirmMessage = 'System message set';
-                }
+                $this->cache->setItem('system-message', $newMessage);
+                $confirmMessage = 'System message set';
             }
 
             $this->setFlashInfoMessage($request, $confirmMessage);


### PR DESCRIPTION
## Purpose

When I try to remove the system message, I am told that a value is required.

Deleting all of the message, followed by clicking ‘set system message’ should, and has previously, work.

Fixes LPAL-175

## Approach

Reorders logic surrounding setting the system message, adds an additional state when attempting to apply an empty message to system message

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
