### PR TITLE
LPAL 646 fix debugging and attempt to improve performance running locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -659,7 +659,6 @@ orbs:
               command: |
                 if << parameters.unit_test >> ; then
                   docker run -d --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name tests << parameters.ecr_url >>/<< parameters.ecr_repository_name_prefix >>_app:latest
-                  docker exec tests docker-php-ext-enable xdebug
                   docker exec tests /app/vendor/bin/phpunit -d memory_limit=256M
                 else
                   echo "phpunit tests not required for this service"

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ cypress/activation_emails/noaccountpasswordreset.*
 cypress/activation_emails/unrecognized.*
 cypress/integration/Stitched*
 cypress/integration/examples/
+cypress/logs/
 **/build
 /cypress/screenshots/
 /cypress/fixtures/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,9 +132,16 @@ services:
     image: lpa-front-app
     build:
       context: ./
+# Build the container with debug on. This will run a lttle slower but debug will always be available
+      args:
+        ENABLE_XDEBUG: 1
       dockerfile: service-front/docker/app/Dockerfile
     volumes:
-      - ./service-front:/app
+# to speed running, volumes are restricted to source code that may change while container is running
+      - ./service-front/module:/app/module
+      - ./service-front/config:/app/config
+      - ./service-front/node_modules:/app/node_modules
+      - ./service-front/assets:/app/assets
     depends_on:
       - dynamodb
       - localstack
@@ -160,9 +167,6 @@ services:
 
       PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
       PHP_IDE_CONFIG: serverName=lpa-front-app
-      # ENABLE_XDEBUG: 'true'
-      XDEBUG_MODE: 'debug'
-      XDEBUG_CONFIG: client_host=host.docker.internal client_port=9003
 
       OPG_LPA_FRONT_EMAIL_TRANSPORT: notify
       OPG_LPA_FRONT_EMAIL_NOTIFY_API_KEY: "${OPG_LPA_API_NOTIFY_API_KEY}"
@@ -227,9 +231,14 @@ services:
     image: lpa-api-app
     build:
       context: ./
+# Build the container with debug on. This will run a lttle slower but debug will always be available
+      args:
+        ENABLE_XDEBUG: 1
       dockerfile: service-api/docker/app/Dockerfile
     volumes:
-      - ./service-api:/app
+# to speed running, volumes are restricted to source code that may change while container is running
+      - ./service-api/module:/app/module
+      - ./service-api/config:/app/config
     depends_on:
       - dynamodb
       - localstack
@@ -271,9 +280,6 @@ services:
 
       PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
       PHP_IDE_CONFIG: serverName=lpa-api-app
-      ENABLE_XDEBUG: "true"
-      XDEBUG_MODE: "debug"
-      XDEBUG_CONFIG: client_host=host.docker.internal client_port=9003 mode=develop,debug
 
   api-composer:
     image: composer:latest
@@ -312,8 +318,13 @@ services:
     build:
       context: ./
       dockerfile: service-admin/docker/app/Dockerfile
+# Build the container with debug on. This will run a lttle slower but debug will always be available
+      args:
+        ENABLE_XDEBUG: 1
     volumes:
-      - ./service-admin:/app
+# to speed running, volumes are restricted to source code that may change while container is running
+      - ./service-admin/src:/app/src
+      - ./service-admin/config:/app/config
     depends_on:
       - dynamodb
       - localstack
@@ -337,11 +348,8 @@ services:
       OPG_LPA_COMMON_DYNAMODB_ENDPOINT: http://dynamodb:8000
 
       PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
-      # ENABLE_XDEBUG: 'true'
       PHP_IDE_CONFIG: serverName=lpa-admin-app
       OPG_LPA_COMMON_ADMIN_ACCOUNTS: "${OPG_LPA_COMMON_ADMIN_ACCOUNTS}"
-      XDEBUG_MODE: 'debug'
-      XDEBUG_CONFIG: client_host=host.docker.internal client_port=9003
 
   admin-composer:
     image: composer:latest
