### PR TITLE
LPAL-582 

### DIFF
--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -51,11 +51,11 @@ resource "aws_cloudwatch_metric_alarm" "account_breakglass_login_alarm" {
 
 # elasticache cloudwatch alerts
 resource "aws_cloudwatch_metric_alarm" "elasticache_high_cpu_utilization" {
-  for_each                  = toset(aws_elasticache_replication_group.front_cache.member_clusters)
+  count                     = local.cache_cluster_count
   actions_enabled           = true
   alarm_actions             = [aws_sns_topic.cloudwatch_to_slack_elasticache_alerts.arn]
-  alarm_description         = "High CPU usage on ${lower(each.value)}"
-  alarm_name                = "High CPU Utilization on ${lower(each.value)}"
+  alarm_description         = "High CPU usage on ${element(local.cache_member_clusters, count.index)}"
+  alarm_name                = "High CPU Utilization on ${element(local.cache_member_clusters, count.index)}"
   comparison_operator       = "GreaterThanThreshold"
   datapoints_to_alarm       = 2
   evaluation_periods        = 2
@@ -68,16 +68,17 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_high_cpu_utilization" {
   threshold                 = 90
   treat_missing_data        = "notBreaching"
   dimensions = {
-    CacheClusterId = each.value
+    CacheClusterId = element(local.cache_member_clusters, count.index)
   }
+  depends_on = [aws_elasticache_replication_group.front_cache]
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_high_swap_utilization" {
-  for_each                  = toset(aws_elasticache_replication_group.front_cache.member_clusters)
+  count                     = local.cache_cluster_count
   actions_enabled           = true
   alarm_actions             = [aws_sns_topic.cloudwatch_to_slack_elasticache_alerts.arn]
-  alarm_description         = "High swap mem usage on ${lower(each.value)}"
-  alarm_name                = "High swap mem Utilization on ${lower(each.value)}"
+  alarm_description         = "High swap mem usage on ${element(local.cache_member_clusters, count.index)}"
+  alarm_name                = "High swap mem Utilization on ${element(local.cache_member_clusters, count.index)}"
   comparison_operator       = "GreaterThanThreshold"
   datapoints_to_alarm       = 2
   evaluation_periods        = 2
@@ -90,8 +91,9 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_high_swap_utilization" {
   threshold                 = 50000000
   treat_missing_data        = "notBreaching"
   dimensions = {
-    CacheClusterId = each.value
+    CacheClusterId = element(local.cache_member_clusters, count.index)
   }
+  depends_on = [aws_elasticache_replication_group.front_cache]
 }
 
 resource "aws_cloudwatch_event_rule" "tasks_stopped" {

--- a/terraform/account/elasticache.tf
+++ b/terraform/account/elasticache.tf
@@ -18,7 +18,7 @@ resource "aws_elasticache_replication_group" "front_cache" {
   engine                        = "redis"
   engine_version                = "5.0.6"
   node_type                     = "cache.t2.micro"
-  number_cache_clusters         = 2
+  number_cache_clusters         = local.cache_cluster_count
   transit_encryption_enabled    = true
   at_rest_encryption_enabled    = true
   automatic_failover_enabled    = true
@@ -29,4 +29,10 @@ resource "aws_elasticache_replication_group" "front_cache" {
   security_group_ids            = [aws_security_group.front_cache.id]
 
   tags = merge(local.default_tags, local.front_component_tag)
+}
+
+
+locals {
+  cache_cluster_count   = 2
+  cache_member_clusters = tolist(aws_elasticache_replication_group.front_cache.member_clusters)
 }


### PR DESCRIPTION

## Purpose

when attempting to deploy this to EU-West-2 in development,  it was discovered that the cloudwatch alarms could not be applied due to this error:
``` log
│ The "for_each" value depends on resource attributes that cannot be
│ determined until apply, so Terraform cannot predict how many instances will
│ be created. To work around this, use the -target argument to first apply
│ only the resources that the for_each depends on.
```
A workaround is to use `count` instead and precompute the member cluster identifiers using locals.

Fixes LPAL-582

## Approach

- Update alarms to use count instead of foreach.
- Add locals to fix issue with cluster member identifiers


## Learning

See:
https://github.com/cloudposse/terraform-aws-elasticache-redis/blob/ea8baf469c304a257d48670d40a42dbf13e2c12a/main.tf#L13
https://github.com/cloudposse/terraform-aws-elasticache-redis/blob/ea8baf469c304a257d48670d40a42dbf13e2c12a/main.tf#L94

for examples of inspiration


## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
