### PR TITLE
LPAL-538 Fix LPA search bug

### DIFF
--- a/service-api/module/Application/src/Model/DataAccess/Postgres/DbWrapper.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/DbWrapper.php
@@ -113,7 +113,7 @@ class DbWrapper
 
         if (isset($criteria['search'])) {
             $quoted = $this->quoteValue($criteria['search']);
-            $select->where([new Expression("search ~* {$quoted}")]);
+            $criteria[] = "search ~* {$quoted}";
             unset($criteria['search']);
         }
 

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/DbWrapper.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/DbWrapper.php
@@ -2,7 +2,6 @@
 
 namespace Application\Model\DataAccess\Postgres;
 
-use Application\Logging\LoggerTrait;
 use Laminas\Db\Adapter\Adapter;
 use Laminas\Db\Adapter\Driver\ResultInterface;
 use Laminas\Db\Metadata\Object\TableObject;

--- a/service-api/module/Application/tests/Model/DataAccess/Postgres/DbWrapperTest.php
+++ b/service-api/module/Application/tests/Model/DataAccess/Postgres/DbWrapperTest.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace ApplicationTest\Model\DataAccess\Postgres;
 
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-
 use Application\Model\DataAccess\Postgres\DbWrapper;
 use Laminas\Db\Adapter\Adapter;
 use Laminas\Db\Adapter\Driver\Pdo\Result;
@@ -12,10 +12,9 @@ use Laminas\Db\Adapter\Platform\PlatformInterface;
 use Laminas\Db\Sql\Select;
 use Laminas\Db\Sql\Sql;
 
-
 class DbWrapperTest extends MockeryTestCase
 {
-    public function testSelect() : void
+    public function testSelect(): void
     {
         $tableName = 'foo';
 
@@ -43,16 +42,9 @@ class DbWrapperTest extends MockeryTestCase
             ->with($tableName)
             ->andReturn($selectMock);
 
-        // confirm the expression passed to where() has the escaped string
-        $selectMock->shouldReceive('where')
-            ->with(Mockery::on(function ($args) {
-                return $args[0]->getExpression() === "search ~* 'o''connor'";
-            }))
-            ->once();
-
         // confirm additional criteria are appended to where
         $selectMock->shouldReceive('where')
-            ->with(['user' => '2']);
+            ->with(['user' => '2', "search ~* 'o''connor'"]);
 
         // additional LIMIT, OFFSET, SORT and COLUMNS settings
         $selectMock->shouldReceive('offset')
@@ -80,6 +72,6 @@ class DbWrapperTest extends MockeryTestCase
             ->with("o'connor")
             ->andReturn("'o''connor'");
 
-        $count = $dbWrapper->select($tableName, $criteria, $options);
+        $dbWrapper->select($tableName, $criteria, $options);
     }
 }


### PR DESCRIPTION
## Purpose

Fixes [LPAL-538](https://opgtransform.atlassian.net/browse/LPAL-538)

## Approach

Incorrect SQL construction. The perils of using mocks in unit tests combined with missing cypress tests.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
