### PR TITLE
LPAL-443 add post release echo to end pipeline job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1155,7 +1155,7 @@ jobs:
           command: |
             export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
             export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
-            echo Terraform workspace: TF_WORKSPACE
+            echo Terraform workspace: $TF_WORKSPACE
             echo Image tag: $IMAGE_TAG
             echo Public Facing Domain: $PUBLIC_FACING_DOMAIN
             echo Front Domain: $FRONT_DOMAIN
@@ -1194,7 +1194,7 @@ jobs:
           command: |
             export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
             export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
-            echo Terraform workspace: TF_WORKSPACE
+            echo Terraform workspace: $TF_WORKSPACE
             echo Image tag: $IMAGE_TAG
             echo Public Facing Domain: $PUBLIC_FACING_DOMAIN
             echo Front Domain: $FRONT_DOMAIN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1153,6 +1153,7 @@ jobs:
       - run:
           name: print deployment values
           command: |
+            export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
             echo Image tag: $IMAGE_TAG
             echo Public Facing Domain: $PUBLIC_FACING_DOMAIN
             echo Front Domain: $FRONT_DOMAIN
@@ -1189,6 +1190,7 @@ jobs:
       - run:
           name: print deployment values
           command: |
+            export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
             echo Image tag: $IMAGE_TAG
             echo Public Facing Domain: $PUBLIC_FACING_DOMAIN
             echo Front Domain: $FRONT_DOMAIN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1140,7 +1140,9 @@ jobs:
           name: Get URLs
           command: |
             export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+            export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
             echo $TF_WORKSPACE
+            echo $IMAGE_TAG
             scripts/pipeline/set_environment_variables/set_slack_env_vars.sh >> $BASH_ENV
 
       - my_slack/notify:
@@ -1151,7 +1153,7 @@ jobs:
       - run:
           name: print deployment values
           command: |
-            echo image tag: $IMAGE_TAG
+            echo Image tag: $IMAGE_TAG
             echo Public Facing Domain: $PUBLIC_FACING_DOMAIN
             echo Front Domain: $FRONT_DOMAIN
             echo Admin Domain: $ADMIN_DOMAIN
@@ -1175,7 +1177,9 @@ jobs:
           name: Get URLs
           command: |
             export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+            export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
             echo $TF_WORKSPACE
+            echo $IMAGE_TAG
             scripts/pipeline/set_environment_variables/set_slack_env_vars.sh >> $BASH_ENV
       - my_slack/notify:
           when: on_success
@@ -1185,7 +1189,7 @@ jobs:
       - run:
           name: print deployment values
           command: |
-            echo image tag: $IMAGE_TAG
+            echo Image tag: $IMAGE_TAG
             echo Public Facing Domain: $PUBLIC_FACING_DOMAIN
             echo Front Domain: $FRONT_DOMAIN
             echo Admin Domain: $ADMIN_DOMAIN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1154,6 +1154,8 @@ jobs:
           name: print deployment values
           command: |
             export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+            export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+            echo Terraform workspace: TF_WORKSPACE
             echo Image tag: $IMAGE_TAG
             echo Public Facing Domain: $PUBLIC_FACING_DOMAIN
             echo Front Domain: $FRONT_DOMAIN
@@ -1191,6 +1193,8 @@ jobs:
           name: print deployment values
           command: |
             export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
+            export TF_WORKSPACE=$(bash ~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
+            echo Terraform workspace: TF_WORKSPACE
             echo Image tag: $IMAGE_TAG
             echo Public Facing Domain: $PUBLIC_FACING_DOMAIN
             echo Front Domain: $FRONT_DOMAIN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1148,7 +1148,13 @@ jobs:
           slack_channel: $BUILD_SLACK_CHANNEL
           template_file: post_environment_domains.j2
           replacement_vars: PUBLIC_FACING_DOMAIN=$PUBLIC_FACING_DOMAIN FRONT_DOMAIN=$FRONT_DOMAIN ADMIN_DOMAIN=$ADMIN_DOMAIN CIRCLE_USERNAME=$CIRCLE_USERNAME CIRCLE_BRANCH=$CIRCLE_BRANCH COMMIT_MESSAGE="$COMMIT_MESSAGE"
-
+      - run:
+          name: print deployment values
+          command: |
+            echo image tag: $IMAGE_TAG
+            echo Public Facing Domain: $PUBLIC_FACING_DOMAIN
+            echo Front Domain: $FRONT_DOMAIN
+            echo Admin Domain: $ADMIN_DOMAIN
   slack_notify_production_release:
     docker:
       - image: circleci/python
@@ -1176,6 +1182,13 @@ jobs:
           slack_channel: $LIVE_SLACK_CHANNEL
           template_file: production_release_notification.j2
           replacement_vars: PUBLIC_FACING_DOMAIN=$PUBLIC_FACING_DOMAIN FRONT_DOMAIN=$FRONT_DOMAIN ADMIN_DOMAIN=$ADMIN_DOMAIN CIRCLE_USERNAME=$CIRCLE_USERNAME CIRCLE_BRANCH=$CIRCLE_BRANCH COMMIT_MESSAGE="$COMMIT_MESSAGE"
+      - run:
+          name: print deployment values
+          command: |
+            echo image tag: $IMAGE_TAG
+            echo Public Facing Domain: $PUBLIC_FACING_DOMAIN
+            echo Front Domain: $FRONT_DOMAIN
+            echo Admin Domain: $ADMIN_DOMAIN
   ecr_scan_results:
     docker:
       - image: circleci/python


### PR DESCRIPTION
## Purpose
Add deployment information that will be useful for developers when debugging issues, and redeployment of the service in case of an error.

Fixes LPAL-443

## Approach

Add some echo commands which show the relevant deployment info

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
