### PR TITLE
LPAL-412 Fix for potential session domain issue

### DIFF
--- a/service-front/config/autoload/global.php
+++ b/service-front/config/autoload/global.php
@@ -58,7 +58,7 @@ return [
         'native_settings' => [
 
             // The cookie name used in the session
-            'name' => 'lpa',
+            'name' => 'lpa2',
 
             // Hash settings
             'hash_function' => 'sha512',

--- a/service-front/module/Application/src/Model/Service/Session/SessionFactory.php
+++ b/service-front/module/Application/src/Model/Service/Session/SessionFactory.php
@@ -3,6 +3,7 @@ namespace Application\Model\Service\Session;
 
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
+use Laminas\Console\Request as ConsoleRequest;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
@@ -43,6 +44,20 @@ class SessionFactory implements FactoryInterface {
             foreach ($config['native_settings'] as $k => $v) {
                 ini_set('session.' . $k, $v);
             }
+        }
+
+        //----------------------------------------
+        // Set the cookie domain
+
+        // Only if it's not a Console request.
+        if(!($container->get('Request') instanceof ConsoleRequest)){
+            // This is requirement of the GDS service checker
+
+            // Get the hostname of the current request
+            $hostname = $container->get('Request')->getUri()->getHost();
+
+            // and set it as the domain cookie.
+            ini_set('session.cookie_domain', $hostname);
         }
 
         return new SessionManager();

--- a/service-front/module/Application/tests/Model/Service/Session/SessionFactoryTest.php
+++ b/service-front/module/Application/tests/Model/Service/Session/SessionFactoryTest.php
@@ -10,6 +10,8 @@ use Interop\Container\Exception\ContainerException;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
+use Laminas\Http\Request;
+use Laminas\Http\Uri;
 use Laminas\Session\Exception\RuntimeException;
 
 class SessionFactoryTest extends MockeryTestCase
@@ -24,6 +26,12 @@ class SessionFactoryTest extends MockeryTestCase
     {
         ServiceTestHelper::disableRedisSaveHandler();
 
+        $uri = Mockery::Mock(Uri::class);
+        $uri->shouldReceive('getHost')->andReturn('foo');
+
+        $request = Mockery::Mock(Request::class);
+        $request->shouldReceive('getUri')->andReturn($uri);
+
         $container = Mockery::Mock(ContainerInterface::class);
         $container->shouldReceive('get')
             ->withArgs(['Config'])
@@ -35,6 +43,10 @@ class SessionFactoryTest extends MockeryTestCase
                     ]
                 ]
             ]);
+
+        $container->shouldReceive('get')
+            ->withArgs(['Request'])
+            ->andReturn($request);
 
         $factory = new SessionFactory();
         $result = $factory($container, null, null);


### PR DESCRIPTION
## Purpose

The LPAL-60 fix potentially broke session handling, so that
users who had recently logged into the front-end get a
"session expired" message. This could be because we changed the
domain on the lpa cookie, meaning that some users had multiple
cookies with the same name but overlapping domains. In this
situation, the old invalid cookie may have been checked by the
application, causing the session to appear as invalid.

This does suggest a possible bug in the application, as we
should ensure that we are checking the cookie for the correct
domain when deciding whether a session is invalid.

Fixes [LPAL-412](https://opgtransform.atlassian.net/browse/LPAL-412)

## Approach

Reinstate old code from the sessionmanagerfactory which explicitly sets the session domain.

Change name of session cookie to avoid collision with existing cookies (lpa -> lpa2).

## Learning

n/a

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [x] The product team have tested these changes
