### PR TITLE
LPAL-462 ApplicationData unit tests

### DIFF
--- a/service-api/module/Application/src/Model/DataAccess/Postgres/AbstractBase.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/AbstractBase.php
@@ -3,6 +3,9 @@ namespace Application\Model\DataAccess\Postgres;
 
 use Application\Logging\LoggerTrait;
 use Laminas\Db\Adapter\Adapter as ZendDbAdapter;
+use Laminas\Db\Metadata\Source\Factory as DbMetadataFactory;
+use Laminas\Db\ResultSet;
+use Laminas\Db\Sql\Sql;
 
 class AbstractBase {
     use LoggerTrait;
@@ -27,7 +30,7 @@ class AbstractBase {
      * @param ZendDbAdapter $adapter
      * @param array $config
      */
-    public final function __construct(ZendDbAdapter $adapter, array $config)
+    public function __construct(ZendDbAdapter $adapter, array $config)
     {
         $this->adapter = $adapter;
         $this->config = $config;
@@ -50,4 +53,42 @@ class AbstractBase {
         return $this->config;
     }
 
+    /**
+     * Returns table object for given name.
+     * @return ???
+     */
+    protected function getTable(string $tableName)
+    {
+        $metadata = DbMetadataFactory::createSourceFromAdapter($this->adapter);
+        return $metadata->getTable($tableName);
+    }
+
+    /**
+     * Perform a raw SQL query via the adapter.
+     * @return ResultSet
+     */
+    protected function rawQuery(string $query)
+    {
+        return $this->adapter->query($query, $this->adapter::QUERY_MODE_EXECUTE);
+    }
+
+    /**
+     * Quote a string for use in a SQL query.
+     * This returns the string with quote marks round it and escapes
+     * any single quotes.
+     * @return string
+     */
+    protected function quoteValue(string $toQuote)
+    {
+        return $this->adapter->getPlatform()->quoteValue($toQuote);
+    }
+
+    /**
+     * Create a SQL statement ready for addition of clauses etc.
+     * @return Sql
+     */
+    protected function createSql()
+    {
+        return new Sql($this->adapter);
+    }
 }

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/AbstractBase.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/AbstractBase.php
@@ -3,9 +3,6 @@ namespace Application\Model\DataAccess\Postgres;
 
 use Application\Logging\LoggerTrait;
 use Laminas\Db\Adapter\Adapter as ZendDbAdapter;
-use Laminas\Db\Metadata\Source\Factory as DbMetadataFactory;
-use Laminas\Db\ResultSet;
-use Laminas\Db\Sql\Sql;
 
 class AbstractBase {
     use LoggerTrait;
@@ -30,7 +27,7 @@ class AbstractBase {
      * @param ZendDbAdapter $adapter
      * @param array $config
      */
-    public function __construct(ZendDbAdapter $adapter, array $config)
+    public final function __construct(ZendDbAdapter $adapter, array $config)
     {
         $this->adapter = $adapter;
         $this->config = $config;
@@ -53,42 +50,4 @@ class AbstractBase {
         return $this->config;
     }
 
-    /**
-     * Returns table object for given name.
-     * @return ???
-     */
-    public function getTable(string $tableName)
-    {
-        $metadata = DbMetadataFactory::createSourceFromAdapter($this->adapter);
-        return $metadata->getTable($tableName);
-    }
-
-    /**
-     * Perform a raw SQL query via the adapter.
-     * @return ResultSet
-     */
-    public function rawQuery(string $query)
-    {
-        return $this->adapter->query($query, $this->adapter::QUERY_MODE_EXECUTE);
-    }
-
-    /**
-     * Quote a string for use in a SQL query.
-     * This returns the string with quote marks round it and escapes
-     * any single quotes.
-     * @return string
-     */
-    public function quoteValue(string $toQuote)
-    {
-        return $this->adapter->getPlatform()->quoteValue($toQuote);
-    }
-
-    /**
-     * Create a SQL statement ready for addition of clauses etc.
-     * @return Sql
-     */
-    public function createSql()
-    {
-        return new Sql($this->adapter);
-    }
 }

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/AbstractBase.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/AbstractBase.php
@@ -57,7 +57,7 @@ class AbstractBase {
      * Returns table object for given name.
      * @return ???
      */
-    protected function getTable(string $tableName)
+    public function getTable(string $tableName)
     {
         $metadata = DbMetadataFactory::createSourceFromAdapter($this->adapter);
         return $metadata->getTable($tableName);
@@ -67,7 +67,7 @@ class AbstractBase {
      * Perform a raw SQL query via the adapter.
      * @return ResultSet
      */
-    protected function rawQuery(string $query)
+    public function rawQuery(string $query)
     {
         return $this->adapter->query($query, $this->adapter::QUERY_MODE_EXECUTE);
     }
@@ -78,7 +78,7 @@ class AbstractBase {
      * any single quotes.
      * @return string
      */
-    protected function quoteValue(string $toQuote)
+    public function quoteValue(string $toQuote)
     {
         return $this->adapter->getPlatform()->quoteValue($toQuote);
     }
@@ -87,7 +87,7 @@ class AbstractBase {
      * Create a SQL statement ready for addition of clauses etc.
      * @return Sql
      */
-    protected function createSql()
+    public function createSql()
     {
         return new Sql($this->adapter);
     }

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/ApplicationData.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/ApplicationData.php
@@ -6,8 +6,6 @@ use PDOException;
 use EmptyIterator;
 use Traversable;
 use Opg\Lpa\DataModel\Lpa\Lpa;
-use Laminas\Db\Adapter\Adapter as ZendDbAdapter;
-use Laminas\Db\Sql\Sql;
 use Laminas\Db\Sql\Predicate\Operator;
 use Laminas\Db\Sql\Predicate\Expression;
 use Laminas\Db\Sql\Predicate\IsNull;
@@ -140,7 +138,10 @@ class ApplicationData implements ApplicationRepository\ApplicationRepositoryInte
             unset($criteria['search']);
         }
 
-        $select->where($criteria);
+        // any remaining criteria are added as additional where conditions
+        if ($criteria !== []) {
+            $select->where($criteria);
+        }
 
         $result = $sql->prepareStatementForSqlObject($select)->execute();
 
@@ -167,7 +168,9 @@ class ApplicationData implements ApplicationRepository\ApplicationRepositoryInte
             unset($criteria['search']);
         }
 
-        $select->where($criteria);
+        if ($criteria !== []) {
+            $select->where($criteria);
+        }
 
         if (isset($options['skip']) && $options['skip'] !== 0) {
             $select->offset($options['skip']);

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/DataFactory.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/DataFactory.php
@@ -17,16 +17,28 @@ class DataFactory implements FactoryInterface
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         // Ensure that the request class exists
-        if (!(class_exists($requestedName) && is_subclass_of($requestedName, AbstractBase::class))) {
-            throw new \RuntimeException("Class {$requestedName} cannot be created with this factory");
+        if (!class_exists($requestedName)) {
+            throw new \RuntimeException("Class {$requestedName} does not exist");
         };
 
-        //---
+        // Special treatment for ApplicationData as it is in the process of being refactored
+        if ($requestedName === ApplicationData::class) {
+            $dbWrapper = new AbstractBase(
+                $container->get('ZendDbAdapter'),
+                $container->get('Config')
+            );
 
-        $test =  new $requestedName(
+            return new ApplicationData($dbWrapper);
+        }
+
+        // Create subclasses of AbstractBase
+        if (!is_subclass_of($requestedName, AbstractBase::class)) {
+            throw new \RuntimeException("Class {$requestedName} cannot be created with this factory");
+        }
+
+        return new $requestedName(
             $container->get('ZendDbAdapter'),
             $container->get('Config')
         );
-        return $test;
     }
 }

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/DataFactory.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/DataFactory.php
@@ -23,15 +23,11 @@ class DataFactory implements FactoryInterface
 
         // Special treatment for ApplicationData as it is in the process of being refactored
         if ($requestedName === ApplicationData::class) {
-            $dbWrapper = new AbstractBase(
-                $container->get('ZendDbAdapter'),
-                $container->get('Config')
-            );
-
-            return new ApplicationData($dbWrapper);
+            $dbWrapper = new DbWrapper($container->get('ZendDbAdapter'));
+            return new ApplicationData($dbWrapper, $container->get('Config'));
         }
 
-        // Create subclasses of AbstractBase
+        // Create subclasses of AbstractBase the old way
         if (!is_subclass_of($requestedName, AbstractBase::class)) {
             throw new \RuntimeException("Class {$requestedName} cannot be created with this factory");
         }

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/DbWrapper.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/DbWrapper.php
@@ -1,0 +1,78 @@
+<?php
+namespace Application\Model\DataAccess\Postgres;
+
+use Application\Logging\LoggerTrait;
+use Laminas\Db\Adapter\Adapter;
+use Laminas\Db\Metadata\Object\TableObject;
+use Laminas\Db\Metadata\Source\Factory as DbMetadataFactory;
+use Laminas\Db\ResultSet;
+use Laminas\Db\Sql\Sql;
+
+/**
+ * Long term plan is to move all subclasses of AbstractBase to instead
+ * have a DbWrapper instance injected into them, to make them testable.
+ * See DataFactory.php which shows the pattern for creating instances
+ * of *Data classes using DbWrapper.
+ */
+class DbWrapper {
+    /**
+     * Time format to use when converting DateTime to a string.
+     */
+    const TIME_FORMAT = 'Y-m-d\TH:i:s.uO'; // ISO8601 including microseconds
+
+    /**
+     * @var Adapter
+     */
+    private $adapter;
+
+    /**
+     * Constructor.
+     * @param Adapter $adapter
+     */
+    public function __construct(Adapter $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * Returns table object for given name.
+     * @param string $tableName Name of table to retrieve metadata for
+     * @return TableObject
+     */
+    public function getTable(string $tableName) : TableObject
+    {
+        $metadata = DbMetadataFactory::createSourceFromAdapter($this->adapter);
+        return $metadata->getTable($tableName);
+    }
+
+    /**
+     * Perform a raw SQL query via the adapter.
+     * @param string $query Raw SQL string to execute on adapter
+     * @return ResultSet
+     */
+    public function rawQuery(string $query) : ResultSet
+    {
+        return $this->adapter->query($query, $this->adapter::QUERY_MODE_EXECUTE);
+    }
+
+    /**
+     * Quote a string for use in a SQL query.
+     * This returns the string with quote marks round it and escapes
+     * any single quotes.
+     * @param string $toQuote String to be quoted
+     * @return string
+     */
+    public function quoteValue(string $toQuote) : string
+    {
+        return $this->adapter->getPlatform()->quoteValue($toQuote);
+    }
+
+    /**
+     * Create a SQL statement ready for addition of clauses etc.
+     * @return Sql
+     */
+    public function createSql() : Sql
+    {
+        return new Sql($this->adapter);
+    }
+}

--- a/service-api/module/Application/tests/Model/DataAccess/Postgres/ApplicationDataTest.php
+++ b/service-api/module/Application/tests/Model/DataAccess/Postgres/ApplicationDataTest.php
@@ -7,8 +7,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Application\Model\DataAccess\Postgres\ApplicationData;
 use Application\Model\DataAccess\Postgres\DbWrapper;
 use Laminas\Db\Adapter\Driver\Pdo\Result;
-use Laminas\Db\Sql\Select;
-use Laminas\Db\Sql\Sql;
 
 
 class ApplicationDataTest extends MockeryTestCase
@@ -16,42 +14,29 @@ class ApplicationDataTest extends MockeryTestCase
     public function testCount() : void
     {
         $expectedCount = 10;
+        $criteria = [
+            'search' => "o'connor",
+            'user' => 1,
+        ];
 
         // mocks
         $dbWrapperMock = Mockery::Mock(DbWrapper::class);
-        $sqlMock = Mockery::Mock(Sql::class);
-        $selectMock = Mockery::Mock(Select::class);
         $resultMock = Mockery::Mock(Result::class);
 
         // expectations
-        $dbWrapperMock->shouldReceive('createSql')
-            ->andReturn($sqlMock);
-        $sqlMock->shouldReceive('select')
-            ->andReturn($selectMock);
-        $selectMock->shouldReceive('columns')
-            ->andReturn($selectMock);
-        $dbWrapperMock->shouldReceive('quoteValue')
-            ->with("o'connor")
-            ->andReturn("'o''connor'");
-
-        // confirm the expression passed to where() has the escaped string
-        $selectMock->shouldReceive('where')
-            ->with(Mockery::on(function ($args) {
-                return $args[0]->getExpression() === "search ~* 'o''connor'";
-            }))
-            ->once();
-
-        // confirm additional criteria are appended to where
-        $selectMock->shouldReceive('where')
-            ->with(['user' => 1]);
-
-        $sqlMock->shouldReceive('prepareStatementForSqlObject')
-            ->with($selectMock)
-            ->andReturn($sqlMock);
-        $sqlMock->shouldReceive('execute')
+        $dbWrapperMock->shouldReceive('select')
+            ->with(
+                ApplicationData::APPLICATIONS_TABLE,
+                $criteria,
+                Mockery::on(function ($options) {
+                    $countExpression = $options['columns']['count'];
+                    return ($countExpression->getExpression() === 'count(*)');
+                })
+            )
             ->andReturn($resultMock);
+
         $resultMock->shouldReceive('isQueryResult')
-            ->andReturn(True);
+            ->andReturn(TRUE);
         $resultMock->shouldReceive('count')
             ->andReturn(1);
         $resultMock->shouldReceive('current')
@@ -59,10 +44,7 @@ class ApplicationDataTest extends MockeryTestCase
 
         // test method
         $applicationData = new ApplicationData($dbWrapperMock, []);
-        $count = $applicationData->count([
-            'search' => "o'connor",
-            'user' => 1,
-        ]);
+        $count = $applicationData->count($criteria);
 
         // assertions
         $this->assertEquals($expectedCount, $count);

--- a/service-api/module/Application/tests/Model/DataAccess/Postgres/ApplicationDataTest.php
+++ b/service-api/module/Application/tests/Model/DataAccess/Postgres/ApplicationDataTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace ApplicationTest\Model\DataAccess\Postgres;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+use Application\Model\DataAccess\Postgres\ApplicationData;
+use Application\Model\DataAccess\Postgres\DbWrapper;
+use Laminas\Db\ResultSet;
+use Laminas\Db\Sql\Select;
+use Laminas\Db\Sql\Sql;
+
+
+class ApplicationDataTest extends MockeryTestCase
+{
+    public function testCount() : void
+    {
+        $expectedCount = 10;
+
+        // mocks
+        $dbWrapperMock = Mockery::Mock(DbWrapper::class);
+        $sqlMock = Mockery::Mock(Sql::class);
+        $selectMock = Mockery::Mock(Select::class);
+        $resultSetMock = Mockery::Mock(ResultSet::class);
+
+        // expectations
+        $dbWrapperMock->shouldReceive('createSql')
+            ->andReturn($sqlMock);
+        $sqlMock->shouldReceive('select')
+            ->andReturn($selectMock);
+        $selectMock->shouldReceive('columns')
+            ->andReturn($selectMock);
+        $dbWrapperMock->shouldReceive('quoteValue')
+            ->with("o'connor")
+            ->andReturn("'o''connor'");
+
+        // confirm the expression passed to where() has the escaped string
+        $selectMock->shouldReceive('where')
+            ->with(Mockery::on(function ($args) {
+                return $args[0]->getExpression() === "search ~* 'o''connor'";
+            }))
+            ->once();
+
+        // confirm additional criteria are appended to where
+        $selectMock->shouldReceive('where')
+            ->with(['user' => 1]);
+
+        $sqlMock->shouldReceive('prepareStatementForSqlObject')
+            ->with($selectMock)
+            ->andReturn($sqlMock);
+        $sqlMock->shouldReceive('execute')
+            ->andReturn($resultSetMock);
+        $resultSetMock->shouldReceive('isQueryResult')
+            ->andReturn(True);
+        $resultSetMock->shouldReceive('count')
+            ->andReturn(1);
+        $resultSetMock->shouldReceive('current')
+            ->andReturn(['count' => $expectedCount]);
+
+        // test method
+        $applicationData = new ApplicationData($dbWrapperMock, []);
+        $count = $applicationData->count([
+            'search' => "o'connor",
+            'user' => 1,
+        ]);
+
+        // assertions
+        $this->assertEquals($expectedCount, $count);
+    }
+}

--- a/service-api/module/Application/tests/Model/DataAccess/Postgres/ApplicationDataTest.php
+++ b/service-api/module/Application/tests/Model/DataAccess/Postgres/ApplicationDataTest.php
@@ -6,7 +6,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 use Application\Model\DataAccess\Postgres\ApplicationData;
 use Application\Model\DataAccess\Postgres\DbWrapper;
-use Laminas\Db\ResultSet;
+use Laminas\Db\Adapter\Driver\Pdo\Result;
 use Laminas\Db\Sql\Select;
 use Laminas\Db\Sql\Sql;
 
@@ -21,7 +21,7 @@ class ApplicationDataTest extends MockeryTestCase
         $dbWrapperMock = Mockery::Mock(DbWrapper::class);
         $sqlMock = Mockery::Mock(Sql::class);
         $selectMock = Mockery::Mock(Select::class);
-        $resultSetMock = Mockery::Mock(ResultSet::class);
+        $resultMock = Mockery::Mock(Result::class);
 
         // expectations
         $dbWrapperMock->shouldReceive('createSql')
@@ -49,12 +49,12 @@ class ApplicationDataTest extends MockeryTestCase
             ->with($selectMock)
             ->andReturn($sqlMock);
         $sqlMock->shouldReceive('execute')
-            ->andReturn($resultSetMock);
-        $resultSetMock->shouldReceive('isQueryResult')
+            ->andReturn($resultMock);
+        $resultMock->shouldReceive('isQueryResult')
             ->andReturn(True);
-        $resultSetMock->shouldReceive('count')
+        $resultMock->shouldReceive('count')
             ->andReturn(1);
-        $resultSetMock->shouldReceive('current')
+        $resultMock->shouldReceive('current')
             ->andReturn(['count' => $expectedCount]);
 
         // test method

--- a/service-api/module/Application/tests/Model/DataAccess/Postgres/ApplicationDataTest.php
+++ b/service-api/module/Application/tests/Model/DataAccess/Postgres/ApplicationDataTest.php
@@ -7,6 +7,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Application\Model\DataAccess\Postgres\ApplicationData;
 use Application\Model\DataAccess\Postgres\DbWrapper;
 use Laminas\Db\Adapter\Driver\Pdo\Result;
+use Laminas\Db\Sql\Predicate\In as InPredicate;
 
 
 class ApplicationDataTest extends MockeryTestCase
@@ -48,5 +49,60 @@ class ApplicationDataTest extends MockeryTestCase
 
         // assertions
         $this->assertEquals($expectedCount, $count);
+    }
+
+    public function testGetByIdsAndUser() : void
+    {
+        $userId = '2';
+        $lpaIds = ['90', '91', '92'];
+
+        // mocks
+        $dbWrapperMock = Mockery::mock(DbWrapper::class);
+        $resultMock = Mockery::Mock(Result::class);
+
+        // expectations
+        $dbWrapperMock->shouldReceive('select')
+            ->with(
+                ApplicationData::APPLICATIONS_TABLE,
+                Mockery::on(function ($criteriaArg) use ($userId, $lpaIds) {
+                    return $criteriaArg[0] == new InPredicate('id', $lpaIds) &&
+                        $criteriaArg['user'] === $userId;
+                }),
+                [],
+            )
+            ->andReturn($resultMock);
+
+        // these are methods called internally when foreach is invoked
+        // with a Traversable, which is what a PDO Result is; we return a
+        // single record to exercise the mapPostgresToLpaCompatible() method
+        $resultMock->shouldReceive('rewind');
+
+        // second time valid() is called, we return FALSE so foreach() stops
+        // traversing the result
+        $resultMock->shouldReceive('valid')
+            ->andReturn(TRUE, FALSE);
+
+        $resultMock->shouldReceive('current')
+            ->andReturn([
+                'document' => '{"a":1}',
+                'metadata' => '{"b":2}',
+                'payment' => null,
+            ]);
+        $resultMock->shouldReceive('next');
+
+        // test method
+        $applicationData = new ApplicationData($dbWrapperMock, []);
+
+        // important to call iterator_to_array() to ensure that all the
+        // items yielded are gathered
+        $lpas = iterator_to_array($applicationData->getByIdsAndUser($lpaIds, $userId));
+
+        // assertions
+        $this->assertEquals(1, count($lpas));
+        $this->assertEquals([
+            'document' => ["a" => 1],
+            'metadata' => ["b" => 2],
+            'payment' => null,
+        ], $lpas[0]);
     }
 }

--- a/service-api/module/Application/tests/Model/DataAccess/Postgres/DbWrapperTest.php
+++ b/service-api/module/Application/tests/Model/DataAccess/Postgres/DbWrapperTest.php
@@ -1,0 +1,83 @@
+<?php
+namespace ApplicationTest\Model\DataAccess\Postgres;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+use Application\Model\DataAccess\Postgres\DbWrapper;
+use Laminas\Db\Adapter\Adapter;
+use Laminas\Db\Adapter\Driver\Pdo\Result;
+use Laminas\Db\Adapter\Platform\PlatformInterface;
+use Laminas\Db\Sql\Select;
+use Laminas\Db\Sql\Sql;
+
+
+class DbWrapperTest extends MockeryTestCase
+{
+    public function testSelect() : void
+    {
+        $tableName = 'foo';
+
+        $criteria = [
+            'search' => "o'connor",
+            'user' => '2',
+        ];
+
+        $options = [
+            'skip' => 10,
+            'limit' => 5,
+            'columns' => ['name', 'age'],
+            'sort' => ['age' => 1],
+        ];
+
+        // mocks
+        $adapterMock = Mockery::Mock(Adapter::class);
+        $sqlMock = Mockery::Mock(Sql::class);
+        $selectMock = Mockery::Mock(Select::class);
+        $resultMock = Mockery::Mock(Result::class);
+
+        // expectations
+        $sqlMock->shouldReceive('select')
+            ->with($tableName)
+            ->andReturn($selectMock);
+
+        // confirm the expression passed to where() has the escaped string
+        $selectMock->shouldReceive('where')
+            ->with(Mockery::on(function ($args) {
+                return $args[0]->getExpression() === "search ~* 'o''connor'";
+            }))
+            ->once();
+
+        // confirm additional criteria are appended to where
+        $selectMock->shouldReceive('where')
+            ->with(['user' => '2']);
+
+        // additional LIMIT, OFFSET, SORT and COLUMNS settings
+        $selectMock->shouldReceive('offset')
+            ->with(10);
+        $selectMock->shouldReceive('limit')
+            ->with(5);
+        $selectMock->shouldReceive('order')
+            ->with('age ASC');
+        $selectMock->shouldReceive('columns')
+            ->with(['name', 'age']);
+
+        $sqlMock->shouldReceive('prepareStatementForSqlObject')
+            ->with($selectMock)
+            ->andReturn($sqlMock);
+        $sqlMock->shouldReceive('execute')
+            ->andReturn($resultMock);
+
+        // patch the createSql() and quoteValue() methods of class under test;
+        // $dbWrapper is a partial mock which defers all methods except the patched ones
+        // to real methods; the array passed here contains constructor arguments
+        $dbWrapper = Mockery::Mock(DbWrapper::class, array($adapterMock))->makePartial();
+        $dbWrapper->shouldReceive('createSql')
+            ->andReturn($sqlMock);
+        $dbWrapper->shouldReceive('quoteValue')
+            ->with("o'connor")
+            ->andReturn("'o''connor'");
+
+        $count = $dbWrapper->select($tableName, $criteria, $options);
+    }
+}

--- a/service-api/module/Application/tests/Model/Service/Applications/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Applications/ServiceTest.php
@@ -602,13 +602,13 @@ class ServiceTest extends AbstractServiceTest
 
     public function testFetchAllSearchByName()
     {
-        $lpas = [FixturesData::getHwLpa(), FixturesData::getPfLpa()];
+        $name = 'o\'connor';
 
         $user = FixturesData::getUser();
 
         $this->setFetchAllExpectations([
             'user' => $user->getId(),
-            'search' => $lpas[0]->document->donor->name
+            'search' => $name
         ], []);
 
         $serviceBuilder = new ServiceBuilder();
@@ -617,7 +617,7 @@ class ServiceTest extends AbstractServiceTest
             ->build();
 
         /** @var Collection $response */
-        $response = $service->fetchAll($user->getId(), ['search' => $lpas[0]->document->donor->name]);
+        $response = $service->fetchAll($user->getId(), ['search' => $name]);
 
         $this->assertEquals(0, $response->count());
     }


### PR DESCRIPTION
## Purpose

Fixes [LPAL-462](https://opgtransform.atlassian.net/browse/LPAL-462)

## Approach

The ApplicationData class was fairly untestable when I first started, so I refactored it to make it more testable, creating a DbWrapper to better encapsulate db access. This could then be injected into the ApplicationData class, and mocked out in tests. The previous inheritance approach didn't give many benefits, as there were few shared methods in the parent class, so composition seemed like a better way to organise things.

I moved most of the code for SELECT queries into the DbWrapper class, including the code to do escaping of values in SELECT statements.

I added tests for DbWrapper->select().

I then added tests for the fetch() and count() methods in ApplicationData, which are simplified by moving a lot of the heavy lifting into DbWrapper.

**As this changes the fundamentals of db access, it's important to thoroughly test in UAT. In addition, this leaves the code in a half-and-half state, where ApplicationData has a different layout from the other \*Data classes. However, I think this structure is better, as it makes those classes potentially unit-testable.**

## Learning

Learned about the niceties of dealing with `yield` in PHP unit tests. 

Learned about using partial mocks which enable methods on a class under test to be patched. Very useful where it's difficult to mock out a dependency. For example, there's no easy way to construct a Sql object from an adapter; the Sql constructor requires you pass the adapter into it. This makes it difficult to mock. By encapsulating `new Sql($adapter)` in a `createSql` method, however, I could patch over `createSql` to return a mock Sql object. Much fun was had.

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
