### PR TITLE
Lpal 598 rebuild s3 region based buckets

### DIFF
--- a/terraform/region/modules/region/elasticache.tf
+++ b/terraform/region/modules/region/elasticache.tf
@@ -15,9 +15,9 @@ resource "aws_elasticache_subnet_group" "private_subnets" {
 resource "aws_elasticache_replication_group" "front_cache" {
   replication_group_id          = "${local.account_name_short}-${local.region_name}-front-cache-rg"
   replication_group_description = "front cache replication group"
-  parameter_group_name          = "default.redis5.0"
+  parameter_group_name          = "default.redis6.x"
   engine                        = "redis"
-  engine_version                = "5.0.6"
+  engine_version                = "6.x"
   node_type                     = "cache.t2.micro"
   number_cache_clusters         = local.cache_cluster_count
   transit_encryption_enabled    = true

--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -1,0 +1,154 @@
+data "aws_elb_service_account" "main" {
+  region = local.region_name
+}
+
+data "aws_iam_policy_document" "loadbalancer_logging" {
+  statement {
+    sid = "accessLogBucketAccess"
+
+    resources = [
+      aws_s3_bucket.access_log.arn,
+      "${aws_s3_bucket.access_log.arn}/*",
+    ]
+
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+
+    principals {
+      identifiers = [data.aws_elb_service_account.main.id]
+
+      type = "AWS"
+    }
+  }
+
+  statement {
+    sid    = "AllowSSLRequestsOnly"
+    effect = "Deny"
+
+    resources = [
+      aws_s3_bucket.access_log.arn,
+      "${aws_s3_bucket.access_log.arn}/*",
+    ]
+
+    actions = ["s3:*"]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}
+
+#versioning not required for a logging bucket bucket logging not needed
+#tfsec:ignore:AWS002  #tfsec:ignore:AWS077
+resource "aws_s3_bucket" "access_log" {
+  bucket = "online-lpa-${local.account_name}-${local.region_name}-lb-access-logs"
+  acl    = "private"
+  tags   = local.default_tags
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "access_log" {
+  bucket                  = aws_s3_bucket.access_log.id
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+  ignore_public_acls      = true
+}
+
+resource "aws_s3_bucket_policy" "access_log" {
+  bucket = aws_s3_bucket.access_log.id
+  policy = data.aws_iam_policy_document.loadbalancer_logging.json
+
+}
+
+#tfsec:ignore:AWS002 #tfsec:ignore:AWS077 - no logging or versioning required as a temp cache
+resource "aws_s3_bucket" "lpa_pdf_cache" {
+  bucket        = lower("online-lpa-pdf-cache-${local.account_name}-${local.region_name}")
+  acl           = "private"
+  force_destroy = local.account_name != "production" ? true : false
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.lpa_pdf_cache.arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+  # Clear items out teh cache after 1 day.
+  lifecycle_rule {
+    enabled = true
+    expiration {
+      days = 1
+    }
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_s3_bucket_policy" "lpa_pdf_cache" {
+  bucket = aws_s3_bucket.lpa_pdf_cache.id
+  policy = data.aws_iam_policy_document.lpa_pdf_cache_policy.json
+
+}
+
+resource "aws_s3_bucket_public_access_block" "lpa_pdf_cache" {
+  bucket = aws_s3_bucket.lpa_pdf_cache.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_kms_key" "lpa_pdf_cache" {
+  description             = "S3 bucket encryption key for lpa_pdf_cache"
+  deletion_window_in_days = 7
+  tags                    = merge(local.default_tags, local.pdf_component_tag)
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "lpa_pdf_cache" {
+  name          = "alias/lpa_pdf_cache-${local.account_name}-${local.region_name}"
+  target_key_id = aws_kms_key.lpa_pdf_cache.key_id
+}
+
+data "aws_iam_policy_document" "lpa_pdf_cache_policy" {
+  statement {
+    sid    = "AllowSSLRequestsOnly"
+    effect = "Deny"
+
+    resources = [
+      aws_s3_bucket.lpa_pdf_cache.arn,
+      "${aws_s3_bucket.lpa_pdf_cache.arn}/*",
+    ]
+
+    actions = ["s3:*"]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}

--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -72,7 +72,6 @@ resource "aws_s3_bucket_public_access_block" "access_log" {
 resource "aws_s3_bucket_policy" "access_log" {
   bucket = aws_s3_bucket.access_log.id
   policy = data.aws_iam_policy_document.loadbalancer_logging.json
-
 }
 
 #tfsec:ignore:AWS002 #tfsec:ignore:AWS077 - no logging or versioning required as a temp cache

--- a/terraform/region/modules/region/variables.tf
+++ b/terraform/region/modules/region/variables.tf
@@ -1,6 +1,6 @@
 variable "account" {
+  description = "the account object passed into the region module."
   type = object({
-
     account_name_short = string
     account_id         = string
     is_production      = string
@@ -15,5 +15,6 @@ variable "account" {
 }
 
 variable "account_name" {
-  type = string
+  description = "account name passed into the region module"
+  type        = string
 }

--- a/terraform/region/terraform.tf
+++ b/terraform/region/terraform.tf
@@ -65,11 +65,6 @@ provider "aws" {
   }
 }
 
-
-
-
-
-
 provider "pagerduty" {
   token = var.pagerduty_token
 }

--- a/terraform/region/variables.tf
+++ b/terraform/region/variables.tf
@@ -1,16 +1,20 @@
 variable "default_role" {
-  default = "opg-lpa-ci"
+  description = "default aws IAM role to use. defaults to the CI Role"
+  default     = "opg-lpa-ci"
 }
 
 variable "pagerduty_token" {
+  description = "pagerduty token"
 }
 
 # variables for terraform.tfvars.json
 variable "account_mapping" {
-  type = map(any)
+  description = "maps the tfvars.json files to accounts"
+  type        = map(any)
 }
 
 variable "accounts" {
+  description = "the account map loaded from tfvars.json"
   type = map(
     object({
       account_id         = string


### PR DESCRIPTION
## Purpose

To add definitions for region based S3 Buckets.

Fixes LPAL-598

## Approach

Takes a copy of existing account based buckets and creates new ones which are region ready.

Additional items: 

- Use Elasticache 6.x on new resources.
- Add descriptions 
- Some minor clean up.

Still not CI Based. in a later ticket.

## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
