### PR TITLE
LPAL-444 Fix reuse link tests by fixing csrf issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,7 @@ dc-up-out:
 
 .PHONY: dc-build
 dc-build:
-	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
-	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
-	export OPG_LPA_API_NOTIFY_API_KEY=${NOTIFY}; \
-	export OPG_LPA_FRONT_OS_PLACES_HUB_LICENSE_KEY=${ORDNANCESURVEY} ; \
-	export OPG_LPA_COMMON_ADMIN_ACCOUNTS=${ADMIN_USERS}; \
-	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build
-
+	@COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build
 
 # remove docker containers, volumes, images left by existing system, remove vendor folders, rebuild everything
 # with no-cache
@@ -87,12 +81,7 @@ dc-build:
 .PHONY: dc-build-clean
 dc-build-clean:
 	@${MAKE} dc-down
-	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
-	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
-	export OPG_LPA_API_NOTIFY_API_KEY=${NOTIFY}; \
-	export OPG_LPA_FRONT_OS_PLACES_HUB_LICENSE_KEY=${ORDNANCESURVEY} ; \
-	export OPG_LPA_COMMON_ADMIN_ACCOUNTS=${ADMIN_USERS}; \
-	docker system prune -f --volumes; \
+	@docker system prune -f --volumes; \
 	docker rmi lpa-pdf-app || true; \
 	docker rmi lpa-admin-web || true; \
 	docker rmi lpa-admin-app || true; \
@@ -115,12 +104,7 @@ dc-build-clean:
 .PHONY: reset-front
 reset-front:
 	@${MAKE} dc-down
-	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
-	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
-	export OPG_LPA_API_NOTIFY_API_KEY=${NOTIFY}; \
-	export OPG_LPA_FRONT_OS_PLACES_HUB_LICENSE_KEY=${ORDNANCESURVEY} ; \
-	export OPG_LPA_COMMON_ADMIN_ACCOUNTS=${ADMIN_USERS}; \
-	docker system prune -f --volumes; \
+	@docker system prune -f --volumes; \
 	docker rmi lpa-front-web || true; \
 	docker rmi lpa-front-app || true; \
 	rm -fr ./service-front/node_modules/parse-json/vendor; \
@@ -135,12 +119,7 @@ reset-front:
 .PHONY: reset-api
 reset-api:
 	@${MAKE} dc-down
-	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
-	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
-	export OPG_LPA_API_NOTIFY_API_KEY=${NOTIFY}; \
-	export OPG_LPA_FRONT_OS_PLACES_HUB_LICENSE_KEY=${ORDNANCESURVEY} ; \
-	export OPG_LPA_COMMON_ADMIN_ACCOUNTS=${ADMIN_USERS}; \
-	docker system prune -f --volumes; \
+	@docker system prune -f --volumes; \
 	docker rmi lpa-api-web || true; \
 	docker rmi lpa-api-app || true; \
 	rm -fr ./service-api/vendor; \
@@ -150,12 +129,7 @@ reset-api:
 
 .PHONY: dc-down
 dc-down:
-	@export OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY=${SENDGRID}; \
-	export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
-	export OPG_LPA_API_NOTIFY_API_KEY=${NOTIFY}; \
-	export OPG_LPA_FRONT_OS_PLACES_HUB_LICENSE_KEY=${ORDNANCESURVEY} ; \
-	export OPG_LPA_COMMON_ADMIN_ACCOUNTS=${ADMIN_USERS}; \
-	docker-compose down --remove-orphans
+	@docker-compose down --remove-orphans
 
 .PHONY: dc-front-unit-tests
 dc-front-unit-tests:

--- a/cypress/integration/ReusableHW.feature
+++ b/cypress/integration/ReusableHW.feature
@@ -1,0 +1,26 @@
+Feature: Homepage
+
+  I want to be able to visit the dashboard and reuse LPA details
+
+  Background:
+    Given I ignore application exceptions
+
+  @focus, @CleanupFixtures, @Reusable
+  Scenario: HW LPA is reusable after skipping replacement attorneys, certificate provider and people to notify (LPAL-64)
+    Given I create HW LPA test fixture with a donor and attorneys
+    And I log in as appropriate test user
+
+    # ** CUT Above Here ** This comment line needed for stitching feature files. Please do not remove
+    And I visit the replacement attorney page for the test fixture lpa
+    And I click "save"
+    And I am taken to the certificate provider page for the test fixture lpa
+    And I click "skip-certificate-provider"
+
+    When I visit the dashboard
+    Then I cannot see a "Reuse LPA details" link for the test fixture lpa
+
+    Given I visit the people to notify page for the test fixture lpa
+    And I click "save"
+    When I visit the dashboard
+    Then I can see a "Reuse LPA details" link for the test fixture lpa
+    And I visit the replacement attorney page for the test fixture lpa

