### PR TITLE
LPAL-64 Enable earlier reuse of LPA details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,23 @@
 SHELL := '/bin/bash'
-SENDGRID := $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_email_sendgrid_api_key | jq -r .'SecretString')
-GOVPAY := $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_gov_pay_key | jq -r .'SecretString')
-ORDNANCESURVEY := $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_os_places_hub_license_key | jq -r .'SecretString')
-ADMIN_USERS := $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_common_admin_accounts | jq -r .'SecretString')
-NOTIFY :=  $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_api_notify_api_key | jq -r .'SecretString')
+
+# Must be set to some string.
+# Used to send notifications to end users from service-front.
+SENDGRID ?= $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_email_sendgrid_api_key | jq -r .'SecretString')
+
+# Used by service-front for making payments.
+# Can be disabled in dev, just don't offer to pay when completing LPA.
+GOVPAY ?= $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_gov_pay_key | jq -r .'SecretString')
+
+# Used by service-front for postcode lookup.
+ORDNANCESURVEY ?= $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_front_os_places_hub_license_key | jq -r .'SecretString')
+
+# Used for emails sent by service-api's account cleanup CLI script.
+NOTIFY ?= $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id development/opg_lpa_api_notify_api_key | jq -r .'SecretString')
+
+# Used in service-admin to determine which logged-in user has admin rights.
+# This user is in the test data seeded into the system.
+ADMIN_USERS := "seeded_test_user@digital.justice.gov.uk"
+
 .PHONY: all
 all:
 	@${MAKE} dc-up

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,11 @@ dc-up:
 	export OPG_LPA_COMMON_ADMIN_ACCOUNTS=${ADMIN_USERS}; \
 	docker-compose up
 
+# target for users outside MoJ to run the stack without 3rd party integrations
+.PHONY: dc-up-out
+dc-up-out:
+	@${MAKE} dc-up SENDGRID=- GOVPAY=- NOTIFY=- ORDNANCESURVEY=-
+
 .PHONY: dc-build
 dc-build:
 	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cd opg-lpa
 If you intend to run the application in tandem with 3rd party integrations, you currently require a Ministry of Justice AWS account. If you don't have one of these, you can still run the stack locally, minus these integrations, with:
 
 ```
-make dc-up SENDGRID=- GOVPAY=- ORDNANCESURVEY=- NOTIFY=-
+make dc-up-out
 ```
 
 The LPA Tool service will be available via <https://localhost:7002/home>

--- a/cypress/integration/Reusable.feature
+++ b/cypress/integration/Reusable.feature
@@ -1,0 +1,32 @@
+Feature: Homepage
+
+  I want to be able to visit the dashboard and reuse LPA details
+
+  Background:
+    Given I ignore application exceptions
+
+  @focus, @CleanupFixtures
+  Scenario: PF LPA is reusable after skipping replacement attorneys, certificate provider and people to notify (LPAL-64)
+    Given I create PF LPA test fixture with a donor and attorneys
+    And I log in as appropriate test user
+    And I visit the replacement attorney page for the test fixture lpa
+    And I click "save"
+    And I visit the certificate provider page for the test fixture lpa
+    And I click "skip-certificate-provider"
+    And I visit the people to notify page for the test fixture lpa
+    And I click "save"
+    When I visit the dashboard
+    Then I can see a "Reuse LPA details" link for the test fixture lpa
+
+  @focus, @CleanupFixtures
+  Scenario: HW LPA is reusable after skipping replacement attorneys, certificate provider and people to notify (LPAL-64)
+    Given I create HW LPA test fixture with a donor and attorneys
+    And I log in as appropriate test user
+    And I visit the replacement attorney page for the test fixture lpa
+    And I click "save"
+    And I visit the certificate provider page for the test fixture lpa
+    And I click "skip-certificate-provider"
+    And I visit the people to notify page for the test fixture lpa
+    And I click "save"
+    When I visit the dashboard
+    Then I can see a "Reuse LPA details" link for the test fixture lpa

--- a/cypress/integration/Reusable.feature
+++ b/cypress/integration/Reusable.feature
@@ -13,7 +13,10 @@ Feature: Homepage
     And I click "save"
     And I visit the certificate provider page for the test fixture lpa
     And I click "skip-certificate-provider"
