### PR TITLE
LPAL-537 Improve error messages when db is unavailable

### DIFF
--- a/service-api/module/Application/src/Library/Authentication/Adapter/LpaAuth.php
+++ b/service-api/module/Application/src/Library/Authentication/Adapter/LpaAuth.php
@@ -3,6 +3,7 @@
 namespace Application\Library\Authentication\Adapter;
 
 use Application\Library\Authentication\Identity;
+use Application\Logging\LoggerTrait;
 use Application\Model\Service\Authentication\Service as AuthenticationService;
 use Laminas\Authentication\Result;
 use Laminas\Authentication\Adapter\AdapterInterface;
@@ -13,6 +14,8 @@ use Laminas\Authentication\Adapter\AdapterInterface;
  */
 class LpaAuth implements AdapterInterface
 {
+    use LoggerTrait;
+
     /**
      * @var AuthenticationService
      */
@@ -45,9 +48,15 @@ class LpaAuth implements AdapterInterface
      */
     public function authenticate()
     {
+        $this->getLogger()->debug('++++++++++++++++++ WELL, HERE WE ARE IN LpaAuth->authenticate; SO FAR, SO GOOD');
         $user = null;
 
-        $data = $this->authenticationService->withToken($this->token, true);
+        try {
+            $data = $this->authenticationService->withToken($this->token, true);
+        } catch (\Exception $ex) {
+            $this->getLogger()->err('_____________________ OH NO CANNOT LOOK UP USER');
+            $this->getLogger()->err($ex);
+        }
 
         //  Clear up the token
         unset($this->token);

--- a/service-api/module/Application/tests/Library/Authentication/Adapter/LpaAuthTest.php
+++ b/service-api/module/Application/tests/Library/Authentication/Adapter/LpaAuthTest.php
@@ -17,12 +17,12 @@ class LpaAuthTest extends MockeryTestCase
      */
     private $authenticationService;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->authenticationService = Mockery::mock(Service::class);
     }
 
-    public function testAuthenticateStandardUser() : void
+    public function testAuthenticateStandardUser(): void
     {
         $this->authenticationService->shouldReceive('withToken')->with('Token', true)
             ->andReturn(['userId' => 'ID', 'username' => 'user name']);
@@ -41,7 +41,7 @@ class LpaAuthTest extends MockeryTestCase
         $this->assertEquals([0 => 'user'], $user->getRoles());
     }
 
-    public function testAuthenticateAdminUser() : void
+    public function testAuthenticateAdminUser(): void
     {
         $this->authenticationService->shouldReceive('withToken')->with('Token', true)
             ->andReturn(['userId' => 'ID', 'username' => 'user name']);
@@ -60,7 +60,7 @@ class LpaAuthTest extends MockeryTestCase
         $this->assertEquals([0 => 'user', 1 => 'admin'], $user->getRoles());
     }
 
-    public function testAuthenticateFailed() : void
+    public function testAuthenticateFailed(): void
     {
         $this->authenticationService->shouldReceive('withToken')->with('Token', true)
             ->andReturn(null);
@@ -70,7 +70,7 @@ class LpaAuthTest extends MockeryTestCase
 
         $this->assertNotNull($result);
         $this->assertInstanceOf(Result::class, $result);
-        $this->assertEquals(Result::FAILURE, $result->getCode());
+        $this->assertEquals(Result::FAILURE_CREDENTIAL_INVALID, $result->getCode());
         $this->assertNull($result->getIdentity());
     }
 }

--- a/service-api/module/Application/tests/Library/Authentication/AuthenticationListenerTest.php
+++ b/service-api/module/Application/tests/Library/Authentication/AuthenticationListenerTest.php
@@ -92,7 +92,9 @@ class AuthenticationListenerTest extends MockeryTestCase
         $this->request->shouldReceive('getHeader')->with('Token')->andReturn($header)->once();
 
         $authenticationResult = Mockery::mock(Result::class);
-        $authenticationResult->shouldReceive('getCode')->andReturn(Result::FAILURE)->once();
+        $authenticationResult->shouldReceive('getCode')
+            ->andReturn(Result::FAILURE_CREDENTIAL_INVALID)
+            ->once();
 
         $this->authService->shouldReceive('authenticate')->andReturn($authenticationResult)->once();
 
@@ -112,7 +114,9 @@ class AuthenticationListenerTest extends MockeryTestCase
             ['type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html',
                 'title' => 'Unauthorized',
                 'status' => 401,
-                'detail' => 'Invalid authentication token'], $apiProblem->toArray());
+            'detail' => 'Invalid authentication token'],
+            $apiProblem->toArray()
+        );
     }
 
     public function testAuthenticationNoToken(): void