@@ -388,6 +396,7 @@ services:
     build:
       context: ./
       dockerfile: service-pdf/docker/app/Dockerfile
+# Other containers are built with debug on. Lines could be put here to build pdf with debug, but not doing as default due to pdf being slow already
     environment:
       OPG_LPA_COMMON_PDF_CACHE_S3_BUCKET: "lpacache"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,9 +132,9 @@ services:
     image: lpa-front-app
     build:
       context: ./
-# Build the container with debug on. This will run a lttle slower but debug will always be available
+# Install xdebug during container build. To use the debugger, ENABLE_DEBUG also must be set in the environment section below
       args:
-        ENABLE_XDEBUG: 1
+        INSTALL_XDEBUG: 1
       dockerfile: service-front/docker/app/Dockerfile
     volumes:
 # to speed running, volumes are restricted to source code that may change while container is running
@@ -167,6 +167,8 @@ services:
 
       PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
       PHP_IDE_CONFIG: serverName=lpa-front-app
+      # enable debug is recommended to default to on for front app because it is frequently useful to be able to debug the front-app 
+      ENABLE_XDEBUG: 'true'
 
       OPG_LPA_FRONT_EMAIL_TRANSPORT: notify
       OPG_LPA_FRONT_EMAIL_NOTIFY_API_KEY: "${OPG_LPA_API_NOTIFY_API_KEY}"
@@ -231,9 +233,9 @@ services:
     image: lpa-api-app
     build:
       context: ./
-# Build the container with debug on. This will run a lttle slower but debug will always be available
+# Install xdebug during container build. To use the debugger, ENABLE_DEBUG also must be set in the environment section below
       args:
-        ENABLE_XDEBUG: 1
+        INSTALL_XDEBUG: 1
       dockerfile: service-api/docker/app/Dockerfile
     volumes:
 # to speed running, volumes are restricted to source code that may change while container is running
@@ -280,6 +282,8 @@ services:
 
       PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
       PHP_IDE_CONFIG: serverName=lpa-api-app
+      # enable debug is recommended to default to off for api to avoid slowness. Turn this on if you ever need to debug the api
+      # ENABLE_XDEBUG: 'true'
 
   api-composer:
     image: composer:latest
@@ -318,9 +322,9 @@ services:
     build:
       context: ./
       dockerfile: service-admin/docker/app/Dockerfile
-# Build the container with debug on. This will run a lttle slower but debug will always be available
+# Install xdebug during container build. To use the debugger, ENABLE_DEBUG also must be set in the environment section below
       args:
-        ENABLE_XDEBUG: 1
+        INSTALL_XDEBUG: 1
     volumes:
 # to speed running, volumes are restricted to source code that may change while container is running
       - ./service-admin/src:/app/src
@@ -349,6 +353,8 @@ services:
 
       PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
       PHP_IDE_CONFIG: serverName=lpa-admin-app
+      # enable debug is recommended to default to off for admin app to avoid slowness, as admin is rarely debugged. Turn this on if you wish to debug the admin app
+      # ENABLE_XDEBUG: 'true'
       OPG_LPA_COMMON_ADMIN_ACCOUNTS: "${OPG_LPA_COMMON_ADMIN_ACCOUNTS}"
 
   admin-composer:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,9 +132,9 @@ services:
     image: lpa-front-app
     build:
       context: ./
-# Install xdebug during container build. To use the debugger, ENABLE_DEBUG also must be set in the environment section below
+# Ideally, debug would always be enabled for front-app, as we often want to debug it. In practice, this still runs too slowly so we leave it off as default
       args:
-        INSTALL_XDEBUG: 1
+        ENABLE_XDEBUG: 0
       dockerfile: service-front/docker/app/Dockerfile
     volumes:
 # to speed running, volumes are restricted to source code that may change while container is running
@@ -167,8 +167,6 @@ services:
 
       PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
       PHP_IDE_CONFIG: serverName=lpa-front-app