-    And I visit the people to notify page for the test fixture lpa
+    When I visit the dashboard
+    Then I cannot see a "Reuse LPA details" link for the test fixture lpa
+
+    Given I visit the people to notify page for the test fixture lpa
     And I click "save"
     When I visit the dashboard
     Then I can see a "Reuse LPA details" link for the test fixture lpa
@@ -26,7 +29,10 @@ Feature: Homepage
     And I click "save"
     And I visit the certificate provider page for the test fixture lpa
     And I click "skip-certificate-provider"
-    And I visit the people to notify page for the test fixture lpa
+    When I visit the dashboard
+    Then I cannot see a "Reuse LPA details" link for the test fixture lpa
+
+    Given I visit the people to notify page for the test fixture lpa
     And I click "save"
     When I visit the dashboard
     Then I can see a "Reuse LPA details" link for the test fixture lpa

--- a/cypress/integration/common/i_can_see.js
+++ b/cypress/integration/common/i_can_see.js
@@ -1,8 +1,17 @@
 import { Then } from "cypress-cucumber-preprocessor/steps";
 
 Then('I can see a "Reuse LPA details" link for the test fixture lpa', (linkText) => {
+	seeReuseDetailsLink(true);
+});
+
+Then('I cannot see a "Reuse LPA details" link for the test fixture lpa', (linkText) => {
+	seeReuseDetailsLink(false);
+});
+
+const seeReuseDetailsLink = (shouldExist) => {
 	cy.get('@lpaId').then((lpaId) => { 
         const selector = 'a[href*="/user/dashboard/create/' + lpaId + '"]';
-        cy.get(selector);
+        const condition = (shouldExist ? 'exist' : 'not.exist');
+        cy.get(selector).should(condition);
     });
-});
+}

--- a/cypress/integration/common/i_can_see.js
+++ b/cypress/integration/common/i_can_see.js
@@ -1,0 +1,8 @@
+import { Then } from "cypress-cucumber-preprocessor/steps";
+
+Then('I can see a "Reuse LPA details" link for the test fixture lpa', (linkText) => {
+	cy.get('@lpaId').then((lpaId) => { 
+        const selector = 'a[href*="/user/dashboard/create/' + lpaId + '"]';
+        cy.get(selector);
+    });
+});

--- a/cypress/integration/common/i_visit.js
+++ b/cypress/integration/common/i_visit.js
@@ -10,6 +10,10 @@ Then(`I visit the login page`, () => {
     cy.visit('/login');
 })
 
+Then(`I visit the dashboard`, () => {
+    cy.visit('/user/dashboard');
+})
+
 Then(`I visit the type page`, () => {
     cy.visitWithChecks('/lpa/type');
 })