--- a/service-api/readme.md
+++ b/service-api/readme.md
@@ -64,6 +64,14 @@ Password: <enter lpapass>
 
 You should now have a psql command line on the postgres server.
 
+## Manually accessing the API
+
+Example of how to get an authentication token for username + password in dev:
+
+```
+curl -i -L -X POST -H "Content-Type: application/json" -d '{"username": "seeded_test_user@digital.justice.gov.uk", "password": "Pass1234"}' "http://localhost:7001/v2/authenticate"
+```
+
 ## License
 
 The Lasting Power of Attorney Attorney API Service is released under the MIT license, a copy of which can be found in [LICENSE](LICENSE).

--- a/service-front/module/Application/src/Controller/AbstractAuthenticatedController.php
+++ b/service-front/module/Application/src/Controller/AbstractAuthenticatedController.php
@@ -74,7 +74,8 @@ abstract class AbstractAuthenticatedController extends AbstractBaseController
         $this->lpaApplicationService = $lpaApplicationService;
         $this->userService = $userService;
 
-        //  If there is a user identity set up the user - if this is missing the request will be bounced in the onDispatch function
+        //  If there is a user identity set up the user - if this is missing the request
+        // will be bounced in the onDispatch function
         if ($authenticationService->hasIdentity()) {
             $this->identity = $authenticationService->getIdentity();
 
@@ -102,8 +103,7 @@ abstract class AbstractAuthenticatedController extends AbstractBaseController
         // Before the user can access any actions that extend this controller...
 
         //----------------------------------------------------------------------
-        // Check we have a user set, thus ensuring an authenticated user
-
+        // Check we have a user set, thus ensuring an authenticated user.
         if (($authenticated = $this->checkAuthenticated()) !== true) {
             return $authenticated;
         }
@@ -200,13 +200,9 @@ abstract class AbstractAuthenticatedController extends AbstractBaseController
         if (!$this->identity instanceof Identity) {
             if ($allowRedirect) {
                 $preAuthRequest = new Container('PreAuthRequest');
-
                 $preAuthRequest->url = (string)$this->getRequest()->getUri();
             }
 
-            //---
-
-            // Redirect to the About You page
             return $this->redirect()->toRoute('login', [
                 'state' => 'timeout'
             ]);

--- a/service-front/module/Application/src/Controller/AbstractAuthenticatedController.php
+++ b/service-front/module/Application/src/Controller/AbstractAuthenticatedController.php
@@ -203,8 +203,18 @@ abstract class AbstractAuthenticatedController extends AbstractBaseController
                 $preAuthRequest->url = (string)$this->getRequest()->getUri();
             }
 
+            // If the user's identity was cleared because of a genuine timeout,
+            // redirect to the login page with session timeout; otherwise,
+            // redirect to the login page and show the "service unavailable" message.
+            $authFailureReason = new Container('AuthFailureReason');
+            if (is_null($authFailureReason->code)) {
+                return $this->redirect()->toRoute('login', [
+                    'state' => 'timeout'
+                ]);
+            }
+
             return $this->redirect()->toRoute('login', [
-                'state' => 'timeout'
+                'state' => 'internalSystemError'
             ]);
         }
 

--- a/service-front/module/Application/src/Controller/Authenticated/DashboardController.php
+++ b/service-front/module/Application/src/Controller/Authenticated/DashboardController.php
@@ -144,7 +144,7 @@ class DashboardController extends AbstractAuthenticatedController
             }
 
             // Redirect them to the first page...
-            return $this->redirect()->toRoute('lpa/form-type', [ 'lpa-id'=>$lpa->id ]);
+            return $this->redirect()->toRoute('lpa/form-type', [ 'lpa-id' => $lpa->id ]);
         }
 
         //---
@@ -160,7 +160,7 @@ class DashboardController extends AbstractAuthenticatedController
         $lpaId = $this->getEvent()->getRouteMatch()->getParam('lpa-id');
 
         if ($this->getLpaApplicationService()->deleteApplication($lpaId) !== true) {
-            throw new \RuntimeException('API client failed to delete LPA for id: '.$lpaId);
+            throw new \RuntimeException('API client failed to delete LPA for id: ' . $lpaId);
         }
 
         $target = 'user/dashboard';
