### PR TITLE
LPAL-497 Add policy to pdf and access logs

### DIFF
--- a/terraform/account/s3.tf
+++ b/terraform/account/s3.tf
@@ -30,6 +30,8 @@ data "aws_iam_policy_document" "loadbalancer_logging" {
       "${aws_s3_bucket.access_log.arn}/*",
     ]
 
+    actions = ["s3:*"]
+
     condition {
       test     = "Bool"
       variable = "aws:SecureTransport"

--- a/terraform/account/s3.tf
+++ b/terraform/account/s3.tf
@@ -132,8 +132,8 @@ data "aws_iam_policy_document" "lpa_pdf_cache_policy" {
     effect = "Deny"
 
     resources = [
-      aws_s3_bucket.lpa_pdf_cache,
-      "${aws_s3_bucket.lpa_pdf_cache}/*",
+      aws_s3_bucket.lpa_pdf_cache.arn,
+      "${aws_s3_bucket.lpa_pdf_cache.arn}/*",
     ]
 
     actions = ["s3:*"]


### PR DESCRIPTION
## Purpose

Security Hub finding fix to S3.
Enforces the use of SSL when accessing s3 buckets. we need to test this works with the PDF cache first before releasing.

Fixes LPAL-497

## Approach

Adds policy changes to`lpa_pdf_cache` and `access_logs`

## Learning

see: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#s3-5-remediation

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
