### PR TITLE
LPAL-650 improve coverage of Change Correspondent feature

### DIFF
--- a/cypress/integration/CorrespondentPFClone.feature
+++ b/cypress/integration/CorrespondentPFClone.feature
@@ -7,19 +7,42 @@ Feature: Add a correspondent to a Property and Finance LPA
         Given I ignore application exceptions
         And I create PF LPA test fixture with donor, single attorney, cert provider, people to notify, instructions, preferences, applicant
 
-    @focus @CleanupFixtures
+    @focus 
     Scenario: Create LPA normal path
         When I log in as appropriate test user
+
         And I visit the correspondent page for the test fixture lpa
         Then I am taken to the correspondent page
         # ** CUT Above Here ** This comment line needed for stitching feature files. Please do not remove
+        #
 
+        # first test - do nothing and ensure the donor is correspondent as default
+        When I click "save"
+        Then I am taken to the who are you page
+        Then I see "The LPA will be sent to Mrs Nancy Garrison" in the page text
+
+        # second test , choose certificate provider as correspondent
+        When I click the last occurrence of "accordion-view-change"
+        Then I am taken to the correspondent page
         And I can find "change-correspondent" with data-inited
         When I click "change-correspondent"
         Then I can find "form-reuse-details"
         And I see "Which details would you like to reuse?" in the page text
-        # donor is correspondent as default
-        # choose attorney as correspondent
+        When I check "reuse-details-3"
+        And I click "continue"
+        And I see "Mr Reece Richards" in the page text
+        And I see "11 Brookside, Cholsey, Wallingford, Oxfordshire, OX10 9NN" in the page text
+        And I check "contactByPost" 
+        When I click "save"
+        Then I am taken to the who are you page
+        And I see "The LPA will be sent to Mr Reece Richards" in the page text
+
+        # third test - switch to attorney as correspondent
+        When I click the last occurrence of "accordion-view-change"
+        Then I am taken to the correspondent page
+        And I can find "change-correspondent" with data-inited
+        When I click "change-correspondent"
+        Then I can find "form-reuse-details"
         When I check "reuse-details-2"
         And I click "continue"
         Then I can find "form-correspondent"
@@ -27,5 +50,7 @@ Feature: Add a correspondent to a Property and Finance LPA
         # next line is essential, cypress needs the form not to be there before it can reliably find save button in CI
         Then I cannot find "form-correspondent"
         And I see "Standard Trust" in the page text
+        And I see "1 Laburnum Place, Sketty, Swansea, Abertawe, SA2 8HT" in the page text
         When I click "save"
         Then I am taken to the who are you page
+        And I see "The LPA will be sent to Standard Trust" in the page text

--- a/cypress/integration/CorrespondentPFClone.feature
+++ b/cypress/integration/CorrespondentPFClone.feature
@@ -7,7 +7,7 @@ Feature: Add a correspondent to a Property and Finance LPA
         Given I ignore application exceptions
         And I create PF LPA test fixture with donor, single attorney, cert provider, people to notify, instructions, preferences, applicant
 
-    @focus 
+    @focus @CleanupFixtures
     Scenario: Create LPA normal path
         When I log in as appropriate test user
 

--- a/cypress/integration/CorrespondentPFClone.feature
+++ b/cypress/integration/CorrespondentPFClone.feature
@@ -17,12 +17,12 @@ Feature: Add a correspondent to a Property and Finance LPA
         When I click "save"
         Then I am taken to the who are you page
         Then I see "The LPA will be sent to Mrs Nancy Garrison" in the page text
+        When I click the last occurrence of "accordion-view-change"
+        Then I am taken to the correspondent page
 
         # ** CUT Above Here ** This comment line needed for stitching feature files. Please do not remove
 
         # second test , choose certificate provider as correspondent
-        When I click the last occurrence of "accordion-view-change"
-        Then I am taken to the correspondent page
         And I can find "change-correspondent" with data-inited
         When I click "change-correspondent"
         Then I can find "form-reuse-details"

--- a/cypress/integration/CorrespondentPFClone.feature
+++ b/cypress/integration/CorrespondentPFClone.feature
@@ -12,6 +12,12 @@ Feature: Add a correspondent to a Property and Finance LPA
         When I log in as appropriate test user
         And I visit the correspondent page for the test fixture lpa
         Then I am taken to the correspondent page
+        # first test - do nothing and ensure the donor is correspondent as default (note that this will only be the case running tests locally with fixtures, whereas
+        # for stitched clone run, the attorney has already been set as the correspondent on the who-is-registering page
+        When I click "save"
+        Then I am taken to the who are you page
+        Then I see "The LPA will be sent to Mrs Nancy Garrison" in the page text
+
         # ** CUT Above Here ** This comment line needed for stitching feature files. Please do not remove
 
         # first test - do nothing and ensure the donor is correspondent as default

--- a/cypress/integration/CorrespondentPFClone.feature
+++ b/cypress/integration/CorrespondentPFClone.feature
@@ -20,11 +20,6 @@ Feature: Add a correspondent to a Property and Finance LPA
 
         # ** CUT Above Here ** This comment line needed for stitching feature files. Please do not remove
 
-        # first test - do nothing and ensure the donor is correspondent as default
-        When I click "save"
-        Then I am taken to the who are you page
-        Then I see "The LPA will be sent to Mrs Nancy Garrison" in the page text
-
         # second test , choose certificate provider as correspondent
         When I click the last occurrence of "accordion-view-change"
         Then I am taken to the correspondent page

--- a/cypress/integration/CorrespondentPFClone.feature
+++ b/cypress/integration/CorrespondentPFClone.feature
@@ -10,11 +10,9 @@ Feature: Add a correspondent to a Property and Finance LPA
     @focus @CleanupFixtures
     Scenario: Create LPA normal path
         When I log in as appropriate test user
-
         And I visit the correspondent page for the test fixture lpa
         Then I am taken to the correspondent page
         # ** CUT Above Here ** This comment line needed for stitching feature files. Please do not remove
-        #
 
         # first test - do nothing and ensure the donor is correspondent as default
         When I click "save"


### PR DESCRIPTION
## Purpose

_LPAL-650 add extra testing to cover gaps revealed during UAT of PHP8 upgrade_

## Approach

_Add extra lines to CorrespondentPFClone feature file. Now tests with Certificate Provider before Attorney, more checking of exact text shown on page as result_ 

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
