### PR TITLE
LPAL-478 Add precommit hooks with instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ cypress/integration/common/local_dev_only.js
 __pycache__
 **/build
 .coverage
+.php-cs-fixer.cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,28 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.19.0
+    rev: v1.50.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
   - repo: https://github.com/awslabs/git-secrets
     rev: master
     hooks:
-      - id: git-secrets
+    - id: git-secrets
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v7.5.0
+    hooks:
+    -   id: gitleaks
+  - repo: https://github.com/digitalpulp/pre-commit-php.git
+    rev: 1.4.0
+    hooks:
+    - id: php-lint-all
+    - id: php-cs
+      files: \.(php)$
+      args: [--standard=PSR12 -p]
+    - id: php-cbf
+      files: \.(php)$
+      args: [--standard=PSR12 -p]
+    - id: php-stan
+      files: \.(php)$
+    - id: php-cs-fixer

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ brew install phpstan
 pre-commit install
 ```
 
-This will install the precommit hooks for the repo. this covers:
+This will install the pre-commit hooks for the repo. This covers:
 
 * PHP code fixers
 * Terraform

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cd opg-lpa
 
 ### install pre-commit hooks (mac)
 
-please install the precommit hooks as follows in the root of the repo directory (Mac only):
+Install the precommit hooks as follows in the root of the repo directory (Mac only):
 
 ```bash
 brew install php-code-sniffer

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ git clone https://github.com/ministryofjustice/opg-lpa.git
 cd opg-lpa
 ```
 
-### install pre-commit hooks (mac)
+### Install pre-commit hooks (mac)
 
 Install the precommit hooks as follows in the root of the repo directory (Mac only):
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Set up software on your machine required to run the application locally:
 * Install [docker-compose](https://docs.docker.com/compose/install/)
 * Install [homebrew](https://docs.brew.sh/) (mac only)
 
-### clone repo
+### Clone repo
 
 Download the repo via:
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ Set up software on your machine required to run the application locally:
 * Install `make` using the native package manager (assuming you are on Mac or Linux)
 * Install [docker](https://docs.docker.com/get-docker/)
 * Install [docker-compose](https://docs.docker.com/compose/install/)
+* Install [homebrew](https://docs.brew.sh/) (mac only)
 
-### Running locally without 3rd party integrations
-
-**This is the recommended approach for developers outside the Ministry of Justice.**
+### clone repo
 
 Download the repo via:
 
@@ -20,6 +19,36 @@ Download the repo via:
 git clone https://github.com/ministryofjustice/opg-lpa.git
 cd opg-lpa
 ```
+
+### install pre-commit hooks (mac)
+
+please install the precommit hooks as follows in the root of the repo directory (Mac only):
+
+```bash
+brew install php-code-sniffer
+brew install php-cs-fixer
+brew install phpstan
+pre-commit install
+```
+
+This will install the precommit hooks for the repo. this covers:
+
+* PHP code fixers
+* Terraform
+* Secrets commit detection (AWS, general secrets)
+* Whitespace and end of file fixers
+
+Add more as needed to the `.pre-commit-config.yaml`.
+
+For linux users, revert to the instructions for installing phpcs, phpstan and precommit hooks:
+
+* <https://github.com/squizlabs/PHP_CodeSniffer>
+* <https://phpstan.org/user-guide/getting-started>
+* <https://pre-commit.com/index.html#install>
+
+### Running locally without 3rd party integrations
+
+**This is the recommended approach for developers outside the Ministry of Justice.**
 
 If you intend to run the application in tandem with 3rd party integrations, you currently require a Ministry of Justice AWS account. If you don't have one of these, you can still run the stack locally, minus these integrations, with:
 
@@ -46,8 +75,8 @@ The long-term plan is for these integrations to be mocked out locally so that a 
 
 To run the application with 3rd party integrations, set up the software needed to support a Ministry of Justice AWS account:
 
-* Install `awscli`: while this can be done via brew, [these instructions](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) may be more useful.
-* Install [homebrew](https://docs.brew.sh/)
+* Install `awscli`: while this can be done via Homebrew, [these instructions](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) may be more useful.
+
 * Install dependencies for the Makefile using brew: `brew install aws-vault jq`
 
 Set up access to Amazon with MFA.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This will install the pre-commit hooks for the repo. This covers:
 
 Add more as needed to the `.pre-commit-config.yaml`.
 
-For linux users, revert to the instructions for installing phpcs, phpstan and precommit hooks:
+For Linux users, revert to the instructions for installing phpcs, phpstan and pre-commit hooks:
 
 * <https://github.com/squizlabs/PHP_CodeSniffer>
 * <https://phpstan.org/user-guide/getting-started>


### PR DESCRIPTION
## Purpose

This PR enables pre-commithooks and adds to existing ones to cover php and secrets.
this is to ensure developers/ webops are checking in standardised code.
This is a first attempt and will need tweaking as needed.

Fixes LPAL-478

## Approach

Add Precommit hooks for:
- PHP
- Secrets scanning

make precommit functional and update readme with install instructions.

## Learning

- https://pre-commit.com/index.html
- https://pre-commit.com/hooks.html
- https://github.com/digitalpulp/pre-commit-php
- https://github.com/zricethezav/gitleaks


## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
