### PR TITLE
LPAL-535 remove apostrophe

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -35,7 +35,7 @@ jobs:
           - name: service-pdf
             path: "./service-pdf"
             code-scan: true
-          - name: service-perfplat'
+          - name: service-perfplat
             path: "./service-perfplat"
             code-scan: true
           - name: tests


### PR DESCRIPTION
## Purpose

addresses one of the trivy scans failing on service-perfplat folder.

Fixes LPAL-535

## Approach

remove errant apostrophe.

## Learning
N/A
## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
