### PR TITLE
LPAL-445 align dev to ADR on Tech guidance.

### DIFF
--- a/terraform/account/certificate.tf
+++ b/terraform/account/certificate.tf
@@ -39,7 +39,7 @@ resource "aws_acm_certificate_validation" "certificate_front" {
 }
 
 resource "aws_acm_certificate" "certificate_front" {
-  domain_name       = "${local.cert_prefix_internal}front.lpa.opg.service.justice.gov.uk"
+  domain_name       = "${local.cert_prefix_internal}${local.cert_prefix_development}front.lpa.opg.service.justice.gov.uk"
   validation_method = "DNS"
   tags              = merge(local.default_tags, local.shared_component_tag)
 }
@@ -72,7 +72,7 @@ resource "aws_acm_certificate_validation" "certificate_admin" {
 }
 
 resource "aws_acm_certificate" "certificate_admin" {
-  domain_name       = "${local.cert_prefix_internal}admin.lpa.opg.service.justice.gov.uk"
+  domain_name       = "${local.cert_prefix_internal}${local.cert_prefix_development}admin.lpa.opg.service.justice.gov.uk"
   validation_method = "DNS"
   tags              = merge(local.default_tags, local.shared_component_tag)
 }
@@ -105,7 +105,7 @@ resource "aws_acm_certificate_validation" "certificate_public_facing" {
 }
 
 resource "aws_acm_certificate" "certificate_public_facing" {
-  domain_name               = "${local.cert_prefix_public_facing}${data.aws_route53_zone.live_lastingpowerofattorney_gov_uk.name}"
+  domain_name               = "${local.cert_prefix_public_facing}${local.cert_prefix_development}${data.aws_route53_zone.live_lastingpowerofattorney_gov_uk.name}"
   validation_method         = "DNS"
   subject_alternative_names = terraform.workspace == "production" ? ["lastingpowerofattorney.service.gov.uk", "maintenance.lastingpowerofattorney.service.gov.uk"] : []
   tags                      = merge(local.default_tags, local.shared_component_tag)

--- a/terraform/account/locals.tf
+++ b/terraform/account/locals.tf
@@ -24,7 +24,7 @@ locals {
   account_id                  = local.account.account_id
   cert_prefix_internal        = local.account_name == "production" ? "" : "*."
   cert_prefix_public_facing   = local.account_name == "production" ? "www." : "*."
-
+  cert_prefix_development     = local.account_name == "development" ? "development." : ""
 
   mandatory_moj_tags = {
     business-unit = "OPG"

--- a/terraform/environment/dns.tf
+++ b/terraform/environment/dns.tf
@@ -18,7 +18,7 @@ resource "aws_service_discovery_private_dns_namespace" "internal" {
 resource "aws_route53_record" "public_facing_lastingpowerofattorney" {
   provider        = aws.management
   zone_id         = data.aws_route53_zone.live_service_lasting_power_of_attorney.zone_id
-  name            = "${local.dns_namespace_env_public}${data.aws_route53_zone.live_service_lasting_power_of_attorney.name}"
+  name            = "${local.dns_namespace_env_public}${local.dns_namespace_dev_prefix}${data.aws_route53_zone.live_service_lasting_power_of_attorney.name}"
   type            = "A"
   allow_overwrite = true
   alias {
@@ -39,7 +39,7 @@ resource "aws_route53_record" "public_facing_lastingpowerofattorney" {
 resource "aws_route53_record" "front" {
   provider = aws.management
   zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  name     = "${local.dns_namespace_env}${local.front_dns}"
+  name     = "${local.dns_namespace_env}${local.dns_namespace_dev_prefix}${local.front_dns}"
   type     = "A"
 
   alias {
@@ -64,7 +64,7 @@ output "front-domain" {
 resource "aws_route53_record" "admin" {
   provider = aws.management
   zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  name     = "${local.dns_namespace_env}${local.admin_dns}"
+  name     = "${local.dns_namespace_env}${local.dns_namespace_dev_prefix}${local.admin_dns}"
   type     = "A"
 
   alias {

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -14,6 +14,7 @@ locals {
   cert_prefix_internal        = local.account_name == "production" ? "" : "*."
   dns_namespace_env           = local.environment == "production" ? "" : "${local.environment}."
   dns_namespace_env_public    = local.environment == "production" ? "www." : "${local.environment}."
+  dns_namespace_dev_prefix    = local.environment == "development" ? "development." ? ""
   track_from_date             = "2019-04-01"
   front_dns                   = "front.lpa"
   admin_dns                   = "admin.lpa"

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -14,7 +14,7 @@ locals {
   cert_prefix_internal        = local.account_name == "production" ? "" : "*."
   dns_namespace_env           = local.environment == "production" ? "" : "${local.environment}."
   dns_namespace_env_public    = local.environment == "production" ? "www." : "${local.environment}."
-  dns_namespace_dev_prefix    = local.environment == "development" ? "development." ? ""
+  dns_namespace_dev_prefix    = local.environment == "development" ? "development." : ""
   track_from_date             = "2019-04-01"
   front_dns                   = "front.lpa"
   admin_dns                   = "admin.lpa"

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -14,7 +14,7 @@ locals {
   cert_prefix_internal        = local.account_name == "production" ? "" : "*."
   dns_namespace_env           = local.environment == "production" ? "" : "${local.environment}."
   dns_namespace_env_public    = local.environment == "production" ? "www." : "${local.environment}."
-  dns_namespace_dev_prefix    = local.environment == "development" ? "development." : ""
+  dns_namespace_dev_prefix    = local.account_name == "development" ? "development." : ""
   track_from_date             = "2019-04-01"
   front_dns                   = "front.lpa"
   admin_dns                   = "admin.lpa"

--- a/terraform/environment/vpc_data.sources.tf
+++ b/terraform/environment/vpc_data.sources.tf
@@ -35,15 +35,15 @@ data "aws_kms_key" "lpa_pdf_cache" {
 }
 
 data "aws_acm_certificate" "certificate_front" {
-  domain = "${local.cert_prefix_internal}${local.cert_prefix_development}front.lpa.opg.service.justice.gov.uk"
+  domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}front.lpa.opg.service.justice.gov.uk"
 }
 
 data "aws_acm_certificate" "certificate_admin" {
-  domain = "${local.cert_prefix_internal}${local.cert_prefix_development}admin.lpa.opg.service.justice.gov.uk"
+  domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}admin.lpa.opg.service.justice.gov.uk"
 }
 
 data "aws_acm_certificate" "public_facing_certificate" {
-  domain = "${local.cert_prefix_public_facing}${local.cert_prefix_development}lastingpowerofattorney.service.gov.uk"
+  domain = "${local.cert_prefix_public_facing}${local.dns_namespace_dev_prefix}lastingpowerofattorney.service.gov.uk"
 }
 
 data "aws_iam_role" "ecs_autoscaling_service_role" {

--- a/terraform/environment/vpc_data.sources.tf
+++ b/terraform/environment/vpc_data.sources.tf
@@ -35,15 +35,15 @@ data "aws_kms_key" "lpa_pdf_cache" {
 }
 
 data "aws_acm_certificate" "certificate_front" {
-  domain = "${local.cert_prefix_internal}front.lpa.opg.service.justice.gov.uk"
+  domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}front.lpa.opg.service.justice.gov.uk"
 }
 
 data "aws_acm_certificate" "certificate_admin" {
-  domain = "${local.cert_prefix_internal}admin.lpa.opg.service.justice.gov.uk"
+  domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}admin.lpa.opg.service.justice.gov.uk"
 }
 
 data "aws_acm_certificate" "public_facing_certificate" {
-  domain = "${local.cert_prefix_public_facing}lastingpowerofattorney.service.gov.uk"
+  domain = "${local.cert_prefix_public_facing}${local.dns_namespace_dev_prefix}lastingpowerofattorney.service.gov.uk"
 }
 
 data "aws_iam_role" "ecs_autoscaling_service_role" {

--- a/terraform/environment/vpc_data.sources.tf
+++ b/terraform/environment/vpc_data.sources.tf
@@ -35,15 +35,15 @@ data "aws_kms_key" "lpa_pdf_cache" {
 }
 
 data "aws_acm_certificate" "certificate_front" {
-  domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}front.lpa.opg.service.justice.gov.uk"
+  domain = "${local.cert_prefix_internal}${local.cert_prefix_development}front.lpa.opg.service.justice.gov.uk"
 }
 
 data "aws_acm_certificate" "certificate_admin" {
-  domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}admin.lpa.opg.service.justice.gov.uk"
+  domain = "${local.cert_prefix_internal}${local.cert_prefix_development}admin.lpa.opg.service.justice.gov.uk"
 }
 
 data "aws_acm_certificate" "public_facing_certificate" {
-  domain = "${local.cert_prefix_public_facing}${local.dns_namespace_dev_prefix}lastingpowerofattorney.service.gov.uk"
+  domain = "${local.cert_prefix_public_facing}${local.cert_prefix_development}lastingpowerofattorney.service.gov.uk"
 }
 
 data "aws_iam_role" "ecs_autoscaling_service_role" {


### PR DESCRIPTION
## Purpose
ACCOUNT LEVEL CHANGE (DEV ONLY AFFECTED).
Align our DNS creation with ADR in Technical Guidance. this is to help clarify which level of environment you are working in.

See Guidance at: https://docs.opg.service.justice.gov.uk/documentation/adrs/adr-002.html#multiple-hosted-zones

Fixes LPAL-445

## Approach

- DNS names will be in the format `[workspace-name].development.[service-name].opg.service.justice.gov.uk` for dev.
- We've also applied this to the public facing dev one e.g.:  `[workspace-name].development.lastingpowerofattorney.service.gov.uk`
- Cert and Cert Validation Changes
- Preproduction and Production will not need to change as these comply with the ADR.


## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
