### PR TITLE
Lpal 600 fix up ecs task

### DIFF
--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -1,0 +1,60 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.65.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:GCDkcISN83t+JK2U+ie3vaECnyxK0Sr6GjO7IrBOVeo=",
+    "zh:108aeaf5e18087d9ac852737a5be1347a28e40825817cc1a29ec523d40268294",
+    "zh:1a719c0c9754f906b2220d3bbf90d483ec0a74cf87768a464d2d657b7901ec6b",
+    "zh:21acdc35ae70a626cbc81eff06181a78843f1ddc2d9200f80fabf2e0466ecbda",
+    "zh:28846628e1a4227a1f2db256d6b22ed36922f37632999af7404aa74703cd9bfb",
+    "zh:32455550dbf86ae07d9782650e86d23c4fa13d7872e48680044692894e8da6ea",
+    "zh:4241246274627c752f9aef2806e810053306001e80fc5b51d27cbe997f75f95e",
+    "zh:5ca0fab3ceb3f41a97c1ebd29561a034cb83fda04da35fd5f8c3c5cb97bb3ea8",
+    "zh:5fed3b79d4ed6424055e8bbfb7a4393e8db5102cdba04b4590f8e0f4194637fb",
+    "zh:99a0bc325b0a59ded1152546c004953a2bb0e110978bf0cc55e1804384941bdb",
+    "zh:e74f9190a417c891992210f9af937ef55749d86a04762d982260fbbc989342a7",
+    "zh:fb6984405ca63d0373bd992ce157e933b8ae9dd94d74b1c5691632f062fe60b2",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.1.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
+    "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
+    "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
+    "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
+    "zh:719dfd97bb9ddce99f7d741260b8ece2682b363735c764cac83303f02386075a",
+    "zh:7598bb86e0378fd97eaa04638c1a4c75f960f62f69d3662e6d80ffa5a89847fe",
+    "zh:ad0a188b52517fec9eca393f1e2c9daea362b33ae2eb38a857b6b09949a727c1",
+    "zh:c46846c8df66a13fee6eff7dc5d528a7f868ae0dcf92d79deaac73cc297ed20c",
+    "zh:dc1a20a2eec12095d04bf6da5321f535351a594a636912361db20eb2a707ccc4",
+    "zh:e57ab4771a9d999401f6badd8b018558357d3cbdf3d33cc0c4f83e818ca8e94b",
+    "zh:ebdcde208072b4b0f8d305ebf2bfdc62c926e0717599dcf8ec2fd8c5845031c3",
+    "zh:ef34c52b68933bedd0868a13ccfd59ff1c820f299760b3c02e008dc95e2ece91",
+  ]
+}
+
+provider "registry.terraform.io/pagerduty/pagerduty" {
+  version     = "1.11.0"
+  constraints = "~> 1.7"
+  hashes = [
+    "h1:fHnJyv6O+84J/6kcXfXL0WMW+ucNWiXLIgUEiv6giRI=",
+    "zh:07c0216925503f75a23fc59e55e1469474d06ce98076d00fa9f7e8e36c4633f4",
+    "zh:566f1b9237ce09580f1f01cabe988c6dd5ff6aca3de660b96ca28cb08f4aadc1",
+    "zh:5a8f7d04eee690626785fadffd06709a39ed4d3d10ddc310806de27f9a4d953c",
+    "zh:6c076938995fd624c806075b8a993573cbef130eb9f107beb5290fb07d466a06",
+    "zh:80c223ae2b533ef62da0018b87e1dff25cb16fdc3681b8b53f6093408b6efc3b",
+    "zh:91fa5c997708631b7ec239893e31c3083fb55065efb6080669415c05071129d7",
+    "zh:9559a6a8a0a08392f0b4c54513c1539db0ced8998950f4b82ff2d487e4fe7bcf",
+    "zh:ab29a383d66adacdaf002e52c63828683d9c95ff44ca8d0a1a8c1d7aa27fc253",
+    "zh:acffba58c738e1c57464cdde6766fd3a8258c4c483c5792c9724c78869024f43",
+    "zh:c2fe03ca140252a954d34a0c8afed13851e5ac38e18b5e052afdfbd2294bd21f",
+    "zh:d1437fde52f29bfcc2f580f97859957a13677d3ae9942cdd3d50b0a1d978e763",
+    "zh:e7499a21b82327c78676e13d23fd5eaaa76fbb85970d069bab30f44c8863f8be",
+  ]
+}

--- a/terraform/environment/ecs_front.tf
+++ b/terraform/environment/ecs_front.tf
@@ -48,7 +48,18 @@ resource "aws_security_group_rule" "front_ecs_service_ingress" {
   source_security_group_id = aws_security_group.front_loadbalancer.id
 }
 
