### PR TITLE
LPAL-500 dampen alarm thresholds

### DIFF
--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -57,6 +57,7 @@ module "aws_rds_api_alarms" {
   actions_alarm                             = [data.aws_sns_topic.rds_events.arn]
   actions_ok                                = [data.aws_sns_topic.rds_events.arn]
   disk_free_storage_space_too_low_threshold = "1000000000" #configured to 1GB
+  disk_burst_balance_too_low_threshold      = "50"
   cpu_utilization_too_high_threshold        = "95"
   db_instance_class                         = "db.m3.medium"
   prefix                                    = "${local.environment}-"

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -59,6 +59,7 @@ module "aws_rds_api_alarms" {
   disk_free_storage_space_too_low_threshold = "1000000000" #configured to 1GB
   disk_burst_balance_too_low_threshold      = "50"
   cpu_utilization_too_high_threshold        = "95"
+  anomaly_band_width                        = "5"
   db_instance_class                         = "db.m3.medium"
   prefix                                    = "${local.environment}-"
   tags                                      = merge(local.default_tags, local.db_component_tag)


### PR DESCRIPTION
## Purpose

reduce disk burst threshold to 50% as 100% too high.
anomalous counts for db connections also adjusted out to 5.
Fixes LPAL-500

## Approach

adjust module parameter for `disk_burst_balance_too_low_threshold` and `anomaly_band_width`

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
