### PR TITLE
lpal-563 remove link to Modernise survey now the deadline is reached

### DIFF
--- a/service-front/module/Application/view/layout/layout.twig
+++ b/service-front/module/Application/view/layout/layout.twig
@@ -144,11 +144,6 @@
         <p>
             Your <a href="/send-feedback">feedback</a> will help us to improve
         </p>
-        <div class="panel panel-border-narrow govuk-details__text" role="note" aria-label="Information">
-        <p>
-            <a href="https://consult.justice.gov.uk/opg/modernising-lasting-powers-of-attorney" rel="noreferrer noopener" target="_blank">Have your say on the future of LPAs<span class="visually-hidden"> (opens in new tab)</a> by taking part in our public consultation
-        </p>
-    </div>
         {% endif %}
 
 


### PR DESCRIPTION
## Purpose

_lpal-563 remove link to Modernise survey now the deadline is reached_

## Approach

_Remove the few lines of twig that had this link in them.  See https://github.com/ministryofjustice/opg-lpa/pull/585/files where this was added. This is simply a reversal of that_ 

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