-      # enable debug is recommended to default to on for front app because it is frequently useful to be able to debug the front-app 
-      ENABLE_XDEBUG: 'true'
 
       OPG_LPA_FRONT_EMAIL_TRANSPORT: notify
       OPG_LPA_FRONT_EMAIL_NOTIFY_API_KEY: "${OPG_LPA_API_NOTIFY_API_KEY}"
@@ -233,9 +231,9 @@ services:
     image: lpa-api-app
     build:
       context: ./
-# Install xdebug during container build. To use the debugger, ENABLE_DEBUG also must be set in the environment section below
+# Enable debug is recommended to default to off for api to avoid slowness. Turn this on if you ever need to debug the api
       args:
-        INSTALL_XDEBUG: 1
+        ENABLE_XDEBUG: 0
       dockerfile: service-api/docker/app/Dockerfile
     volumes:
 # to speed running, volumes are restricted to source code that may change while container is running
@@ -282,8 +280,6 @@ services:
 
       PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
       PHP_IDE_CONFIG: serverName=lpa-api-app
-      # enable debug is recommended to default to off for api to avoid slowness. Turn this on if you ever need to debug the api
-      # ENABLE_XDEBUG: 'true'
 
   api-composer:
     image: composer:latest
@@ -322,9 +318,9 @@ services:
     build:
       context: ./
       dockerfile: service-admin/docker/app/Dockerfile
-# Install xdebug during container build. To use the debugger, ENABLE_DEBUG also must be set in the environment section below
+# enable debug is recommended to default to off for admin app to avoid slowness, as admin is rarely debugged. Turn this on if you wish to debug the admin app
       args:
-        INSTALL_XDEBUG: 1
+        ENABLE_XDEBUG: 0
     volumes:
 # to speed running, volumes are restricted to source code that may change while container is running
       - ./service-admin/src:/app/src
@@ -353,8 +349,6 @@ services:
 
       PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
       PHP_IDE_CONFIG: serverName=lpa-admin-app
-      # enable debug is recommended to default to off for admin app to avoid slowness, as admin is rarely debugged. Turn this on if you wish to debug the admin app
-      # ENABLE_XDEBUG: 'true'
       OPG_LPA_COMMON_ADMIN_ACCOUNTS: "${OPG_LPA_COMMON_ADMIN_ACCOUNTS}"
 
   admin-composer:

--- a/service-admin/.dockerignore
+++ b/service-admin/.dockerignore
@@ -1,0 +1,4 @@
+LICENSE
+LICENSE.md
+README.md
+docker/

--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -14,17 +14,10 @@ RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS icu-d
         && docker-php-ext-install intl \
         && docker-php-ext-install bcmath 
 
-# Enable debug if needed. Should only be used locally
-ARG ENABLE_XDEBUG=0
-RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
+# Install debug if needed. Should only be used locally
+ARG INSTALL_XDEBUG=0
+RUN if [[ $INSTALL_XDEBUG = 1 ]] ; then \
       pecl install xdebug ; \
-      docker-php-ext-enable xdebug ; \
-      echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
     fi ;
 
 # Clean up build dependencies, but only after everything else we need has been installed
@@ -38,4 +31,13 @@ COPY service-admin/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
 WORKDIR /app
 
-CMD php-fpm
+# On startup, enable xdebug if required. Note this would require the container to have been built with INSTALL_DEBUG set
+CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug; \
+    echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+) \
+  && php-fpm

--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -11,11 +11,24 @@ RUN apk upgrade --available
 RUN apk add --update --no-cache icu
 
 RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS icu-dev \
-        && pecl install xdebug \
-        && pecl clear-cache \
         && docker-php-ext-install intl \