--- a/service-api/module/Application/src/Model/Service/Applications/Collection.php
+++ b/service-api/module/Application/src/Model/Service/Applications/Collection.php
@@ -17,7 +17,26 @@ class Collection extends Paginator
         //  Get the abbreviated details of the LPA
         foreach ($lpas as $lpa) {
             /** @var $lpa Lpa */
-            $applications[] = $lpa->abbreviatedToArray();
+            $lpaData = $lpa->abbreviatedToArray();
+
+            // Append additional useful fields from the LPA which
+            // we can use to determine whether its data is reusable
+            $lpaData['hasCompletedDonor'] = $lpa->hasDonor();
+
+            // PF LPA => hasWhenLpaStarts
+            // HW LPA => hasPrimaryAttorneyDecisions
+            $lpaData['hasCompletedWhenLpaConditions'] = $lpa->hasWhenLpaStarts() ||
+                $lpa->hasPrimaryAttorneyDecisions();
+
+            $lpaData['hasCompletedPrimaryAttorneys'] = $lpa->hasPrimaryAttorney();
+            $lpaData['hasCompletedReplacementAttorneys'] = $lpa->hasDocument() &&
+                array_key_exists(Lpa::REPLACEMENT_ATTORNEYS_CONFIRMED, $lpa->getMetadata());
+            $lpaData['hasCompletedCertificateProvider'] = $lpa->hasCertificateProvider()
+                || $lpa->hasCertificateProviderSkipped();
+            $lpaData['hasCompletedPeopleToNotify'] = $lpa->hasDocument() &&
+                array_key_exists(Lpa::PEOPLE_TO_NOTIFY_CONFIRMED, $lpa->getMetadata());
+
+            $applications[] = $lpaData;
         }
 
         return [

--- a/service-api/module/Application/src/Model/Service/Applications/Collection.php
+++ b/service-api/module/Application/src/Model/Service/Applications/Collection.php
@@ -14,29 +14,10 @@ class Collection extends Paginator
 
         $lpas = iterator_to_array($this->getItemsByPage($this->getCurrentPageNumber()));
 
-        //  Get the abbreviated details of the LPA
+        //  Get the full details of the LPA
         foreach ($lpas as $lpa) {
             /** @var $lpa Lpa */
-            $lpaData = $lpa->abbreviatedToArray();
-
-            // Append additional useful fields from the LPA which
-            // we can use to determine whether its data is reusable
-            $lpaData['hasCompletedDonor'] = $lpa->hasDonor();
-
-            // PF LPA => hasWhenLpaStarts
-            // HW LPA => hasPrimaryAttorneyDecisions
-            $lpaData['hasCompletedWhenLpaConditions'] = $lpa->hasWhenLpaStarts() ||
-                $lpa->hasPrimaryAttorneyDecisions();
-
-            $lpaData['hasCompletedPrimaryAttorneys'] = $lpa->hasPrimaryAttorney();
-            $lpaData['hasCompletedReplacementAttorneys'] = $lpa->hasDocument() &&
-                array_key_exists(Lpa::REPLACEMENT_ATTORNEYS_CONFIRMED, $lpa->getMetadata());
-            $lpaData['hasCompletedCertificateProvider'] = $lpa->hasCertificateProvider()
-                || $lpa->hasCertificateProviderSkipped();
-            $lpaData['hasCompletedPeopleToNotify'] = $lpa->hasDocument() &&
-                array_key_exists(Lpa::PEOPLE_TO_NOTIFY_CONFIRMED, $lpa->getMetadata());
-
-            $applications[] = $lpaData;
+            $applications[] = $lpa->toArray();
         }
 
         return [

--- a/service-api/module/Application/tests/Model/Service/Applications/CollectionTest.php
+++ b/service-api/module/Application/tests/Model/Service/Applications/CollectionTest.php
@@ -19,7 +19,7 @@ class CollectionTest extends TestCase
         $array = $collection->toArray();
 
         $this->assertEquals(count($lpaArray), $array['total']);
-        $this->assertEquals($array['applications'][0], $lpa1->abbreviatedToArray());
-        $this->assertEquals($array['applications'][1], $lpa2->abbreviatedToArray());
+        $this->assertEquals($array['applications'][0], $lpa1->toArray());
+        $this->assertEquals($array['applications'][1], $lpa2->toArray());
     }
 }

--- a/service-api/module/Application/tests/Model/Service/Applications/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Applications/ServiceTest.php
@@ -520,7 +520,7 @@ class ServiceTest extends AbstractServiceTest
         $applications = $apiLpaCollection['applications'];
         $this->assertEquals(1, count($applications));
 
-        $this->assertEquals(($lpas[0])->abbreviatedToArray(), $applications[0]);
+        $this->assertEquals(($lpas[0])->toArray(), $applications[0]);
     }
 
     public function testFetchAllSearchById()
@@ -546,7 +546,7 @@ class ServiceTest extends AbstractServiceTest
         $applications = $apiLpaCollection['applications'];
         $this->assertEquals(1, count($applications));
 
-        $this->assertEquals(($lpas[1])->abbreviatedToArray(), $applications[0]);
+        $this->assertEquals(($lpas[1])->toArray(), $applications[0]);
     }
 
     public function testFetchAllSearchByIdAndFilter()
@@ -596,7 +596,7 @@ class ServiceTest extends AbstractServiceTest
         $applications = $apiLpaCollection['applications'];
         $this->assertEquals(1, count($applications));
 
-        $this->assertEquals(($lpas[0])->abbreviatedToArray(), $applications[0]);
+        $this->assertEquals(($lpas[0])->toArray(), $applications[0]);
     }
 
     public function testFetchAllSearchByName()
