### PR TITLE
add account level perfplat secrets

### DIFF
--- a/terraform/account/locals.tf
+++ b/terraform/account/locals.tf
@@ -65,4 +65,9 @@ locals {
   db_component_tag = {
     component = "db"
   }
+
+  performance_platform_component_tag = {
+    component = "perform_platform"
+  }
+
 }

--- a/terraform/account/put_secrets.tf
+++ b/terraform/account/put_secrets.tf
@@ -80,3 +80,16 @@ resource "aws_secretsmanager_secret" "api_rds_password" {
   tags       = merge(local.default_tags, local.db_component_tag)
   kms_key_id = aws_kms_key.secrets_encryption_key.arn
 }
+
+#perfplat db secrets
+resource "aws_secretsmanager_secret" "perfplat_db_username" {
+  name       = "${local.account_name}/perfplat_db_username"
+  tags       = merge(local.default_tags, local.db_component_tag)
+  kms_key_id = aws_kms_key.secrets_encryption_key.arn
+}
+
+resource "aws_secretsmanager_secret" "perfplat_db_password" {
+  name       = "${local.account_name}/perfplat_db_password"
+  tags       = merge(local.default_tags, local.db_component_tag)
+  kms_key_id = aws_kms_key.secrets_encryption_key.arn
+}

--- a/terraform/account/put_secrets.tf
+++ b/terraform/account/put_secrets.tf
@@ -84,12 +84,12 @@ resource "aws_secretsmanager_secret" "api_rds_password" {
 #performance platform db secrets
 resource "aws_secretsmanager_secret" "performance_platform_db_username" {
   name       = "${local.account_name}/performance_platform_db_username"
-  tags       = merge(local.default_tags, local.perfplat_component_tag)
+  tags       = merge(local.default_tags, local.performance_platform_component_tag)
   kms_key_id = aws_kms_key.secrets_encryption_key.arn
 }
 
 resource "aws_secretsmanager_secret" "performance_platform_db_password" {
   name       = "${local.account_name}/performance_platform_db_password"
-  tags       = merge(local.default_tags, local.perfplat_component_tag)
+  tags       = merge(local.default_tags, local.performance_platform_component_tag)
   kms_key_id = aws_kms_key.secrets_encryption_key.arn
 }

--- a/terraform/account/put_secrets.tf
+++ b/terraform/account/put_secrets.tf
@@ -81,7 +81,7 @@ resource "aws_secretsmanager_secret" "api_rds_password" {
   kms_key_id = aws_kms_key.secrets_encryption_key.arn
 }
 
-#perfplat db secrets
+#performance platform db secrets
 resource "aws_secretsmanager_secret" "performance_platform_db_username" {
   name       = "${local.account_name}/performance_platform_db_username"
   tags       = merge(local.default_tags, local.perfplat_component_tag)

--- a/terraform/account/put_secrets.tf
+++ b/terraform/account/put_secrets.tf
@@ -82,14 +82,14 @@ resource "aws_secretsmanager_secret" "api_rds_password" {
 }
 
 #perfplat db secrets
-resource "aws_secretsmanager_secret" "perfplat_db_username" {
-  name       = "${local.account_name}/perfplat_db_username"
-  tags       = merge(local.default_tags, local.db_component_tag)
+resource "aws_secretsmanager_secret" "performance_platform_db_username" {
+  name       = "${local.account_name}/performance_platform_db_username"
+  tags       = merge(local.default_tags, local.perfplat_component_tag)
   kms_key_id = aws_kms_key.secrets_encryption_key.arn
 }
 
-resource "aws_secretsmanager_secret" "perfplat_db_password" {
-  name       = "${local.account_name}/perfplat_db_password"
-  tags       = merge(local.default_tags, local.db_component_tag)
+resource "aws_secretsmanager_secret" "performance_platform_db_password" {
+  name       = "${local.account_name}/performance_platform_db_password"
+  tags       = merge(local.default_tags, local.perfplat_component_tag)
   kms_key_id = aws_kms_key.secrets_encryption_key.arn
 }


### PR DESCRIPTION
## Purpose

ACCOUNT LEVEL CHANGE

Add Secrets for perfplat-worker db.

part of the work for LPAL-457

## Approach

Adds new account level resources which have the postgres account details for the perfplat data.

## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