--- a/cypress/integration/ReusablePF.feature
+++ b/cypress/integration/ReusablePF.feature
@@ -9,10 +9,13 @@ Feature: Homepage
   Scenario: PF LPA is reusable after skipping replacement attorneys, certificate provider and people to notify (LPAL-64)
     Given I create PF LPA test fixture with a donor and attorneys
     And I log in as appropriate test user
+
+    # ** CUT Above Here ** This comment line needed for stitching feature files. Please do not remove
     And I visit the replacement attorney page for the test fixture lpa
     And I click "save"
-    And I visit the certificate provider page for the test fixture lpa
+    And I am taken to the certificate provider page for the test fixture lpa
     And I click "skip-certificate-provider"
+
     When I visit the dashboard
     Then I cannot see a "Reuse LPA details" link for the test fixture lpa
 
@@ -20,19 +23,4 @@ Feature: Homepage
     And I click "save"
     When I visit the dashboard
     Then I can see a "Reuse LPA details" link for the test fixture lpa
-
-  @focus, @CleanupFixtures, @Reusable
-  Scenario: HW LPA is reusable after skipping replacement attorneys, certificate provider and people to notify (LPAL-64)
-    Given I create HW LPA test fixture with a donor and attorneys
-    And I log in as appropriate test user
     And I visit the replacement attorney page for the test fixture lpa
-    And I click "save"
-    And I visit the certificate provider page for the test fixture lpa
-    And I click "skip-certificate-provider"
-    When I visit the dashboard
-    Then I cannot see a "Reuse LPA details" link for the test fixture lpa
-
-    Given I visit the people to notify page for the test fixture lpa
-    And I click "save"
-    When I visit the dashboard
-    Then I can see a "Reuse LPA details" link for the test fixture lpa

--- a/cypress/integration/common/i_am_taken_to.js
+++ b/cypress/integration/common/i_am_taken_to.js
@@ -115,6 +115,10 @@ Then(`I am taken to the complete page`, () => {
     checkOnPageWithPath('complete');
     cy.contains('Last steps');
 });
