### PR TITLE
LPAL-631: pin to 3.14 alpine linux for PHP.

### DIFF
--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -5,7 +5,7 @@ COPY service-api/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:7.4-fpm-alpine
+FROM php:7.4-fpm-alpine3.14
 
 RUN apk add --upgrade apk-tools
 RUN apk upgrade --available


### PR DESCRIPTION
## Purpose

Pin  PHP to alpine3.14 as 3.15 broke postgres libraries
Fixes LPAL-631

## Approach

Update Dockerfile.
## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
