### PR TITLE
LPAL-534 - BREAKFIX: make autoscale to 100 Gb available o n RDS DB.

### DIFF
--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -8,6 +8,7 @@ resource "aws_db_instance" "api" {
   identifier                  = lower("api-${local.environment}")
   name                        = "api2"
   allocated_storage           = 10
+  max_allocated_storage       = 100
   storage_type                = "gp2"
   storage_encrypted           = true
   skip_final_snapshot         = local.account.skip_final_snapshot


### PR DESCRIPTION
## Purpose

To enable autoscale of storage on Make an LPA RDS instance in production. This will allow it to increase to 100Gb, but in 10 Gb increments.

Fixes Low storage event on production.

**NOTE**: We may apply this fix prior to merging main in order to fix the service.

Fixes https://opgtransform.atlassian.net/browse/LPAL-534
## Approach
adds a `max_allocated_storage` of 100gb, should go up in 5 Gb increments.
## Learning

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.StorageTypes.html#USER_PIOPS.Autoscaling
https://aws.amazon.com/about-aws/whats-new/2019/06/rds-storage-auto-scaling/

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