@@ -638,7 +638,7 @@ class ServiceTest extends AbstractServiceTest
             ->withArgs([$lpa->getId()])
             ->andReturn($lpa->toArray());
     }
-    
+
     /**
      * @param User $user
      */

--- a/service-front/module/Application/src/Model/Service/Lpa/Application.php
+++ b/service-front/module/Application/src/Model/Service/Lpa/Application.php
@@ -237,8 +237,7 @@ class Application extends AbstractService implements ApiClientAwareInterface
                 $progress = 'Created';
             }
 
-            // Create a record for the returned LPA in an array object;
-            // LPA details are reusable so long as the LPA at least has a donor
+            // Create a record for the returned LPA in an array object
             $result['applications'][$applicationIdx] = new ArrayObject([
                 'id' => $lpa->getId(),
                 'version' => 2,

--- a/service-front/module/Application/tests/Model/Service/Lpa/ApplicationTest.php
+++ b/service-front/module/Application/tests/Model/Service/Lpa/ApplicationTest.php
@@ -33,6 +33,28 @@ class ApplicationTest extends MockeryTestCase
      */
     private $service;
 
+    private function modifiedLPA($id = 5531003157, $completedAt = null, $processingStatus = null, $rejectedDate = null)
+    {
+        $decodeJsonAsArray = TRUE;
+        $arr = json_decode(FixturesData::getHwLpaJson(), $decodeJsonAsArray);
+
+        $arr['id'] = $id;
+
+        if ($completedAt != null) {
+            $arr['completedAt'] = $completedAt;
+        }
+
+        if ($processingStatus) {
+            $arr['metadata'][Lpa::SIRIUS_PROCESSING_STATUS] = $processingStatus;
+        }
+
+        if ($rejectedDate != null) {
+            $arr['metadata'][Lpa::APPLICATION_REJECTED_DATE] = $rejectedDate;
+        }
+
+        return $arr;
+    }
+
     public function setUp() : void
     {
         $identity = Mockery::mock();
@@ -134,42 +156,6 @@ class ApplicationTest extends MockeryTestCase
         $result = $this->service->getLpaSummaries();
 
         $this->assertEquals(['applications' => [],'trackingEnabled' => true], $result);
-    }
-
-    private function modifiedLPA($id = 5531003157, $completedAt = null, $processingStatus = null, $rejectedDate = null)
-    {
-        $lpaJson = FixturesData::getHwLpaJson();
-
-        $lpaJson = str_replace('"id" : 5531003156', '"id" : ' . $id, $lpaJson);
-
-        if ($completedAt != null) {
-            $lpaJson = str_replace(
-                '"completedAt" : "2017-03-24T16:21:52.804Z"',
-                '"completedAt" : "' . $completedAt . '"',
-                $lpaJson
-            );
-        }
-
-        if ($processingStatus) {
-            $lpaJson = str_replace(
-                '"metadata" : {',
-                '"metadata" : {
-                "' . Lpa::SIRIUS_PROCESSING_STATUS . '" : "' . $processingStatus . '",',
-                $lpaJson
-            );
-        }
-
-        if ($rejectedDate != null) {
-            $lpaJson = str_replace(
-                '"metadata" : {',
-                '"metadata" : {
-                 "' . Lpa::APPLICATION_REJECTED_DATE . '" : "' . $rejectedDate . '",',
-                $lpaJson
-            );
-        }
-
-
-        return $lpaJson;
     }
 
     /**

--- a/service-front/module/Application/tests/Model/Service/Lpa/ApplicationTest.php
+++ b/service-front/module/Application/tests/Model/Service/Lpa/ApplicationTest.php
@@ -193,7 +193,8 @@ class ApplicationTest extends MockeryTestCase
                 'updatedAt' => new DateTime('2017-03-24T16:21:52.804000+0000'),
                 'progress' => 'Completed',
                 'rejectedDate' => null,
-                'refreshId' => null
+                'refreshId' => null,
+                'isReusable' => true
             ]),
             new ArrayObject([
                 'id' => 5531003157,
@@ -203,7 +204,8 @@ class ApplicationTest extends MockeryTestCase
                 'updatedAt' => new DateTime('2017-03-24T16:21:52.804000+0000'),
                 'progress' => 'Completed',
                 'rejectedDate' => null,
-                'refreshId' => null
+                'refreshId' => null,
+                'isReusable' => true
             ])
         ], 'trackingEnabled' => true], $result);
     }
@@ -229,7 +231,8 @@ class ApplicationTest extends MockeryTestCase
                 'updatedAt' => new DateTime('2017-03-24T16:21:52.804000+0000'),
                 'progress' => 'Waiting',
                 'rejectedDate' => null,
-                'refreshId' => 5531003157
+                'refreshId' => 5531003157,
+                'isReusable' => true
             ])
         ], 'trackingEnabled' => true], $result);
     }
@@ -255,7 +258,8 @@ class ApplicationTest extends MockeryTestCase
                 'updatedAt' => new DateTime('2017-03-24T16:21:52.804000+0000'),
                 'progress' => 'Processed',
                 'rejectedDate' => '2019-01-2',
-                'refreshId' => 5531003157
+                'refreshId' => 5531003157,
+                'isReusable' => true
             ])
         ], 'trackingEnabled' => true], $result);
     }

--- a/service-front/module/Application/view/application/authenticated/dashboard/index.twig
+++ b/service-front/module/Application/view/application/authenticated/dashboard/index.twig
@@ -16,7 +16,7 @@
                 <li><strong class="bold-small">continue creating</strong> an LPA</li>
                 <li><strong class="bold-small">check the signing dates</strong> on an LPA are in the right order before you send it to OPG - if they're not, we cannot register the LPA and you may have to pay another application fee
                 </li>
-                <li><strong class="bold-small">reuse details from an existing LPA to create a new one</strong> - you can do this once you've completed all sections up to and including the person to notify section, and have added a certificate provider
+                <li><strong class="bold-small">reuse details from an existing LPA to create a new one</strong> - you can do this once you've completed all sections up to and including the person to notify section
                 </li>
             </ul>
         </div>

--- a/service-front/module/Application/view/application/authenticated/dashboard/macros.twig
+++ b/service-front/module/Application/view/application/authenticated/dashboard/macros.twig
@@ -52,7 +52,7 @@
                         {% if lpa.progress in ['Started', 'Created'] %}Continue<span class="visually-hidden"> LPA A{{ lpa.id }}</span>{% else %}View LPA<span class="visually-hidden"> A{{ lpa.id }}</span>{% endif %}
                     </a>
                     <ul class="list-item_secondary_actions">
-                        {% if lpa.progress != 'Started' %}
+                        {% if lpa.isReusable %}
                             <li>
                                 <a href="/lpa/{{ lpa.id }}/date-check" data-journey-click="page:link:navigation: Check signing dates">Check <span class="extra-text">signing</span> dates<span class="visually-hidden"> for A{{ lpa.id }}</span></a>
                             </li>

--- a/service-front/module/Application/view/application/authenticated/lpa/certificate-provider/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/certificate-provider/index.twig
@@ -98,7 +98,7 @@
 
         <div class="form-group">
             <a href="{{ url('lpa/certificate-provider/add', {'lpa-id': lpa.id}) }}" role="button" class="button js-form-popup" data-cy="add-certificate-provider">Add a certificate provider</a>
-            <input type="submit" name="submit" class="button-link button-input-to-link" value="Skip this question for now" data-journey-click="page:link:skip: Skip this question for now" />
+            <input type="submit" name="submit" class="button-link button-input-to-link" value="Skip this question for now" data-journey-click="page:link:skip: Skip this question for now" data-cy="skip-certificate-provider"/>
         </div>
 
         {{ form().closeTag|raw }}


### PR DESCRIPTION
## Purpose

Fixes [LPAL-64]()

## Approach

Modify the logic which determines whether an LPA application is reusable, pushing it out of the template into the service. Rather than using the LPA status, we now look for metadata to show that the LPA has reached the point where people to notify has been confirmed (i.e. user has clicked on the "Save and continue" button on the people to notify page, regardless of whether they've set people to notify).

This PR also includes some code to enable working on this codebase without AWS credentials.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [x] The product team have tested these changes
