### PR TITLE
LPAL-645 part 2: enable waf web acl association with front and admin

### DIFF
--- a/terraform/environment/modules/environment/variables.tf
+++ b/terraform/environment/modules/environment/variables.tf
@@ -16,26 +16,27 @@ variable "lambda_container_version" {
 
 variable "account" {
   type = object({
-    dr_enabled                   = bool
-    performance_platform_enabled = bool
-    pagerduty_service_name       = string
-    account_id                   = string
-    is_production                = string
-    sirius_api_gateway_endpoint  = string
-    sirius_api_gateway_arn       = string
-    deletion_protection          = bool
-    backup_retention_period      = number
-    auth_token_ttl_secs          = number
-    skip_final_snapshot          = bool
-    psql_engine_version          = string
-    psql_parameter_group_family  = string
-    aurora_enabled               = bool
-    aurora_serverless            = bool
-    aurora_instance_count        = number
-    deletion_protection          = bool
-    always_on                    = bool
-    log_retention_in_days        = number
-    account_name_short           = string
+    dr_enabled                             = bool
+    performance_platform_enabled           = bool
+    pagerduty_service_name                 = string
+    account_id                             = string
+    is_production                          = string
+    sirius_api_gateway_endpoint            = string
+    sirius_api_gateway_arn                 = string
+    deletion_protection                    = bool
+    backup_retention_period                = number
+    auth_token_ttl_secs                    = number
+    skip_final_snapshot                    = bool
+    psql_engine_version                    = string
+    psql_parameter_group_family            = string
+    aurora_enabled                         = bool
+    aurora_serverless                      = bool
+    aurora_instance_count                  = number
+    deletion_protection                    = bool
+    always_on                              = bool
+    log_retention_in_days                  = number
+    account_name_short                     = string
+    associate_alb_with_waf_web_acl_enabled = bool
     regions = map(
       object({
         region     = string

--- a/terraform/environment/modules/environment/waf.tf
+++ b/terraform/environment/modules/environment/waf.tf
@@ -1,0 +1,16 @@
+data "aws_wafv2_web_acl" "main" {
+  name  = "${local.account_name}-${local.region_name}-web-acl"
+  scope = "REGIONAL"
+}
+
+resource "aws_wafv2_web_acl_association" "front" {
+  count        = var.account.associate_alb_with_waf_web_acl_enabled ? 1 : 0
+  resource_arn = aws_lb.front.arn
+  web_acl_arn  = data.aws_wafv2_web_acl.main.arn
+}
+
+resource "aws_wafv2_web_acl_association" "admin" {
+  count        = var.account.associate_alb_with_waf_web_acl_enabled ? 1 : 0
+  resource_arn = aws_lb.admin.arn
+  web_acl_arn  = data.aws_wafv2_web_acl.main.arn
+}

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -25,6 +25,7 @@
       "psql_parameter_group_family": "postgres10",
       "log_retention_in_days": 7,
       "account_name_short" : "dev",
+      "associate_alb_with_waf_web_acl_enabled": false,
       "autoscaling": {
         "front": {
           "minimum": 1,
@@ -74,6 +75,7 @@
       "psql_parameter_group_family": "postgres10",
       "log_retention_in_days": 7,
       "account_name_short" : "pre",
+      "associate_alb_with_waf_web_acl_enabled": true,
       "autoscaling": {
         "front": {
           "minimum": 1,
@@ -123,6 +125,7 @@
       "psql_parameter_group_family": "postgres10",
       "log_retention_in_days": 120,
       "account_name_short" : "prod",
+      "associate_alb_with_waf_web_acl_enabled": true,
       "autoscaling": {
         "front": {
           "minimum": 3,

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -22,26 +22,27 @@ variable "lambda_container_version" {
 variable "accounts" {
   type = map(
     object({
-      dr_enabled                   = bool
-      performance_platform_enabled = bool
-      pagerduty_service_name       = string
-      account_id                   = string
-      is_production                = string
-      sirius_api_gateway_endpoint  = string
-      sirius_api_gateway_arn       = string
-      deletion_protection          = bool
-      backup_retention_period      = number
-      auth_token_ttl_secs          = number
-      skip_final_snapshot          = bool
-      psql_engine_version          = string
-      psql_parameter_group_family  = string
-      aurora_enabled               = bool
-      aurora_serverless            = bool
-      aurora_instance_count        = number
-      deletion_protection          = bool
-      always_on                    = bool
-      log_retention_in_days        = number
-      account_name_short           = string
+      dr_enabled                             = bool
+      performance_platform_enabled           = bool
+      pagerduty_service_name                 = string
+      account_id                             = string
+      is_production                          = string
+      sirius_api_gateway_endpoint            = string
+      sirius_api_gateway_arn                 = string
+      deletion_protection                    = bool
+      backup_retention_period                = number
+      auth_token_ttl_secs                    = number
+      skip_final_snapshot                    = bool
+      psql_engine_version                    = string
+      psql_parameter_group_family            = string
+      aurora_enabled                         = bool
+      aurora_serverless                      = bool
+      aurora_instance_count                  = number
+      deletion_protection                    = bool
+      always_on                              = bool
+      log_retention_in_days                  = number
+      account_name_short                     = string
+      associate_alb_with_waf_web_acl_enabled = bool
       regions = map(
         object({
           region     = string


### PR DESCRIPTION
## Purpose

To associate the front and asmin  Load balancers with the WAF ACL.

Fixes LPAL-645, a follow on from #761 

## Approach

Add associations entries to the WAF ACL for front and asmin LBs.

## Learning

see also:

- https://github.com/ministryofjustice/opg-use-an-lpa/pull/1277 
- https://github.com/ministryofjustice/opg-use-an-lpa/pull/1288

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
