### PR TITLE
LPAL-524 SNS encryption doesn't appear to work for certain alerts.

### DIFF
--- a/terraform/account/sns.tf
+++ b/terraform/account/sns.tf
@@ -1,4 +1,4 @@
-#tfsec:ignore:AWS016 fix for now,
+#tfsec:ignore:AWS016 fix for now, to be followed with a CMK KMS
 resource "aws_sns_topic" "cloudwatch_to_slack_breakglass_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-Breakglass-alert"
   tags = merge(local.default_tags, local.shared_component_tag)

--- a/terraform/account/sns.tf
+++ b/terraform/account/sns.tf
@@ -1,11 +1,10 @@
+#tfsec:ignore:AWS016 fix for now,
 resource "aws_sns_topic" "cloudwatch_to_slack_breakglass_alerts" {
-  name              = "CloudWatch-to-PagerDuty-${local.account_name}-Breakglass-alert"
-  tags              = merge(local.default_tags, local.shared_component_tag)
-  kms_master_key_id = "alias/aws/sns"
+  name = "CloudWatch-to-PagerDuty-${local.account_name}-Breakglass-alert"
+  tags = merge(local.default_tags, local.shared_component_tag)
 }
-
+#tfsec:ignore:AWS016 unsupported for this type of alert
 resource "aws_sns_topic" "cloudwatch_to_slack_elasticache_alerts" {
-  name              = "CloudWatch-to-PagerDuty-${local.account_name}-elasticache-alert"
-  tags              = merge(local.default_tags, local.front_component_tag)
-  kms_master_key_id = "alias/aws/sns"
+  name = "CloudWatch-to-PagerDuty-${local.account_name}-elasticache-alert"
+  tags = merge(local.default_tags, local.front_component_tag)
 }

--- a/terraform/environment/sns.tf
+++ b/terraform/environment/sns.tf
@@ -1,13 +1,13 @@
+#tfsec:ignore:AWS016 - remove for now until we confirm this works with encryption
 resource "aws_sns_topic" "cloudwatch_to_pagerduty" {
-  name              = "CloudWatch-to-PagerDuty-${local.environment}"
-  tags              = merge(local.default_tags, local.shared_component_tag)
-  kms_master_key_id = "alias/aws/sns"
+  name = "CloudWatch-to-PagerDuty-${local.environment}"
+  tags = merge(local.default_tags, local.shared_component_tag)
 }
 
+#tfsec:ignore:AWS016 - remove for now until we confirm this works with encryption
 resource "aws_sns_topic" "cloudwatch_to_pagerduty_ops" {
-  name              = "CloudWatch-to-PagerDuty-${local.environment}-Ops"
-  tags              = merge(local.default_tags, local.shared_component_tag)
-  kms_master_key_id = "alias/aws/sns"
+  name = "CloudWatch-to-PagerDuty-${local.environment}-Ops"
+  tags = merge(local.default_tags, local.shared_component_tag)
 }
 
 resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription" {

--- a/terraform/environment/sns.tf
+++ b/terraform/environment/sns.tf
@@ -1,13 +1,13 @@
-#tfsec:ignore:AWS016 - remove for now until we confirm this works with encryption
 resource "aws_sns_topic" "cloudwatch_to_pagerduty" {
-  name = "CloudWatch-to-PagerDuty-${local.environment}"
-  tags = merge(local.default_tags, local.shared_component_tag)
+  name              = "CloudWatch-to-PagerDuty-${local.environment}"
+  tags              = merge(local.default_tags, local.shared_component_tag)
+  kms_master_key_id = "alias/aws/sns"
 }
 
-#tfsec:ignore:AWS016 - remove for now until we confirm this works with encryption
 resource "aws_sns_topic" "cloudwatch_to_pagerduty_ops" {
-  name = "CloudWatch-to-PagerDuty-${local.environment}-Ops"
-  tags = merge(local.default_tags, local.shared_component_tag)
+  name              = "CloudWatch-to-PagerDuty-${local.environment}-Ops"
+  tags              = merge(local.default_tags, local.shared_component_tag)
+  kms_master_key_id = "alias/aws/sns"
 }
 
 resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription" {


### PR DESCRIPTION
## Purpose

Temporarily remove encryption on SNS topics reserved for cloudtrail based alerts. 
Also remove Elasticache SNS encryption due to silently disassociating it self.

Will follow up with a separate ticket to cover a CMK based approach, where possible.


Fixes LPAL-524 temporarily.

## Approach

remove encryption (for now).

## Learning
- CMK needed for cloudwatch alerts (not fixed yet, to follow).
https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-permissions-for-sns-notifications.html
- Elasticache doesn't support encrypted topics, but fails quietly.
https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/ElastiCacheSNS.html

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
