### PR TITLE
LPAL-291 - Adds requires to front_docker_build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,7 @@ path_to_live: &path_to_live
         ecr_repository_name_prefix: online-lpa/front
         service_path: service-front
         filters: { branches: { only: [master] } }
+        requires: [node_build_web]
 
     - build_containers_and_push_to_ecr/checkout_docker_build_push_web-app:
         name: admin_docker_build


### PR DESCRIPTION
## Purpose

Adds missing requires to build step to fix deployment to master

Fixes LPAL-####

## Approach

_Explain how your code addresses the purpose of the change_ 

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