-        && docker-php-ext-install bcmath \
-        && apk del .build-dependencies
+        && docker-php-ext-install bcmath 
+
+# Enable debug if needed. Should only be used locally
+ARG ENABLE_XDEBUG=0
+RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
+      pecl install xdebug ; \
+      docker-php-ext-enable xdebug ; \
+      echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    fi ;
+
+# Clean up build dependencies, but only after everything else we need has been installed
+RUN apk del .build-dependencies
 
 COPY shared/logging /shared/logging
 COPY service-admin /app
@@ -25,5 +38,4 @@ COPY service-admin/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
 WORKDIR /app
 
-CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug) \
-    && php-fpm
+CMD php-fpm

--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -14,10 +14,17 @@ RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS icu-d
         && docker-php-ext-install intl \
         && docker-php-ext-install bcmath 
 
-# Install debug if needed. Should only be used locally
-ARG INSTALL_XDEBUG=0
-RUN if [[ $INSTALL_XDEBUG = 1 ]] ; then \
+# Enable debug if needed. Should only be used locally
+ARG ENABLE_XDEBUG=0
+RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
       pecl install xdebug ; \
+      docker-php-ext-enable xdebug ; \
+      echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
     fi ;
 
 # Clean up build dependencies, but only after everything else we need has been installed
@@ -31,13 +38,4 @@ COPY service-admin/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
 WORKDIR /app
 
-# On startup, enable xdebug if required. Note this would require the container to have been built with INSTALL_DEBUG set
-CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug; \
-    echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-) \
-  && php-fpm
+CMD php-fpm

--- a/service-api/.dockerignore
+++ b/service-api/.dockerignore
@@ -1,0 +1,6 @@
+LICENSE
+LICENSE-ZF2.txt
+Makefile
+__pycache__
+docker/
+readme.md

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -21,17 +21,10 @@ RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS postg
 # Default for AWS. Should be set to 1 for local development.
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
 
-# Enable debug if needed. Should only be used locally
-ARG ENABLE_XDEBUG=0
-RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
+# Install debug if needed. Should only be used locally
+ARG INSTALL_XDEBUG=0
+RUN if [[ $INSTALL_XDEBUG = 1 ]] ; then \
       pecl install xdebug ; \
-      docker-php-ext-enable xdebug ; \
-      echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
     fi ;
 
 # Clean up build dependencies, but only after everything else we need has been installed
@@ -45,5 +38,14 @@ COPY service-api/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
 WORKDIR /app
 
-CMD chmod +x /app/docker/app/db-migrations.sh && /app/docker/app/db-migrations.sh \
+# On startup, enable xdebug if required. Note this would require the container to have been built with INSTALL_DEBUG set
+CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug; \
+    echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+) \
+  && chmod +x /app/docker/app/db-migrations.sh && /app/docker/app/db-migrations.sh \
   && php-fpm

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -21,10 +21,17 @@ RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS postg
 # Default for AWS. Should be set to 1 for local development.
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
 
-# Install debug if needed. Should only be used locally
-ARG INSTALL_XDEBUG=0
-RUN if [[ $INSTALL_XDEBUG = 1 ]] ; then \
+# Enable debug if needed. Should only be used locally
+ARG ENABLE_XDEBUG=0
+RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
       pecl install xdebug ; \
+      docker-php-ext-enable xdebug ; \
+      echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
     fi ;
 
 # Clean up build dependencies, but only after everything else we need has been installed
@@ -38,14 +45,5 @@ COPY service-api/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
 WORKDIR /app
 
-# On startup, enable xdebug if required. Note this would require the container to have been built with INSTALL_DEBUG set
-CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug; \
-    echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-) \
-  && chmod +x /app/docker/app/db-migrations.sh && /app/docker/app/db-migrations.sh \
+CMD chmod +x /app/docker/app/db-migrations.sh && /app/docker/app/db-migrations.sh \
   && php-fpm

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -14,12 +14,28 @@ RUN apk add --update --no-cache postgresql-libs
 
 # Postgres dev lib is temporary
 RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS postgresql-dev \