-// from front to Elasticache
+// from front to Elasticache (new regional one)
+#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
+resource "aws_security_group_rule" "front_ecs_service_elasticache_region_ingress" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 6379
+  protocol                 = "tcp"
+  security_group_id        = data.aws_security_group.front_cache_region.id
+  source_security_group_id = aws_security_group.front_ecs_service.id
+}
+
+// from front to Elasticache (legacy - remove after.)
 #tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "front_ecs_service_elasticache_ingress" {
   type                     = "ingress"
@@ -264,7 +275,7 @@ locals {
         { "name" : "OPG_LPA_COMMON_PDF_QUEUE_URL", "value" : aws_sqs_queue.pdf_fifo_queue.id },
         { "name" : "OPG_LPA_ENDPOINTS_API", "value" : "http://${local.api_service_fqdn}" },
         { "name" : "OPG_LPA_OS_PLACES_HUB_ENDPOINT", "value" : "https://api.os.uk/search/places/v1/postcode" },
-        { "name" : "OPG_LPA_COMMON_REDIS_CACHE_URL", "value" : "tls://${data.aws_elasticache_replication_group.front_cache.primary_endpoint_address}" },
+        { "name" : "OPG_LPA_COMMON_REDIS_CACHE_URL", "value" : "tls://${data.aws_elasticache_replication_group.front_cache_region.primary_endpoint_address}" },
         { "name" : "AWS_ACCOUNT_TYPE", "value" : local.account_name },
         { "name" : "OPG_LPA_FRONT_EMAIL_TRANSPORT", "value" : "notify" }
       ]
@@ -312,7 +323,7 @@ locals {
         { "name" : "OPG_LPA_COMMON_RESQUE_REDIS_HOST", "value" : "redisback" },
         { "name" : "OPG_LPA_COMMON_PDF_CACHE_S3_BUCKET", "value" : data.aws_s3_bucket.lpa_pdf_cache.bucket },
         { "name" : "OPG_LPA_ENDPOINTS_API", "value" : "http://${local.api_service_fqdn}" },
-        { "name" : "OPG_LPA_COMMON_REDIS_CACHE_URL", "value" : "tls://${data.aws_elasticache_replication_group.front_cache.primary_endpoint_address}" },
+        { "name" : "OPG_LPA_COMMON_REDIS_CACHE_URL", "value" : "tls://${data.aws_elasticache_replication_group.front_cache_region.primary_endpoint_address}" },
         { "name" : "OPG_LPA_FRONT_EMAIL_TRANSPORT", "value" : "notify" }
       ]
     }

