### PR TITLE
LPAL-556 add a secret for cross region snapshot encryption

### DIFF
--- a/terraform/account/put_secrets.tf
+++ b/terraform/account/put_secrets.tf
@@ -2,6 +2,14 @@ resource "aws_kms_key" "secrets_encryption_key" {
   enable_key_rotation = true
 }
 
+resource "aws_kms_key" "rds_snapshot_cross_region_encryption_key" {
+  enable_key_rotation = true
+}
+
+resource "aws_kms_alias" "rds_snapshot_cross_region_encryption" {
+  target_key_id = aws_kms_key.rds_snapshot_cross_region_encryption_key.key_id
+  name          = "alias/rds-snapshot-cross-region-encryption-key"
+}
 
 # common
 resource "aws_secretsmanager_secret" "opg_lpa_common_admin_accounts" {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -55,7 +55,7 @@
       "sirius_api_gateway_endpoint": "https://integration.dev.lpa.api.opg.service.justice.gov.uk/v1/lpa-online-tool/lpas/",
       "sirius_api_gateway_arn": "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/lpa-online-tool/*",
       "auth_token_ttl_secs": 4500,
-      "backup_retention_period": 0,
+      "backup_retention_period": 2,
       "skip_final_snapshot" : true,
       "psql_engine_version": "10.17",
       "psql_parameter_group_family": "postgres10",


### PR DESCRIPTION
## Purpose

to add a kms key for RDS Cross region snapshots.

Supports LPAL-556

## Approach

Add CMK for encrypting snapshots for cross region replication.
Unfortunately the Terraform AWS provider currently doesn't support Cross Region Replication, so this will have to be done manually.
this [issue](https://github.com/hashicorp/terraform-provider-aws/issues/20606) has been raised on the providers github repo.

Also enable snapshot retention to 2 days for testing purposes in preproduction. We'll remove this later, once satisfied it works.

## Learning

Cross-region snapshots for RDS: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReplicateBackups.html

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