@@ -213,7 +213,7 @@ class DashboardController extends AbstractAuthenticatedController
     //------------------------------------------------------------------
 
     /**
-     * This is overridden to prevent people being (accidently?) directed to this controller post-auth.
+     * This is overridden to prevent people being (accidentally?) directed to this controller post-auth.
      *
      * @return bool|\Laminas\Http\Response
      */

--- a/service-front/module/Application/src/Controller/General/AuthController.php
+++ b/service-front/module/Application/src/Controller/General/AuthController.php
@@ -94,7 +94,11 @@ class AuthController extends AbstractBaseController
                                 $formFlowChecker = new FormFlowChecker($lpa);
                                 $destinationRoute = $formFlowChecker->backToForm();
 
-                                return $this->redirect()->toRoute($destinationRoute, ['lpa-id' => $lpa->id], $formFlowChecker->getRouteOptions($destinationRoute));
+                                return $this->redirect()->toRoute(
+                                    $destinationRoute,
+                                    ['lpa-id' => $lpa->id],
+                                    $formFlowChecker->getRouteOptions($destinationRoute)
+                                );
                             }
                         }
 
@@ -104,7 +108,9 @@ class AuthController extends AbstractBaseController
 
                     //  If necessary set a flash message showing that the user account will now remain active
                     if (in_array('inactivity-flags-cleared', $result->getMessages())) {
-                        $this->flashMessenger()->addWarningMessage('Thanks for logging in. Your LPA account will stay open for another 9 months.');
+                        $this->flashMessenger()->addWarningMessage(
+                            'Thanks for logging in. Your LPA account will stay open for another 9 months.'
+                        );
                     }
 
                     // Else Send them to the dashboard...
@@ -133,12 +139,14 @@ class AuthController extends AbstractBaseController
             }
         }
 
-        $isTimeout = ( $this->params('state') == 'timeout' );
+        $isTimeout = ($this->params('state') == 'timeout');
+        $isInternalSystemError = ($this->params('state') == 'internalSystemError');
 
         return new ViewModel([
             'form' => $form,
             'authError' => $authError,
-            'isTimeout' => $isTimeout
+            'isTimeout' => $isTimeout,
+            'isInternalSystemError' => $isInternalSystemError,
         ]);
     }
 

--- a/service-front/module/Application/src/Model/Service/ApiClient/Exception/ApiException.php
+++ b/service-front/module/Application/src/Model/Service/ApiClient/Exception/ApiException.php
@@ -8,6 +8,11 @@ use RuntimeException;
 class ApiException extends RuntimeException
 {
     /**
+     * @var int
+     */
+    private $statusCode;
+
+    /**
      * @var array
      */
     private $body;
@@ -21,6 +26,7 @@ class ApiException extends RuntimeException
     public function __construct(ResponseInterface $response, string $message = null)
     {
         $this->body = json_decode($response->getBody(), true);
+        $this->statusCode = $response->getStatusCode();
 
         //  If no message was provided create one from the response data
         if (is_null($message)) {
@@ -29,11 +35,12 @@ class ApiException extends RuntimeException
 
             //  If there is still no message then compose a standard message
             if (is_null($message)) {
-                $message = 'HTTP:' . $response->getStatusCode() . ' - ' . (is_array($this->body) ? print_r($this->body, true) : 'Unexpected API response');
+                $message = 'HTTP:' . $this->statusCode . ' - ' .
+                (is_array($this->body) ? print_r($this->body, true) : 'Unexpected API response');
             }
         }
 
-        parent::__construct($message, $response->getStatusCode());
+        parent::__construct($message, $this->statusCode);
     }
 
     /**
@@ -74,5 +81,15 @@ class ApiException extends RuntimeException
         }
 
         return null;
+    }
+
+    /**
+     * Get the status code of the response which created this exception.
+     *
+     * @return int
+     */
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
     }
 }