-  && pecl install xdebug \
-  && pecl clear-cache \
   && docker-php-ext-install pgsql pdo_pgsql \
   && docker-php-ext-install bcmath \
-  && docker-php-ext-install opcache \
-  && apk del .build-dependencies
+  && docker-php-ext-install opcache 
+
+# Default for AWS. Should be set to 1 for local development.
+ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
+
+# Enable debug if needed. Should only be used locally
+ARG ENABLE_XDEBUG=0
+RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
+      pecl install xdebug ; \
+      docker-php-ext-enable xdebug ; \
+      echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    fi ;
+
+# Clean up build dependencies, but only after everything else we need has been installed
+RUN apk del .build-dependencies
 
 COPY service-api /app
 COPY shared/logging /shared/logging
@@ -27,11 +43,7 @@ COPY --from=composer /app/vendor /app/vendor
 COPY service-api/docker/app/app-php.ini /usr/local/etc/php/conf.d/
 COPY service-api/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
-# Default for AWS. Should be set to 1 for local development.
-ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
-
 WORKDIR /app
 
-CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug) \
-  && chmod +x /app/docker/app/db-migrations.sh && /app/docker/app/db-migrations.sh \
+CMD chmod +x /app/docker/app/db-migrations.sh && /app/docker/app/db-migrations.sh \
   && php-fpm

--- a/service-front/.dockerignore
+++ b/service-front/.dockerignore
@@ -1,0 +1,5 @@
+docker/
+readme.md
+LICENCE
+LICENSE-ZF2.txt
+Makefile

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -10,17 +10,33 @@ FROM php:7.4-fpm-alpine
 RUN apk add --upgrade apk-tools
 RUN apk upgrade --available
 
-RUN apk add --update --no-cache icu
+RUN apk add --update --no-cache icu 
 
 RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS icu-dev \
         && pecl install redis \
-        && pecl install xdebug \
-        && pecl clear-cache \
         && docker-php-ext-enable redis \
         && docker-php-ext-install intl \
         && docker-php-ext-install bcmath \
-        && docker-php-ext-install opcache \
-        && apk del .build-dependencies
+        && docker-php-ext-install opcache 
+
+# Default for AWS. Should be set to 1 for local development.
+ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
+
+# Enable debug if needed. Should only be used locally
+ARG ENABLE_XDEBUG=0
+RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
+    pecl install xdebug ; \
+    docker-php-ext-enable xdebug ; \
+    echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+fi
+
+# Clean up build dependencies, but only after everything else we need has been installed
+RUN apk del .build-dependencies
 
 COPY service-front /app
 COPY shared/logging /shared/logging
@@ -28,10 +44,6 @@ COPY --from=composer /app/vendor /app/vendor
 COPY service-front/docker/app/app-php.ini /usr/local/etc/php/conf.d/
 COPY service-front/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
-# Default for AWS. Should be set to 1 for local development.
-ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
-
 WORKDIR /app
 
-CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug) \
-    && php-fpm
+CMD php-fpm

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -23,16 +23,9 @@ RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS icu-d
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
 
 # Enable debug if needed. Should only be used locally
-ARG ENABLE_XDEBUG=0
-RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
-    pecl install xdebug ; \
-    docker-php-ext-enable xdebug ; \
-    echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+ARG INSTALL_XDEBUG=0
+RUN if [[ $INSTALL_XDEBUG = 1 ]] ; then \
+    pecl install xdebug; \
 fi
 
 # Clean up build dependencies, but only after everything else we need has been installed
@@ -46,4 +39,13 @@ COPY service-front/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
 WORKDIR /app
 
-CMD php-fpm
+# On startup, enable xdebug if required. Note this would require the container to have been built with INSTALL_DEBUG set
+CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug; \
+    echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+) \
+  && php-fpm

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -23,9 +23,16 @@ RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS icu-d
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
 
 # Enable debug if needed. Should only be used locally
