### PR TITLE
LPAL-626 cypress tests add failed logs plugin.

### DIFF
--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 RUN pip3 install boto3 requests
 
 RUN npm install --save-dev axe-core \
-    cypress-cucumber-preprocessor cypress-plugin-tab
+    cypress-cucumber-preprocessor cypress-plugin-tab cypress-failed-log
 
 ENV CYPRESS_VIDEO=false
 ENV CYPRESS_RUN_A11Y_TESTS=true

--- a/cypress/integration/ApplicantPF.feature
+++ b/cypress/integration/ApplicantPF.feature
@@ -16,7 +16,7 @@ Feature: Add Applicant to a Property and Finance LPA
         Then I am taken to the applicant page
         When I click "save"
         Then I see in the page text
-            | There is a problem |
+            | There is delibrately break the build here a problem |
             | Select the person who is applying to register the LPA |
         And I see "Error" in the title
         # select the donor as applicant

--- a/cypress/integration/ApplicantPF.feature
+++ b/cypress/integration/ApplicantPF.feature
@@ -16,7 +16,7 @@ Feature: Add Applicant to a Property and Finance LPA
         Then I am taken to the applicant page
         When I click "save"
         Then I see in the page text
-            | There is delibrately break the build here a problem |
+            | There is a problem |
             | Select the person who is applying to register the LPA |
         And I see "Error" in the title
         # select the donor as applicant

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -60,5 +60,9 @@ module.exports = (on, config) => {
     },
   });
 
+  on('task', {
+    failed: require('cypress-failed-log/src/failed')(),
+  })
+
   return config;
 }

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -14,6 +14,7 @@
 // ***********************************************************
 
 
+require('cypress-failed-log')
 // Import commands.js using ES2015 syntax:
 import './commands'
 


### PR DESCRIPTION
## Purpose

_Recent changes to cypress flags to speed it up, have removed some feedback when tests fail. Introduce the failed logs plugin to give this feedback on the command line_

Fixes LPAL-626

## Approach

_Install the necessary plugin_ 

Learning: 
- Plugin: https://github.com/bahmutov/cypress-failed-log

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
