### PR TITLE
LPAL-620 remove standard kms key use on sns topic as is not usable in cloudwatch

### DIFF
--- a/terraform/environment/sns.tf
+++ b/terraform/environment/sns.tf
@@ -1,13 +1,13 @@
+#tfsec:ignore:aws-sns-enable-topic-encryption CMK to be added
 resource "aws_sns_topic" "cloudwatch_to_pagerduty" {
-  name              = "CloudWatch-to-PagerDuty-${local.environment}"
-  tags              = merge(local.default_tags, local.shared_component_tag)
-  kms_master_key_id = "alias/aws/sns"
-}
+  name = "CloudWatch-to-PagerDuty-${local.environment}"
+  tags = merge(local.default_tags, local.shared_component_tag)
 
+}
+#tfsec:ignore:aws-sns-enable-topic-encryption  CMK to be added
 resource "aws_sns_topic" "cloudwatch_to_pagerduty_ops" {
-  name              = "CloudWatch-to-PagerDuty-${local.environment}-Ops"
-  tags              = merge(local.default_tags, local.shared_component_tag)
-  kms_master_key_id = "alias/aws/sns"
+  name = "CloudWatch-to-PagerDuty-${local.environment}-Ops"
+  tags = merge(local.default_tags, local.shared_component_tag)
 }
 
 resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription" {


### PR DESCRIPTION
## Purpose

remove SNS default key on Cloudwatch to Pagerduty SNS topics on environment level resources. it was prevented firing of alarms by this error:

```
Failed to execute action arn:aws:sns:eu-west-1:xxxxxxxxxx:CloudWatch-to-PagerDuty-production-Ops. Received error: "null (Service: AWSKMS; Status Code: 400; Error Code: AccessDeniedException; Request ID:some-request-uuid; Proxy: null)"
```

Fixes LPAL-620, and should reinstate environment level ops notifications.

## Approach

- remove and ignore the encryption on tfsec 
- I have created a further ticket to fix to use a CMK: see LPAL-619

## Learning


https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