-ARG INSTALL_XDEBUG=0
-RUN if [[ $INSTALL_XDEBUG = 1 ]] ; then \
-    pecl install xdebug; \
+ARG ENABLE_XDEBUG=0
+RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
+    pecl install xdebug ; \
+    docker-php-ext-enable xdebug ; \
+    echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
 fi
 
 # Clean up build dependencies, but only after everything else we need has been installed
@@ -39,13 +46,4 @@ COPY service-front/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
 WORKDIR /app
 
-# On startup, enable xdebug if required. Note this would require the container to have been built with INSTALL_DEBUG set
-CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug; \
-    echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-) \
-  && php-fpm
+CMD php-fpm

--- a/service-pdf/.dockerignore
+++ b/service-pdf/.dockerignore
@@ -1,0 +1,4 @@
+LICENSE
+Makefile
+README.md
+docker/

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -12,10 +12,24 @@ RUN apk upgrade --available
 
 RUN apk update \
     && apk add --no-cache openjdk8-jre gcc make musl-dev pkgconfig bash\
-    && apk add --no-cache --update --virtual buildDeps autoconf \
-    && pecl install xdebug \
-    && pecl clear-cache \
-    && apk del buildDeps
+    && apk add --no-cache --update --virtual buildDeps autoconf 
+
+# Enable debug if needed. Should only be used locally.
+ARG ENABLE_XDEBUG=0
+RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
+    pecl install xdebug ; \
+    docker-php-ext-enable xdebug ; \
+    echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+    echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+fi
+
+# Clean up build dependencies, but only after everything else we need has been installed
+RUN apk del buildDeps
+
 WORKDIR /usr/local/bin/
 # This is version 3.2.1 of this tool, we will need to check this regularly.
 # PDFTK does have a community based docker container, but the version is not up to date.


### PR DESCRIPTION
## Purpose

_LPAL-646 get the debugger working again and do a few things to try to slim down building and running locally_

## Approach

- Config for debug is now set to what is required for xdebug 3, and debugger works again inside phpstorm. 
- We no longer install debugger by default, we now depend on ENABLE_DEBUG being set. We only want the debugger when running locally, not in CI, and its a potential security risk if installed on live even if not enabled.
- CircleCI therefore no longer turns on debugger to run unit tests. These run fine without the debugger. Perhaps in the past there was a dependency here, but no longer needed.
- I tried just installing the debugger during build phase if required, then optionally enabling it just as the container runs up, just as we currently do prior to this PR (not currently working in phpstorm prior to this PR, of course). This would have allowed the debugger to be installed ready to go at build phase, then toggled on and off easily. When you do that, a docker exec onto the running container reveals that xdebug is indeed installed and enabled, but for some as yet unknown reason, phpstorm fails to recognise the debugger. phpstorm only seems to be able to recognise the debugger if it was enabled during the build phase of the container. There may be a way around this, we could address this in future PR if we find a fix. For now we have to live with rebuilding the container if we want to debug it. Its sub-optimal, but better than no debugger at all!
- ENABLE_XDEBUG is still switched off by default due to slowness. It'd be very nice to have this on as default for the front-app , as we frequently debug that,  but looks like we might all need faster machines and/or some other speed optimisation first.
- For the pdf container, I've updated dockerfile similarly to the others. However, it looks like we've never actually tried to turn debugger on for pdf generator. Seems likely it'd run incredibly slow. But its there in case we ever want to do anything with it.
- Introduced dockerignore  files to avoid copying unnecessary content onto containers. This has limited value so far but is a proof of concept that could enable us to exclude larger directories in future. 
-  Have modified docker-compose to mount as volumes, only dirs that contain source code that could change and that we'd want to reflect immediately. This means the huge vendor directory, which is copied anyway, won't be included, which ought to help performance. - 

## Learning

_dockerignore is potentially powerful technique for avoiding copying onto containers, files that are irrelevant or security risk or slow down proceedings.  phpstorm has a problem recognising the debugger when its been enabled only just as the container starts up, maybe in the long run we could find out why and fix this

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
