### PR TITLE
LPAL-525 Add Task fail eventbridge rule and publish to ops pagerduty sns

### DIFF
--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -125,10 +125,10 @@ resource "aws_cloudwatch_event_target" "tasks_stopped" {
 
 resource "aws_sns_topic_policy" "task_stopped_policy" {
   arn    = aws_sns_topic.cloudwatch_to_pagerduty_ops.arn
-  policy = data.aws_iam_policy_document.sns_topic_policy.json
+  policy = data.aws_iam_policy_document.task_stopped_topic_policy.json
 }
 
-data "aws_iam_policy_document" "stopped_tasks_topic_policy" {
+data "aws_iam_policy_document" "task_stopped_topic_policy" {
   statement {
     effect  = "Allow"
     actions = ["SNS:Publish"]

--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -120,11 +120,11 @@ resource "aws_cloudwatch_event_rule" "tasks_stopped" {
 resource "aws_cloudwatch_event_target" "tasks_stopped" {
   rule      = aws_cloudwatch_event_rule.tasks_stopped.name
   target_id = "SendToSNS"
-  arn       = aws_sns_topic.cloudwatch_to_pagerduty_ops.arn
+  arn       = aws_sns_topic.cloudwatch_to_account_ops_alerts.arn
 }
 
 resource "aws_sns_topic_policy" "task_stopped_policy" {
-  arn    = aws_sns_topic.cloudwatch_to_pagerduty_ops.arn
+  arn    = aws_sns_topic.cloudwatch_to_account_ops_alerts.arn
   policy = data.aws_iam_policy_document.task_stopped_topic_policy.json
 }
 
@@ -138,6 +138,6 @@ data "aws_iam_policy_document" "task_stopped_topic_policy" {
       identifiers = ["events.amazonaws.com"]
     }
 
-    resources = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
+    resources = [aws_sns_topic.cloudwatch_to_account_ops_alerts.arn]
   }
 }

--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -108,6 +108,13 @@ resource "aws_cloudwatch_event_rule" "tasks_stopped" {
       stopCode   = ["TaskFailedToStart"]
     }
   })
+  tags = merge(
+    local.default_tags,
+    local.shared_component_tag,
+    {
+      "Name" = "online-lpa"
+    },
+  )
 }
 
 resource "aws_cloudwatch_event_target" "tasks_stopped" {

--- a/terraform/account/pagerduty.tf
+++ b/terraform/account/pagerduty.tf
@@ -40,6 +40,14 @@ resource "aws_sns_topic_subscription" "cloudwatch_elasticache_alerts_sns_subscri
   endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration.integration_key}/enqueue"
 }
 
+resource "aws_sns_topic_subscription" "cloudwatch_account_ops_sns_subscription" {
+  topic_arn              = aws_sns_topic.cloudwatch_to_account_ops_alerts.arn
+  protocol               = "https"
+  endpoint_auto_confirms = true
+  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration.integration_key}/enqueue"
+}
+
+
 resource "aws_sns_topic_subscription" "rds_events_sns_subscription" {
   topic_arn              = aws_sns_topic.rds_events.arn
   protocol               = "https"

--- a/terraform/account/sns.tf
+++ b/terraform/account/sns.tf
@@ -9,6 +9,12 @@ resource "aws_sns_topic" "cloudwatch_to_slack_elasticache_alerts" {
   tags = merge(local.default_tags, local.front_component_tag)
 }
 
+#tfsec:ignore:AWS016 unsupported for this type of alert
+resource "aws_sns_topic" "cloudwatch_to_account_ops_alerts" {
+  name = "CloudWatch-to-PagerDuty-${local.account_name}-account-ops-alert"
+  tags = merge(local.default_tags, local.shared_component_tag)
+}
+
 resource "aws_sns_topic" "rds_events" {
   name = "${local.account_name}-rds-events"
   tags = merge(local.default_tags, local.db_component_tag)


### PR DESCRIPTION
## Purpose

Add notifications for task failures on ECS.

Fixes LPAL-525

## Approach

- Set up EventBridge Rule to capture task stopped with  a `TaskFailedToStart` reason
- event target to point at the pager duty ops SNS topic

## Learning

- used this as a guide: https://github.com/wellcomecollection/platform-infrastructure/pull/246 

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
