### PR TITLE
HOTFIX: fix permissions on KMS key access for cluster

### DIFF
--- a/terraform/environment/ecs_cluster.tf
+++ b/terraform/environment/ecs_cluster.tf
@@ -113,4 +113,19 @@ data "aws_iam_policy_document" "execution_role" {
       data.aws_secretsmanager_secret.performance_platform_db_password.arn
     ]
   }
+
+  statement {
+    effect = "Allow"
+
+    resources = [data.aws_kms_alias.secrets_encryption_alias.target_key_arn]
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKeyPair",
+      "kms:GenerateDataKeyPairWithoutPlaintext",
+      "kms:GenerateDataKeyWithoutPlaintext",
+      "kms:DescribeKey",
+    ]
+  }
 }

--- a/terraform/environment/shared_data_sources.tf
+++ b/terraform/environment/shared_data_sources.tf
@@ -33,3 +33,7 @@ data "aws_acm_certificate" "public_facing_certificate" {
 data "aws_iam_role" "ecs_autoscaling_service_role" {
   name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
 }
+
+data "aws_kms_alias" "secrets_encryption_alias" {
+  name = "alias/secrets_encryption_key-${local.account_name}"
+}

--- a/terraform/region/modules/region/kms.tf
+++ b/terraform/region/modules/region/kms.tf
@@ -2,6 +2,12 @@ resource "aws_kms_key" "secrets_encryption_key" {
   enable_key_rotation = true
 }
 
+resource "aws_kms_alias" "secrets_encryption_alias" {
+  name          = "alias/secrets_encryption_key-${terraform.workspace}"
+  target_key_id = aws_kms_key.secrets_encryption_key.key_id
+}
+
+
 resource "aws_kms_key" "lpa_pdf_cache" {
   description             = "S3 bucket encryption key for lpa_pdf_cache"
   deletion_window_in_days = 7


### PR DESCRIPTION
## Purpose

To fix issues with encryption key for cluster on ECS. 

Fixes LPAL-#### (TO FOLLOW)

## Approach

Add iam permissions to ecs to decrypt key.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
