### PR TITLE
adjust anomaly and eval periods for RDS alarms

### DIFF
--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -59,7 +59,8 @@ module "aws_rds_api_alarms" {
   disk_free_storage_space_too_low_threshold = "1000000000" #configured to 1GB
   disk_burst_balance_too_low_threshold      = "50"
   cpu_utilization_too_high_threshold        = "95"
-  anomaly_band_width                        = "5"
+  anomaly_band_width                        = "10"
+  evaluation_period                         = "10"
   db_instance_class                         = "db.m3.medium"
   prefix                                    = "${local.environment}-"
   tags                                      = merge(local.default_tags, local.db_component_tag)


### PR DESCRIPTION
## Purpose
attempt to reduce some of the chatty alarms a bit.

Fixes LPAL-551

## Approach

up anomaly value to 10 
up eval periods to 10 x 60 seconds.

## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
