### PR TITLE
LPAL-459 Escape string used to query for LPAs

### DIFF
--- a/service-api/module/Application/src/Model/DataAccess/Postgres/ApplicationData.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/ApplicationData.php
@@ -110,20 +110,19 @@ class ApplicationData extends AbstractBase implements ApplicationRepository\Appl
      */
     public function count(array $criteria) : int
     {
-        $sql    = new Sql($this->getZendDb());
+        $adapter = $this->getZendDb();
+        $sql    = new Sql($adapter);
         $select = $sql->select(self::APPLICATIONS_TABLE);
 
         $select->columns(['count' => new Expression('count(*)')]);
 
         if (isset($criteria['search'])) {
-            $select->where([new Expression("search ~* '{$criteria['search']['$regex']}'")]);
+            $quoted = $adapter->getPlatform()->quoteValue($criteria['search']);
+            $select->where([new Expression("search ~* {$quoted}")]);
             unset($criteria['search']);
         }
 
         $select->where($criteria);
-
-        // Below echo left purposely to view the prepared sql query for test
-        //  echo $select->getSqlString($this->getZendDb()->getPlatform())."\n";
 
         $result = $sql->prepareStatementForSqlObject($select)->execute();
 
@@ -141,11 +140,13 @@ class ApplicationData extends AbstractBase implements ApplicationRepository\Appl
      */
     public function fetch(array $criteria, array $options = []) : Traversable
     {
-        $sql    = new Sql($this->getZendDb());
+        $adapter = $this->getZendDb();
+        $sql    = new Sql($adapter);
         $select = $sql->select(self::APPLICATIONS_TABLE);
 
         if (isset($criteria['search'])) {
-            $select->where([new Expression("search ~* '{$criteria['search']['$regex']}'")]);
+            $quoted = $adapter->getPlatform()->quoteValue($criteria['search']);
+            $select->where([new Expression("search ~* {$quoted}")]);
             unset($criteria['search']);
         }
 

--- a/service-api/module/Application/src/Model/Service/Applications/Service.php
+++ b/service-api/module/Application/src/Model/Service/Applications/Service.php
@@ -176,10 +176,7 @@ class Service extends AbstractService
                     $filter['id'] = (int)$ident;
                 } elseif (strlen($search) >= 3) {
                     // Otherwise assume it's a name, and only search if 3 chars or longer
-                    $filter['search'] = [
-                        '$regex' => '.*' . $search . '.*',
-                        '$options' => 'i',
-                    ];
+                    $filter['search'] = $search;
                 }
             }
         }

--- a/service-api/module/Application/tests/Model/Service/Applications/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Applications/ServiceTest.php
@@ -608,10 +608,7 @@ class ServiceTest extends AbstractServiceTest
 
         $this->setFetchAllExpectations([
             'user' => $user->getId(),
-            'search' => [
-                '$regex' => '.*' . $lpas[0]->document->donor->name . '.*',
-                '$options' => 'i',
-            ],
+            'search' => $lpas[0]->document->donor->name
         ], []);
 
         $serviceBuilder = new ServiceBuilder();


### PR DESCRIPTION
## Purpose

Fixes [LPAL-459](https://opgtransform.atlassian.net/browse/LPAL-459)

## Approach

Use platform-specific quoteValue() method to escape the string
passed into the SQL statement used to query for LPAs by
donor name or LPA ID.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