+
+Then(`I am taken to the certificate provider page for the test fixture lpa`, () => {
+    checkOnPageWithPath('certificate-provider');
+})
  
 Then(`I am taken to the donor page`, () => {
     // We arrive at the donor page when we've just created an lpa through the web, so we store the lpaId for future use at this point

--- a/cypress/integration/common/i_can_see.js
+++ b/cypress/integration/common/i_can_see.js
@@ -1,15 +1,15 @@
 import { Then } from "cypress-cucumber-preprocessor/steps";
 
 Then('I can see a "Reuse LPA details" link for the test fixture lpa', (linkText) => {
-	seeReuseDetailsLink(true);
+    seeReuseDetailsLink(true);
 });
 
 Then('I cannot see a "Reuse LPA details" link for the test fixture lpa', (linkText) => {
-	seeReuseDetailsLink(false);
+    seeReuseDetailsLink(false);
 });
 
 const seeReuseDetailsLink = (shouldExist) => {
-	cy.get('@lpaId').then((lpaId) => { 
+    cy.get('@lpaId').then((lpaId) => {
         const selector = 'a[href*="/user/dashboard/create/' + lpaId + '"]';
         const condition = (shouldExist ? 'exist' : 'not.exist');
         cy.get(selector).should(condition);

--- a/cypress/integration/common/i_click.js
+++ b/cypress/integration/common/i_click.js
@@ -4,12 +4,20 @@ import { Then } from "cypress-cucumber-preprocessor/steps";
 // been temporarily disabled while the page is loading. This may need ultimately to be done for more or even all steps here
  
 Then(`I click {string}`, (clickable) => {
-    // if this results in an Oops, then retry the click
-    // we currently believe this to be caused by the CSRF problem, which we intend to fix fully in future
-    // and this retry step will be able to be removed from the tests
-    cy.get("[data-cy=" + clickable + "]").should('not.be.disabled').click().document().then(docStr => {
-        if (docStr.documentElement.innerHTML.includes('Oops! Something went wrong with the information you entered.')) {
+    // If this results in an Oops, then retry the click.
+    // We currently believe this to be caused by the CSRF problem, which we intend to fix fully in future
+    // and this retry step will be able to be removed from the tests.
+    // Also note that CSRF errors can also occur without "Oops" showing on the page. Examples
+    // are when the CSRF token is incorrect when clicking "Save and continue" on the replacement
+    // attorneys page - the title says "Error" but there is no indication of what the error is
+    // in the page itself.
+    cy.get("[data-cy=" + clickable + "]").should('not.be.disabled').click().document().then(doc => {
+        if (doc.documentElement.innerHTML.includes('Oops! Something went wrong with the information you entered.')) {
             cy.log("Received the Oops! Something went wrong with the information you entered message, so retrying the click");
+            cy.get("[data-cy=" + clickable + "]").click();
+        }
+        else if (doc.title.startsWith('Error')) {
+            cy.log("Saw 'Error' in page title, so retrying the click");
             cy.get("[data-cy=" + clickable + "]").click();
         }
     });
@@ -45,4 +53,3 @@ Then(`If I am on dashboard I click to create lpa`, () => {
         }
     });
 })
-

--- a/cypress/integration/common/i_visit.js
+++ b/cypress/integration/common/i_visit.js
@@ -49,10 +49,6 @@ Then(`I visit the replacement attorney page for the test fixture lpa`, () => {
     visitPageForTestFixture('replacement-attorney');
 })
 
-Then(`I visit the certificate provider page for the test fixture lpa`, () => {
-    visitPageForTestFixture('certificate-provider');
-})
-
 Then(`I visit the people to notify page for the test fixture lpa`, () => {
     visitPageForTestFixture('people-to-notify');
 })

--- a/cypress/stitch.sh
+++ b/cypress/stitch.sh
@@ -3,6 +3,7 @@
 cat cypress/integration/LpaTypePF.feature | sed "s/@CreateLpa/@StitchedPF/" > cypress/integration/StitchedCreatePFLpa.feature 
 awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/integration/DonorPF.feature >> cypress/integration/StitchedCreatePFLpa.feature 
 awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/integration/AttorneysPF.feature >> cypress/integration/StitchedCreatePFLpa.feature 
+awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/integration/ReusablePF.feature >> cypress/integration/StitchedCreatePFLpa.feature
 awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/integration/ReplacementAttorneysPF.feature >> cypress/integration/StitchedCreatePFLpa.feature 
 awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/integration/CertProviderPF.feature >> cypress/integration/StitchedCreatePFLpa.feature 
 awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/integration/PeopleToNotifyPF.feature >> cypress/integration/StitchedCreatePFLpa.feature 
@@ -18,6 +19,7 @@ awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/inte
 cat cypress/integration/LpaTypeHW.feature | sed "s/@CreateLpa/@StitchedHW/" > cypress/integration/StitchedCreateHWLpa.feature 
 awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/integration/DonorHW.feature >> cypress/integration/StitchedCreateHWLpa.feature 
 awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/integration/AttorneysHW.feature >> cypress/integration/StitchedCreateHWLpa.feature 
+awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/integration/ReusableHW.feature >> cypress/integration/StitchedCreateHWLpa.feature
 awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/integration/ReplacementAttorneysHW.feature >> cypress/integration/StitchedCreateHWLpa.feature 
 awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/integration/CertProviderHW.feature >> cypress/integration/StitchedCreateHWLpa.feature 
 awk '/needed for stitching/,0{if (!/needed for stitching/)print}' < cypress/integration/PeopleToNotifyHW.feature >> cypress/integration/StitchedCreateHWLpa.feature 

--- a/node-build-assets/docker/Dockerfile
+++ b/node-build-assets/docker/Dockerfile
@@ -4,10 +4,10 @@ FROM alpine:latest
 RUN apk add ruby
 RUN apk add npm
 
-RUN npm install -g grunt-cli \
-    && npm install -g grunt-contrib-watch \
-    && npm install -g sass
+WORKDIR /app
 
-WORKDIR /service-front
+COPY ./node-build-assets/docker/start.sh /app/
+RUN npm install -g grunt-cli grunt-contrib-watch sass && \
+    chmod +x /app/start.sh
 
-CMD ["grunt", "build", "watch"]
+CMD ["/app/start.sh"]

--- a/node-build-assets/docker/start.sh
+++ b/node-build-assets/docker/start.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cd /service-front
 npm install grunt
-grunt build watch
+grunt build_js_dev build_css watch

--- a/node-build-assets/docker/start.sh
+++ b/node-build-assets/docker/start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd /service-front
+npm install grunt
+grunt build watch

--- a/service-front/Gruntfile.js
+++ b/service-front/Gruntfile.js
@@ -66,7 +66,7 @@ module.exports = function (grunt) {
       },
       js: {
         files: 'assets/js/**/*.js',
-        tasks: ['concat', 'uglify']
+        tasks: ['concat', 'copy:jsdev']
       },
       templates: {
         files: ['<%= handlebars.compile.src %>'],
@@ -143,6 +143,11 @@ module.exports = function (grunt) {
           process: injectEnvVars
         },
         flatten: true
+      },
+
+      jsdev: {
+        src: 'public/assets/v2/js/application.js',
+        dest: 'public/assets/v2/js/application.min.js'
       }
     },
 
@@ -287,6 +292,7 @@ module.exports = function (grunt) {
   // define tasks
   grunt.registerTask('test', ['scsslint', 'jshint']);
   grunt.registerTask('build_js', ['copy:jsenv', 'handlebars', 'concat', 'uglify']);
+  grunt.registerTask('build_js_dev', ['copy:jsenv', 'handlebars', 'concat', 'copy:jsdev']);
   grunt.registerTask('build_css', ['sass', 'replace', 'copy:css', 'cssmin']);
   grunt.registerTask('build', ['build_js', 'build_css']);
 };

--- a/tests/python-api-client/lpaapi.py
+++ b/tests/python-api-client/lpaapi.py
@@ -39,7 +39,7 @@ def deleteViaAPI(lpaId, jsonData, pathSuffix = ''):
     pathTemplate = '{apiRoot}/v2/user/{userId}/applications/{lpaId}/{pathSuffix}'
     fullPath = pathTemplate.format(apiRoot = apiRoot, userId = userId, lpaId = lpaId, pathSuffix = pathSuffix)
     r = s.delete(fullPath, headers=token)
-    print(r)
+    print(r,file=sys.stderr)
 
 def authenticate(username = "seeded_test_user@digital.justice.gov.uk", password = "Pass1234"):
     # authenticate using the suppled creds, returning the resulting token and the userId
@@ -64,7 +64,7 @@ def deleteLpa(lpaId):
     lpaPath = f'{apiRoot}/v2/user/{userId}/applications/{lpaId}'
     emptyData = []
     r = s.delete(lpaPath, headers=token)
-    print(r)
+    print(r,file=sys.stderr)
 
 def setLpaType(lpaId, lpaType = 'health-and-welfare'):
     lpaTypeJson = {"type": lpaType}
@@ -128,7 +128,7 @@ def deletePrimaryAttorney(lpaId, index = 1):
     token, userId = authenticate()
     primaryAttorneyPath = f'{apiRoot}/v2/user/{userId}/applications/{lpaId}/primary-attorneys/{index}'
     r = s.delete(primaryAttorneyPath, headers=token)
-    print(r)
+    print(r,file=sys.stderr)
 
 def addReplacementAttorney(lpaId):
     replacementAttorneyDetails = {"name":{"title":"Ms","first":"Isobel","last":"Ward"},"dob":{"date":"1937-02-01T00:00:00.000000+0000"},"id":None,"address":{"address1":"2 Westview","address2":"Staplehay","address3":"Trull, Taunton, Somerset","postcode":"TA3 7HF"},"email":None,"type":"human"}
@@ -142,7 +142,7 @@ def deleteReplacementAttorney(lpaId, index = 1):
     token, userId = authenticate()
     replacementAttorneyPath = f'{apiRoot}/v2/user/{userId}/applications/{lpaId}/replacement-attorneys/{index}'
     r = s.delete(replacementAttorneyPath, headers=token)
-    print(r)
+    print(r,file=sys.stderr)
 
 def setReplacementAttorneysConfirmed(lpaId):
     token, userId = authenticate()
@@ -203,5 +203,5 @@ def getPdf1(lpaId):
     token, userId = authenticate()
     pdf1Path = f'{apiRoot}/v2/user/{userId}/applications/{lpaId}/pdfs/lp1'
     r = s.get(pdf1Path, headers=token )
-    print(r)
-    print(r.content)
+    print(r,file=sys.stderr)
+    print(r.content,file=sys.stderr)


### PR DESCRIPTION
## Purpose

Draft PR to demo approach to dealing with Laminas session mangling.

Important commit is 7b727d1d5 where I bypass Laminas session handling in the Csrf validator, instead writing the CSRF token directly with the Redis client. This code could be moved up to the AbstractCsrfForm initialisation config.

Fixes LPAL-444

## Approach

_Explain how your code addresses the purpose of the change_ 

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