--- a/service-front/module/Application/src/Model/Service/User/Details.php
+++ b/service-front/module/Application/src/Model/Service/User/Details.php
@@ -223,14 +223,28 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
     public function getTokenInfo($token)
     {
         try {
-            return $this->apiClient->httpPost('/v2/authenticate', [
+            $response = $this->apiClient->httpPost('/v2/authenticate', [
                 'authToken' => $token,
             ]);
+
+            $success = true;
+            if (isset($response['expiresIn'])) {
+                $expiresIn = $response['expiresIn'];
+            }
+            $failureCode = null;
         } catch (ApiException $ex) {
             $this->getLogger()->err($ex);
+
+            $success = false;
+            $expiresIn = null;
+            $failureCode = $ex->getStatusCode();
         }
 
-        return false;
+        return [
+            'success' => $success,
+            'failureCode' => $failureCode,
+            'expiresIn' => $expiresIn,
+        ];
     }
 
     /**

--- a/service-front/module/Application/tests/Controller/AbstractAuthenticatedControllerTest.php
+++ b/service-front/module/Application/tests/Controller/AbstractAuthenticatedControllerTest.php
@@ -24,7 +24,7 @@ class AbstractAuthenticatedControllerTest extends AbstractControllerTest
 
         $this->request->shouldReceive('getUri')->andReturn('http://localhost/home');
         $this->redirect->shouldReceive('toRoute')
-            ->withArgs(['login', ['state'=>'timeout']])->andReturn($response)->once();
+            ->withArgs(['login', ['state' => 'timeout']])->andReturn($response)->once();
 
         $result = $controller->onDispatch($event);
 
@@ -72,7 +72,7 @@ class AbstractAuthenticatedControllerTest extends AbstractControllerTest
             'clear_storage' => true
         ]])->once();
         $this->redirect->shouldReceive('toRoute')
-            ->withArgs(['login', ['state'=>'timeout']])->andReturn($response)->once();
+            ->withArgs(['login', ['state' => 'timeout']])->andReturn($response)->once();
 
         $result = $controller->onDispatch($event);
 
@@ -122,6 +122,38 @@ class AbstractAuthenticatedControllerTest extends AbstractControllerTest
         $this->assertInstanceOf(ViewModel::class, $result);
         $this->assertEquals('', $result->getTemplate());
         $this->assertEquals('Placeholder page', $result->content);
+    }
+
+    public function testOnDispatchDatabaseDown()
+    {
+        // Simulate the database being unavailable, which results in a marker in the session;
+        // see Module.php, where this marker is added before the session is handed over to the controller.
+        $authFailureReason = new Container('AuthFailureReason');
+        $authFailureReason->reason = 'Internal system error';
+        $authFailureReason->code = 500;
+
+        // Simulate bootstrapIdentity() being unable to find the user; see Module.php
+        $this->setIdentity(null);
+
+        // mocks and stubs
+        $event = Mockery::mock(MvcEvent::class);
+        $response = new Response();
+
+        // expectations
+        $this->logger->shouldReceive('info');
+        $this->request->shouldReceive('getUri');
+
+        $this->redirect->shouldReceive('toRoute')
+            ->withArgs(['login', ['state' => 'internalSystemError']])
+            ->andReturn($response)
+            ->once();
+
+        // test
+        $controller = $this->getController(TestableAbstractAuthenticatedController::class);
+
+        $result = $controller->onDispatch($event);
+
+        $this->assertEquals($response, $result);
     }
 
     public function testResetSessionCloneData()

--- a/service-front/module/Application/tests/Controller/AbstractAuthenticatedControllerTest.php
+++ b/service-front/module/Application/tests/Controller/AbstractAuthenticatedControllerTest.php
@@ -127,7 +127,7 @@ class AbstractAuthenticatedControllerTest extends AbstractControllerTest
     public function testOnDispatchDatabaseDown()
     {
         // Simulate the database being unavailable, which results in a marker in the session;
-        // see Module.php, where this marker is added before the session is handed over to the controller.
+        // see Module.php, where this marker is added before the session is handed over to the controller
         $authFailureReason = new Container('AuthFailureReason');
         $authFailureReason->reason = 'Internal system error';
         $authFailureReason->code = 500;

--- a/service-front/module/Application/tests/Controller/AbstractControllerTest.php
+++ b/service-front/module/Application/tests/Controller/AbstractControllerTest.php
@@ -172,9 +172,10 @@ abstract class AbstractControllerTest extends MockeryTestCase
     protected $userDetails;
 
     /**
-     * Set up the services in default configuration - these can be adapted in the subclasses before getting the controller to test
+     * Set up the services in default configuration - these can be adapted in the subclasses before getting the
+     * controller to test
      */
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->lpa = FixturesData::getPfLpa();
 
@@ -223,7 +224,9 @@ abstract class AbstractControllerTest extends MockeryTestCase
 
         $this->user = $this->getUserDetails();
 
-        $this->setIdentity(new UserIdentity($this->user->id, 'token', 60 * 60, new DateTime('today midnight')));
+        $this->setIdentity(
+            new UserIdentity($this->user->id, 'token', 60 * 60, new DateTime('today midnight'))
+        );
 
         //  Config array merged so it can be updated in calling test class if required
         $this->config = [
@@ -316,9 +319,15 @@ abstract class AbstractControllerTest extends MockeryTestCase
                 //  If there is no identity then the getApplication call will not be made in the abstract contructor
                 if (!is_null($this->userIdentity)) {
                     if ($this->lpa instanceof Lpa) {
-                        $this->lpaApplicationService->shouldReceive('getApplication')->withArgs([$lpaId])->andReturn($this->lpa)->once();
+                        $this->lpaApplicationService->shouldReceive('getApplication')
+                            ->withArgs([$lpaId])
+                            ->andReturn($this->lpa)
+                            ->once();
                     } else {
-                        $this->lpaApplicationService->shouldReceive('getApplication')->withArgs([$lpaId])->andReturn(false)->once();
+                        $this->lpaApplicationService->shouldReceive('getApplication')
+                            ->withArgs([$lpaId])
+                            ->andReturn(false)
+                            ->once();
                     }
                 }
 
@@ -671,11 +680,17 @@ abstract class AbstractControllerTest extends MockeryTestCase
         return $flattenAttorneyData;
     }
 
-    public function tearDown() : void
+    public function tearDown(): void
     {
-        //Clear out Zend containers
+        // We have what are effectively global variables to track status from Module.php into
+        // controllers, as Module.php bootstraps identity via the API. Clear out the containers
+        // so we can be sure there's nothing being carried between tests.
         $preAuthRequest = new Container('PreAuthRequest');
         $preAuthRequest->url = null;
+
+        $authFailureReason = new Container('AuthFailureReason');
+        $authFailureReason->code = null;
+        $authFailureReason->reason = null;
 
         parent::tearDown();
     }

--- a/service-front/module/Application/tests/Controller/Authenticated/DashboardControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/DashboardControllerTest.php
@@ -309,9 +309,11 @@ class DashboardControllerTest extends AbstractControllerTest
 
         $response = new Response();
 
-        $this->sessionManager->shouldReceive('start')->never();
-        $preAuthRequest = new ArrayObject(['url' => 'https://localhost/user/about-you']);
         $this->request->shouldReceive('getUri')->never();
+
+        // Session should start as we check the content of the AuthFailureReason container in the session
+        // to decide where to redirect to
+        $this->sessionManager->shouldReceive('start')->once();
 
         $this->redirect->shouldReceive('toRoute')
             ->withArgs(['login', ['state' => 'timeout']])->andReturn($response)->once();

--- a/service-front/module/Application/tests/Controller/Authenticated/DeleteControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/DeleteControllerTest.php
@@ -59,12 +59,11 @@ class DeleteControllerTest extends AbstractControllerTest
 
         $response = new Response();
 
-        $this->sessionManager->shouldReceive('start')->never();
-        $preAuthRequest = new ArrayObject(['url' => 'https://localhost/user/about-you']);
+        $this->sessionManager->shouldReceive('start')->once();
         $this->request->shouldReceive('getUri')->never();
 
         $this->redirect->shouldReceive('toRoute')
-            ->withArgs(['login', [ 'state'=>'timeout' ]])->andReturn($response)->once();
+            ->withArgs(['login', [ 'state' => 'timeout' ]])->andReturn($response)->once();
 
         Container::setDefaultManager($this->sessionManager);
         $result = $controller->testCheckAuthenticated(true);

--- a/service-front/module/Application/tests/Model/Service/ApiClient/ClientTest.php
+++ b/service-front/module/Application/tests/Model/Service/ApiClient/ClientTest.php
@@ -36,7 +36,7 @@ class ClientTest extends MockeryTestCase
      */
     private $client;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->httpClient = Mockery::mock(HttpClient::class);
         $this->logger = Mockery::mock(Logger::class);
@@ -89,7 +89,7 @@ class ClientTest extends MockeryTestCase
      *  As the token is private, test that it is updated indirectly by seeing what is added to a request header
      * @throws \Http\Client\Exception
      */
-    public function testUpdateToken() : void
+    public function testUpdateToken(): void
     {
         $this->client->updateToken('new token');
 
@@ -108,7 +108,7 @@ class ClientTest extends MockeryTestCase
     /**
      * @throws \Http\Client\Exception
      */
-    public function testHttpGet() : void
+    public function testHttpGet(): void
     {
         $this->setUpRequest();
 
@@ -120,7 +120,7 @@ class ClientTest extends MockeryTestCase
     /**
      * @throws \Http\Client\Exception
      */
-    public function testHttpGetWithQuery() : void
+    public function testHttpGetWithQuery(): void
     {
         $this->setUpRequest(200, '{"test":"value"}', 'GET', 'base_url/path?a=1');
 
@@ -132,7 +132,7 @@ class ClientTest extends MockeryTestCase
     /**
      * @throws \Http\Client\Exception
      */
-    public function testHttpGetJsonFalse() : void
+    public function testHttpGetJsonFalse(): void
     {
         $this->setUpRequest();
 
@@ -144,7 +144,7 @@ class ClientTest extends MockeryTestCase
     /**
      * @throws \Http\Client\Exception
      */
-    public function testHttpGetNoContent() : void
+    public function testHttpGetNoContent(): void
     {
         $this->setUpRequest(204, null);
 
@@ -156,10 +156,10 @@ class ClientTest extends MockeryTestCase
     /**
      * @throws \Http\Client\Exception
      */
-    public function testHttpGetNotFound() : void
+    public function testHttpGetNotFound(): void
     {
         $this->setUpRequest(404, null);
-        $this->response->shouldReceive('getStatusCode')->twice()->andReturn(404);
+        $this->response->shouldReceive('getStatusCode')->once()->andReturn(404);
         $this->response->shouldReceive('getBody')->once()->andReturn(null);
 
         $expectedLoggerArgs = [
@@ -180,10 +180,10 @@ class ClientTest extends MockeryTestCase
     /**
      * @throws \Http\Client\Exception
      */
-    public function testHttpError() : void
+    public function testHttpError(): void
     {
         $this->setUpRequest(500, 'An error');
-        $this->response->shouldReceive('getStatusCode')->times(2)->andReturn(500);
+        $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
 
         $expectedLoggerArgs = [
             'HTTP:500 - Unexpected API response',
@@ -200,7 +200,7 @@ class ClientTest extends MockeryTestCase
         $this->client->httpGet('path');
     }
 
-    public function testHttpDelete() : void
+    public function testHttpDelete(): void
     {
         $this->setUpRequest(204, null, 'DELETE');
 
@@ -209,10 +209,10 @@ class ClientTest extends MockeryTestCase
         $this->assertNull($result);
     }
 
-    public function testHttpDeleteError() : void
+    public function testHttpDeleteError(): void
     {
         $this->setUpRequest(500, 'An error', 'DELETE');
-        $this->response->shouldReceive('getStatusCode')->times(2)->andReturn(500);
+        $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
 
         $expectedLoggerArgs = [
             'HTTP:500 - Unexpected API response',
@@ -229,7 +229,7 @@ class ClientTest extends MockeryTestCase
         $this->client->httpDelete('path');
     }
 
-    public function testHttpPatch() : void
+    public function testHttpPatch(): void
     {
         $this->setUpRequest(
             200,
@@ -244,7 +244,7 @@ class ClientTest extends MockeryTestCase
         $this->assertEquals(['test' => 'value'], $result);
     }
 
-    public function testHttpPatchAccept() : void
+    public function testHttpPatchAccept(): void
     {
         $this->setUpRequest(
             201,
@@ -254,15 +254,15 @@ class ClientTest extends MockeryTestCase
             '{"a":1}'
         );
 
-        $result = $this->client->httpPatch('path', ['a'=>1]);
+        $result = $this->client->httpPatch('path', ['a' => 1]);
 
         $this->assertEquals(['test' => 'value'], $result);
     }
 
-    public function testHttpPatchError() : void
+    public function testHttpPatchError(): void
     {
         $this->setUpRequest(500, 'An error', 'PATCH', 'base_url/path', '{"a":1}');
-        $this->response->shouldReceive('getStatusCode')->times(2)->andReturn(500);
+        $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
 
         $expectedLoggerArgs = [
             'HTTP:500 - Unexpected API response',
@@ -279,16 +279,16 @@ class ClientTest extends MockeryTestCase
         $this->client->httpPatch('path');
     }
 
-    public function testHttpPost() : void
+    public function testHttpPost(): void
     {
         $this->setUpRequest(200, '{"test": "value"}', 'POST', 'base_url/path', '{"a":1}');
 
-        $result = $this->client->httpPost('path', ['a'=>1]);
+        $result = $this->client->httpPost('path', ['a' => 1]);
 
         $this->assertEquals(['test' => 'value'], $result);
     }
 
-    public function testHttpPostAccept() : void
+    public function testHttpPostAccept(): void
     {
         $this->setUpRequest(201, '{"test": "value"}', 'POST', 'base_url/path', '{"a":1}');
 
@@ -297,10 +297,10 @@ class ClientTest extends MockeryTestCase
         $this->assertEquals(['test' => 'value'], $result);
     }
 
-    public function testHttpPostError() : void
+    public function testHttpPostError(): void
     {
         $this->setUpRequest(500, 'An error', 'POST', 'base_url/path', '{"a":1}');
-        $this->response->shouldReceive('getStatusCode')->times(2)->andReturn(500);
+        $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
 
         $expectedLoggerArgs = [
             'HTTP:500 - Unexpected API response',
@@ -317,7 +317,7 @@ class ClientTest extends MockeryTestCase
         $this->client->httpPost('path');
     }
 
-    public function testHttpPut() : void
+    public function testHttpPut(): void
     {
         $this->setUpRequest(200, '{"test": "value"}', 'PUT', 'base_url/path', '{"a":1}');
 
@@ -326,7 +326,7 @@ class ClientTest extends MockeryTestCase
         $this->assertEquals(['test' => 'value'], $result);
     }
 
-    public function testHttpPutAccept() : void
+    public function testHttpPutAccept(): void
     {
         $this->setUpRequest(201, '{"test": "value"}', 'PUT', 'base_url/path', '{"a":1}');
 
@@ -335,10 +335,10 @@ class ClientTest extends MockeryTestCase
         $this->assertEquals(['test' => 'value'], $result);
     }
 
-    public function testHttpPutError() : void
+    public function testHttpPutError(): void
     {
         $this->setUpRequest(500, 'An error', 'PUT', 'base_url/path', '{"a":1}');
-        $this->response->shouldReceive('getStatusCode')->times(2)->andReturn(500);
+        $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
 
         $this->logger->shouldReceive('err')
                      ->withArgs(['HTTP:500 - Unexpected API response', ['headers' => ['Token' => 'test token']]])

--- a/service-front/module/Application/tests/Model/Service/ApiClient/Exception/ApiExceptionTest.php
+++ b/service-front/module/Application/tests/Model/Service/ApiClient/Exception/ApiExceptionTest.php
@@ -15,12 +15,12 @@ class ApiExceptionTest extends MockeryTestCase
      */
     private $response;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->response = Mockery::mock(ResponseInterface::class);
     }
 
-    public function testConstructor() : void
+    public function testConstructor(): void
     {
         $this->response->shouldReceive('getBody')->once()->andReturn(null);
         $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
@@ -31,7 +31,7 @@ class ApiExceptionTest extends MockeryTestCase
         $this->assertEquals(500, $result->getCode());
     }
 
-    public function testConstructorMessageInResponse() : void
+    public function testConstructorMessageInResponse(): void
     {
         $this->response->shouldReceive('getBody')->once()->andReturn('{"detail":"Body exception message"}');
         $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
@@ -42,10 +42,10 @@ class ApiExceptionTest extends MockeryTestCase
         $this->assertEquals(500, $result->getCode());
     }
 
-    public function testConstructorNoMessage() : void
+    public function testConstructorNoMessage(): void
     {
         $this->response->shouldReceive('getBody')->once()->andReturn(null);
-        $this->response->shouldReceive('getStatusCode')->times(2)->andReturn(500);
+        $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
 
         $result = new ApiException($this->response);
 
@@ -53,50 +53,50 @@ class ApiExceptionTest extends MockeryTestCase
         $this->assertEquals(500, $result->getCode());
     }
 
-    public function testGetTitle() : void
+    public function testGetTitle(): void
     {
         $this->response->shouldReceive('getBody')->once()->andReturn('{"title":"Test Title"}');
-        $this->response->shouldReceive('getStatusCode')->times(2)->andReturn(500);
+        $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
 
         $result = new ApiException($this->response);
 
         $this->assertEquals('Test Title', $result->getTitle());
     }
 
-    public function testGetTitleNotPresent() : void
+    public function testGetTitleNotPresent(): void
     {
         $this->response->shouldReceive('getBody')->once()->andReturn(null);
-        $this->response->shouldReceive('getStatusCode')->times(2)->andReturn(500);
+        $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
 
         $result = new ApiException($this->response);
 
         $this->assertNull($result->getTitle());
     }
 
-    public function testGetData() : void
+    public function testGetData(): void
     {
         $this->response->shouldReceive('getBody')->once()->andReturn('{"data":"Test Data"}');
-        $this->response->shouldReceive('getStatusCode')->times(2)->andReturn(500);
+        $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
 
         $result = new ApiException($this->response);
 
         $this->assertEquals('Test Data', $result->getData());
     }
 
-    public function testGetDataWithKey() : void
+    public function testGetDataWithKey(): void
     {
         $this->response->shouldReceive('getBody')->once()->andReturn('{"data":{"test":"Test Data"}}');
-        $this->response->shouldReceive('getStatusCode')->times(2)->andReturn(500);
+        $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
 
         $result = new ApiException($this->response);
 
         $this->assertEquals('Test Data', $result->getData('test'));
     }
 
-    public function testGetDataNotPresent() : void
+    public function testGetDataNotPresent(): void
     {
         $this->response->shouldReceive('getBody')->once()->andReturn(null);
-        $this->response->shouldReceive('getStatusCode')->times(2)->andReturn(500);
+        $this->response->shouldReceive('getStatusCode')->once()->andReturn(500);
 
         $result = new ApiException($this->response);
 

--- a/service-front/module/Application/tests/Model/Service/User/DetailsTest.php
+++ b/service-front/module/Application/tests/Model/Service/User/DetailsTest.php
@@ -2,6 +2,7 @@
 
 namespace ApplicationTest\Model\Service\User;
 
+use Hamcrest\MatcherAssert;
 use Laminas\Mail\Exception\InvalidArgumentException;
 use Laminas\Session\Container;
 use Exception;
@@ -476,11 +477,15 @@ class DetailsTest extends AbstractEmailServiceTest
         $this->apiClient->shouldReceive('httpPost')
             ->withArgs(['/v2/authenticate', ['authToken' => 'test-token']])
             ->once()
-            ->andReturn(['test' => 'response']);
+            ->andReturn(['expiresIn' => 10000]);
 
         $result = $this->service->getTokenInfo('test-token');
 
-        $this->assertEquals(['test' => 'response'], $result);
+        $this->assertEquals([
+            'success' => true,
+            'failureCode' => null,
+            'expiresIn' => 10000,
+        ], $result);
     }
 
     public function testGetTokenInfoApiException(): void
@@ -492,7 +497,11 @@ class DetailsTest extends AbstractEmailServiceTest
 
         $result = $this->service->getTokenInfo('test-token');
 
-        $this->assertEquals(false, $result);
+        MatcherAssert::assertThat([
+            'success' => false,
+            'failureCode' => 500,
+            'expiresIn' => null,
+        ], Matchers::equalTo($result));
     }
 
     public function testDelete(): void

--- a/service-front/module/Application/view/application/general/auth/partials/error-summary.twig
+++ b/service-front/module/Application/view/application/general/auth/partials/error-summary.twig
@@ -16,6 +16,13 @@
           <p data-tracking-summary="Session timed out">Sorry, your session has timed out due to inactivity or because you have signed in on another browser. Please sign in again.</p>
       </div>
     </div>
+{% elseif isInternalSystemError %}
+    <div class="error-summary text" role="group" aria-labelledby="error-heading" tabindex="-1">
+      <h2 class="heading-medium error-summary-heading" id="error-heading">There is a problem</h2>
+      <div class="error-summary-text" data-tracking-context="Session">
+          <p data-tracking-summary="Internal error">Sorry, the service is unavailable. Please try again later.</p>
+      </div>
+    </div>
 {% endif %}
 
 {% if authError %}

--- a/service-front/module/Application/view/application/general/auth/partials/error-summary.twig
+++ b/service-front/module/Application/view/application/general/auth/partials/error-summary.twig
@@ -22,7 +22,9 @@
     <div class="error-summary text" role="group" aria-labelledby="error-heading" tabindex="-1">
       <h2 class="heading-medium error-summary-heading" id="error-heading" data-cy="error-heading">There is a problem</h2>
       <div class="error-summary-text" data-tracking-context="Signing in">
-            {% if authError == 'not-activated' %}
+            {% if authError == 'api-error' %}
+                <p data-tracking-summary="API unavailable">Sorry, the service is unavailable. Please try again later.</p>
+            {% elseif authError == 'not-activated' %}
                 <p data-tracking-summary="Account not activated">Your account has not been activated. Click on the link in the email sent to you when you created the account.
                     If you have not received an email, check your spam, bulk or junk email folder or <a href="{{ url('register/resend-email') }}">resend activation email</a>.</p>
             {% elseif authError == 'locked' %}


### PR DESCRIPTION
## Purpose

Fixes [LPAL-537](https://opgtransform.atlassian.net/browse/LPAL-537)

## Approach

Modify the API to return a 500 response code when the database is unavailable.

Add extra conditions to treat 500 responses differently from 401 responses.

Unfortunately, the structure of the code means that the only mechanism we have right now for communicating between the Module.php bootstrap methods and controller methods is by putting data into the session, which is tantamount to using global variables. There may be a better way to perform this communication.

Wonder whether there is a way to test this in UAT?

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
