### PR TITLE
LPAL-557 move maint windows to wednesday mornings for RDS and Elasticache

### DIFF
--- a/terraform/account/elasticache.tf
+++ b/terraform/account/elasticache.tf
@@ -23,9 +23,9 @@ resource "aws_elasticache_replication_group" "front_cache" {
   at_rest_encryption_enabled    = true
   automatic_failover_enabled    = true
   maintenance_window            = "wed:05:00-wed:09:00"
-
-  subnet_group_name  = aws_elasticache_subnet_group.private_subnets.name
-  security_group_ids = [aws_security_group.front_cache.id]
+  notification_topic_arn        = aws_sns_topic.cloudwatch_to_slack_elasticache_alerts.arn
+  subnet_group_name             = aws_elasticache_subnet_group.private_subnets.name
+  security_group_ids            = [aws_security_group.front_cache.id]
 
   tags = merge(local.default_tags, local.front_component_tag)
 }

--- a/terraform/account/elasticache.tf
+++ b/terraform/account/elasticache.tf
@@ -23,6 +23,7 @@ resource "aws_elasticache_replication_group" "front_cache" {
   at_rest_encryption_enabled    = true
   automatic_failover_enabled    = true
   maintenance_window            = "wed:05:00-wed:09:00"
+  snapshot_window               = "02:00-04:50"
   notification_topic_arn        = aws_sns_topic.cloudwatch_to_slack_elasticache_alerts.arn
   subnet_group_name             = aws_elasticache_subnet_group.private_subnets.name
   security_group_ids            = [aws_security_group.front_cache.id]

--- a/terraform/account/elasticache.tf
+++ b/terraform/account/elasticache.tf
@@ -22,6 +22,7 @@ resource "aws_elasticache_replication_group" "front_cache" {
   transit_encryption_enabled    = true
   at_rest_encryption_enabled    = true
   automatic_failover_enabled    = true
+  maintenance_window            = "wed:05:00-wed:09:00"
 
   subnet_group_name  = aws_elasticache_subnet_group.private_subnets.name
   security_group_ids = [aws_security_group.front_cache.id]

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -30,7 +30,7 @@ resource "aws_db_instance" "api" {
   parameter_group_name                = aws_db_parameter_group.postgres-db-params.name
   vpc_security_group_ids              = [aws_security_group.rds-api.id]
   auto_minor_version_upgrade          = true
-  maintenance_window                  = "sun:01:00-sun:01:30"
+  maintenance_window                  = "wed:05:00-wed:09:00"
   multi_az                            = true
   backup_retention_period             = local.account.backup_retention_period
   deletion_protection                 = local.account.deletion_protection


### PR DESCRIPTION
## Purpose

We want the maintenance windows to be close to the Wednesday morning Business downtime preferred slot.

Fixes LPAL-557

## Approach

change elasticache and RDS in production to have maintenance windows from 05:00 -09:00 on Wednesdays.
Also as part of this change: topic publish missed previously. should now be subscribed.

## Learning
N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
