### PR TITLE
LPAL-493 Update `required_version`

### DIFF
--- a/terraform/account/versions.tf
+++ b/terraform/account/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 1.7"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 }

--- a/terraform/account_ingress/versions.tf
+++ b/terraform/account_ingress/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 3.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 }

--- a/terraform/email/versions.tf
+++ b/terraform/email/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 3.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 }

--- a/terraform/environment/versions.tf
+++ b/terraform/environment/versions.tf
@@ -14,5 +14,5 @@ terraform {
     }
   }
 
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 }


### PR DESCRIPTION
## Purpose

update providers to `required_version = " >=1.0` in terraform.

Fixes LPAL-493

## Approach

N/A

## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
