### PR TITLE
LPAL-652 elasticache alert for high swap use to 95 MBits

### DIFF
--- a/terraform/region/modules/region/cloudwatch.tf
+++ b/terraform/region/modules/region/cloudwatch.tf
@@ -36,7 +36,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_high_swap_utilization" {
   ok_actions                = [aws_sns_topic.cloudwatch_to_slack_elasticache_alerts.arn]
   period                    = "60"
   statistic                 = "Sum"
-  threshold                 = 50000000
+  threshold                 = 95000000
   treat_missing_data        = "notBreaching"
   dimensions = {
     CacheClusterId = element(local.cache_member_clusters, count.index)


### PR DESCRIPTION
## Purpose

To adjust the alert from 50MBits, to 95MBits. 
The current alert is triggering too much and the service is not affected at this level. The normal range is 20 to 90 MBits.

Fixes LPAL-652

## Approach

Change CloudWatch alarm to new value.

## Learning

N/A

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
