### PR TITLE
LPAL-636 - Security issue: Fix Lambda critical CVE ALAS2-2021-1722 from AWS

### DIFF
--- a/service-perfplat/docker/Dockerfile-worker-ci
+++ b/service-perfplat/docker/Dockerfile-worker-ci
@@ -17,6 +17,10 @@ FROM public.ecr.aws/lambda/python:3.8
 
 # fixes security issues detected in build.
 RUN yum update -y rpm openssl curl
+RUN yum update nss
+RUN yum update nss-util
+RUN yum update nss-softokn
+RUN yum update nspr
 
 RUN yum install -y postgresql && \
     yum clean all && \

--- a/service-perfplat/docker/Dockerfile-worker-dev
+++ b/service-perfplat/docker/Dockerfile-worker-dev
@@ -17,6 +17,10 @@ FROM public.ecr.aws/lambda/python:3.8
 
 # fixes security issues detected in build.
 RUN yum update -y rpm openssl curl
+RUN yum update nss
+RUN yum update nss-util
+RUN yum update nss-softokn
+RUN yum update nspr
 
 RUN yum install -y postgresql && \
     yum clean all && \


### PR DESCRIPTION
## Purpose

Security bulletin publish by AWS for nss libraries - https://alas.aws.amazon.com/AL2/ALAS-2021-1722.html

Fixes LPAL-636

## Approach

_Explain how your code addresses the purpose of the change_ 

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