--- a/terraform/environment/ecs_front.tf
+++ b/terraform/environment/ecs_front.tf
@@ -49,9 +49,9 @@ resource "aws_security_group_rule" "front_ecs_service_ingress" {
 }
 
 // from front to Elasticache (new regional one)
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "front_ecs_service_elasticache_region_ingress" {
   type                     = "ingress"
+  description              = "allows service front access to elasticache"
   from_port                = 0
   to_port                  = 6379
   protocol                 = "tcp"

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -8,8 +8,10 @@ locals {
 
   opg_project                 = "lpa"
   account_name                = lookup(var.account_mapping, terraform.workspace, "development")
+  account_name_short          = local.account.account_name_short
   account                     = var.accounts[local.account_name]
   environment                 = terraform.workspace
+  region_name                 = "eu-west-1"
   cert_prefix_public_facing   = local.environment == "production" ? "www." : "*."
   cert_prefix_internal        = local.account_name == "production" ? "" : "*."
   dns_namespace_env           = local.environment == "production" ? "" : "${local.environment}."

--- a/terraform/environment/shared_data_sources.tf
+++ b/terraform/environment/shared_data_sources.tf
@@ -1,7 +1,7 @@
 data "aws_security_group" "front_cache" {
-  name = "front-cache"
+  name = "${local.account_name_short}-${local.region_name}-front-cache"
 }
 
 data "aws_elasticache_replication_group" "front_cache" {
-  replication_group_id = "front-cache-replication-group"
+  replication_group_id = "${local.account_name_short}-${local.region_name}-front-cache-rg"
 }

--- a/terraform/environment/shared_data_sources.tf
+++ b/terraform/environment/shared_data_sources.tf
@@ -5,3 +5,31 @@ data "aws_security_group" "front_cache" {
 data "aws_elasticache_replication_group" "front_cache" {
   replication_group_id = "${local.account_name_short}-${local.region_name}-front-cache-rg"
 }
+
+data "aws_s3_bucket" "access_log" {
+  bucket = "online-lpa-${local.account_name}-${local.region_name}-lb-access-logs"
+}
+
+data "aws_s3_bucket" "lpa_pdf_cache" {
+  bucket = lower("online-lpa-pdf-cache-${local.account_name}-${local.region_name}")
+}
+
+data "aws_kms_key" "lpa_pdf_cache" {
+  key_id = "alias/lpa_pdf_cache-${local.account_name}"
+}
+
+data "aws_acm_certificate" "certificate_front" {
+  domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}front.lpa.opg.service.justice.gov.uk"
+}
+
+data "aws_acm_certificate" "certificate_admin" {
+  domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}admin.lpa.opg.service.justice.gov.uk"
+}
+
+data "aws_acm_certificate" "public_facing_certificate" {
+  domain = "${local.cert_prefix_public_facing}${local.dns_namespace_dev_prefix}lastingpowerofattorney.service.gov.uk"
+}
+
+data "aws_iam_role" "ecs_autoscaling_service_role" {
+  name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
+}

--- a/terraform/environment/shared_data_sources.tf
+++ b/terraform/environment/shared_data_sources.tf
@@ -1,8 +1,8 @@
-data "aws_security_group" "front_cache" {
+data "aws_security_group" "front_cache_region" {
   name = "${local.account_name_short}-${local.region_name}-front-cache"
 }
 
-data "aws_elasticache_replication_group" "front_cache" {
+data "aws_elasticache_replication_group" "front_cache_region" {
   replication_group_id = "${local.account_name_short}-${local.region_name}-front-cache-rg"
 }
 
@@ -32,4 +32,12 @@ data "aws_acm_certificate" "public_facing_certificate" {
 
 data "aws_iam_role" "ecs_autoscaling_service_role" {
   name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
+}
+
+#keep as is as we want to destroy after new one in place.
+data "aws_elasticache_replication_group" "front_cache" {
+  replication_group_id = "front-cache-replication-group"
+}
+data "aws_security_group" "front_cache" {
+  name = "front-cache"
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -23,6 +23,7 @@
       "psql_engine_version": "10.17",
       "psql_parameter_group_family": "postgres10",
       "log_retention_in_days": 7,
+      "account_name_short" : "dev",
       "autoscaling": {
         "front": {
           "minimum": 1,
@@ -60,6 +61,7 @@
       "psql_engine_version": "10.17",
       "psql_parameter_group_family": "postgres10",
       "log_retention_in_days": 7,
+      "account_name_short" : "pre",
       "autoscaling": {
         "front": {
           "minimum": 1,
@@ -97,6 +99,7 @@
       "psql_engine_version": "10.17",
       "psql_parameter_group_family": "postgres10",
       "log_retention_in_days": 120,
+      "account_name_short" : "prod",
       "autoscaling": {
         "front": {
           "minimum": 3,

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -32,6 +32,7 @@ variable "accounts" {
       deletion_protection          = bool
       always_on                    = bool
       log_retention_in_days        = number
+      account_name_short           = string
       autoscaling = object({
         front = object({
           minimum = number

--- a/terraform/environment/vpc_data.sources.tf
+++ b/terraform/environment/vpc_data.sources.tf
@@ -21,31 +21,3 @@ data "aws_subnet_ids" "public" {
 module "allowed_ip_list" {
   source = "git@github.com:ministryofjustice/terraform-aws-moj-ip-whitelist.git"
 }
-
-data "aws_s3_bucket" "access_log" {
-  bucket = "online-lpa-${local.account_name}-lb-access-logs"
-}
-
-data "aws_s3_bucket" "lpa_pdf_cache" {
-  bucket = lower("online-lpa-pdf-cache-${local.account_name}")
-}
-
-data "aws_kms_key" "lpa_pdf_cache" {
-  key_id = "alias/lpa_pdf_cache-${local.account_name}"
-}
-
-data "aws_acm_certificate" "certificate_front" {
-  domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}front.lpa.opg.service.justice.gov.uk"
-}
-
-data "aws_acm_certificate" "certificate_admin" {
-  domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}admin.lpa.opg.service.justice.gov.uk"
-}
-
-data "aws_acm_certificate" "public_facing_certificate" {
-  domain = "${local.cert_prefix_public_facing}${local.dns_namespace_dev_prefix}lastingpowerofattorney.service.gov.uk"
-}
-
-data "aws_iam_role" "ecs_autoscaling_service_role" {
-  name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
-}


### PR DESCRIPTION
## Purpose

hook up ECS to new region level named resources.

Fixes LPAL-600

## Approach

- Add environment level values for short name into variables e.g. `dev, pre, prod`
- Hard code `eu-west-1` as region name - this will be refactored later when we modularise environment level resources.
- Point to new elasticache.
- Point to new PDF Cache S3 bucket.
- Add security group rule to allow access to new Elasticache, whilst temporarily retaining existing one.
- Move of data sources to a different file make this more canonical.

## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
