### PR TITLE
LPAL-535 precursor work to add topic and event subscription to RDS.

### DIFF
--- a/terraform/account/sns.tf
+++ b/terraform/account/sns.tf
@@ -8,3 +8,26 @@ resource "aws_sns_topic" "cloudwatch_to_slack_elasticache_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-elasticache-alert"
   tags = merge(local.default_tags, local.front_component_tag)
 }
+
+resource "aws_sns_topic" "rds_events" {
+  name = "${local.account_name}-rds-events"
+  tags = merge(local.default_tags, local.db_component_tag)
+}
+
+resource "aws_db_event_subscription" "rds_events" {
+  name      = "${local.account_name}-rds-event-sub"
+  sns_topic = aws_sns_topic.rds_events.arn
+  event_categories = [
+    "availability",
+    "deletion",
+    "failover",
+    "failure",
+    "low storage",
+    "maintenance",
+    "notification",
+    "read replica",
+    "recovery",
+    "restoration",
+    "security",
+  ]
+}


### PR DESCRIPTION
## Purpose

ACCOUNT LEVEL CHANGE
Add Event subscription and SNS Topic for DB alerts at the account level.

Assists LPAL-500 and other tickets related to RDS Security Hub findings, and 535 which adds cloudwatch monitoring.
See #620 

## Approach

At account level:
- add `aws_db_event_subscription` 
- add `aws_sns_topic`

## Learning

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html 

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
