### PR TITLE
add deletion protection for preprod and prod.

### DIFF
--- a/terraform/environment/load_balancer_admin.tf
+++ b/terraform/environment/load_balancer_admin.tf
@@ -28,7 +28,7 @@ resource "aws_lb" "admin" {
   security_groups = [
     aws_security_group.admin_loadbalancer.id,
   ]
-
+  enable_deletion_protection = local.account_name == "development" ? false : true
   access_logs {
     bucket  = data.aws_s3_bucket.access_log.bucket
     prefix  = "${local.environment}-admin"

--- a/terraform/environment/load_balancer_front.tf
+++ b/terraform/environment/load_balancer_front.tf
@@ -29,7 +29,7 @@ resource "aws_lb" "front" {
   security_groups = [
     aws_security_group.front_loadbalancer.id,
   ]
-
+  enable_deletion_protection = local.account_name == "development" ? false : true
   access_logs {
     bucket  = data.aws_s3_bucket.access_log.bucket
     prefix  = "${local.environment}-front"


### PR DESCRIPTION
## Purpose

Addresses Security Hub Finding for deletion protection on aws load balancers

Fixes LPAL-498

## Approach

update terraform with `enable_deletion_protection = local.account_name == "development" ? false : true`
We want development to be able to delete these automatically due their ephemeral nature.

## Learning

remediation: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#elb-6-remediation

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
