### PR TITLE
LPAL-656 Adjust ECR Scan reports and script to be Inspector2 compatible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1135,7 +1135,7 @@ orbs:
           - run:
               name: Run seeding ecs task
               command: |
-                python scripts/pipeline/start_seeding_task/ecs_start_seeding_task.py
+                python3 scripts/pipeline/start_seeding_task/ecs_start_seeding_task.py
 
       run_healthcheck_test:
         #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1440,7 +1440,7 @@ jobs:
             export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
             echo $IMAGE_TAG
             cd scripts/pipeline/check_ecr_scan_results/
-            python aws_ecr_scan_results.py  --search online-lpa,perfplat \
+            python3 aws_ecr_scan_results.py  --search online-lpa/pdf_app \
                                            --tag ${IMAGE_TAG} \
                                            --build_url $CIRCLE_BUILD_URL \
                                            --branch $CIRCLE_BRANCH \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,6 +373,7 @@ path_to_live: &path_to_live
             flask_docker_build,
             perfplat-lambda-docker-api-build,
             perfplat-lambda-docker-worker-build,
+            preprod_environment_apply_terraform
           ]
 
     - infrastructure_and_deployment/seed_environment_databases:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1440,7 +1440,7 @@ jobs:
             export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
             echo $IMAGE_TAG
             cd scripts/pipeline/check_ecr_scan_results/
-            python3 aws_ecr_scan_results.py  --search online-lpa/pdf_app \
+            python3 aws_ecr_scan_results.py  --search online-lpa,perfplat \
                                            --tag ${IMAGE_TAG} \
                                            --build_url $CIRCLE_BUILD_URL \
                                            --branch $CIRCLE_BRANCH \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,7 @@ pr_build: &pr_build
             flask_docker_build,
             perfplat-lambda-docker-worker-build,
             perfplat-lambda-docker-api-build,
+            dev_environment_apply_terraform
           ]
 
     - infrastructure_and_deployment/seed_environment_databases:

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -126,7 +126,6 @@ class ECRScanChecker:
             report = ''
             try:
                 findings = self.list_findings(image,tag,push_date,self.aws_account_id,report_limit)
-                print(json.dumps(findings, indent=4, sort_keys=True, default=str))
                 if findings['findings'] != []:
                     title_info = {
                         'image': image,

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -114,23 +114,24 @@ class ECRScanChecker:
         push_date,
         report_limit,
         branch,
-        build_url
+        build_url,
+        slack_channel,
+        slack_token,
+        test_mode
         ):
         print('Checking ECR scan results...')
-        report = ''
+
         for image in repositories:
-            print(image)
+            print(f'image: {image}')
+            report = ''
             try:
                 findings = self.list_findings(image,tag,push_date,self.aws_account_id,report_limit)
                 print(json.dumps(findings, indent=4, sort_keys=True, default=str))
                 if findings['findings'] != []:
-                    counts = len(findings)
-                    print(counts)
                     title_info = {
                         'image': image,
                         'report_limit': report_limit
                     }
-
 
                     report = self.render('header.j2', title_info)
                     finding_results = []
@@ -141,7 +142,8 @@ class ECRScanChecker:
                     report += self.render('finding.j2', {'results': finding_results})
                 else:
                     report += self.render('no_scan_results.j2', {'image': image})
-
+                report += self.write_build_details(branch,build_url)
+                self.post_to_slack(report,slack_channel,slack_token,test_mode)
             except self.aws_ecr_client.exceptions.ImageNotFoundException:
                 print(f'skipping finding check for image: {image} tag: {tag} - no image present')
                 continue
@@ -155,12 +157,6 @@ class ECRScanChecker:
                 print('trace:')
                 traceback.print_exc()
                 sys.exit(1)
-
-
-
-        report += self.write_build_details(branch,build_url)
-        return report
-
 
     def list_findings(self, repository_name, tag, push_date, aws_account_id, report_limit):
         date_start_inclusive = datetime.combine(
@@ -267,7 +263,7 @@ def main():
                         action='store_true')
     parser.add_argument('--account_id',
                         default='311462405659',
-                        help='Optionally specify account for scan, defauts to the management account')
+                        help='Optionally specify account for scan, defaults to the management account')
     parser.add_argument('--branch',
                         default='N/A',
                         help='branch for build')
@@ -285,17 +281,17 @@ def main():
 
     repos_to_check = work.get_repositories(args.search)
 
-    report = work.generate_report(
+    work.generate_report(
         repos_to_check,
         args.tag,
         args.ecr_push_date,
         args.result_limit,
         args.branch,
-        args.build_url
+        args.build_url,
+        args.slack_channel,
+        args.slack_token,
+        args.test_mode
     )
-
-    work.post_to_slack(report,args.slack_channel,args.slack_token, args.test_mode)
-
 
 if __name__ == '__main__':
     main()

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -122,12 +122,12 @@ class ECRScanChecker:
             print(image)
             try:
                 findings = self.list_findings(image,tag,push_date,self.aws_account_id,report_limit)
-                print(findings)
+                print(json.dumps(findings, indent=4, sort_keys=True, default=str))
                 if findings['findings'] != []:
-                    counts = findings['findingSeverityCounts']
+                    counts = len(findings)
+                    print(counts)
                     title_info = {
                         'image': image,
-                        'counts': counts,
                         'report_limit': report_limit
                     }
 
@@ -206,10 +206,9 @@ class ECRScanChecker:
 
     def summarise_finding(self, finding, tag, image):
         finding_result = {
-            'cve_tag': finding['name'],
+            'title': finding['title'],
             'emoji': self.get_severity_emoji(finding['severity']),
             'severity': finding['severity'],
-            'cve_link': finding['uri'],
             'image': image,
             'tag': tag
         }

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -205,7 +205,8 @@ class ECRScanChecker:
             'emoji': self.get_severity_emoji(finding['severity']),
             'severity': finding['severity'],
             'image': image,
-            'tag': tag
+            'tag': tag,
+            'type' : finding['type']
         }
 
         finding_result['description'] = 'None'

--- a/scripts/pipeline/check_ecr_scan_results/templates/finding.j2
+++ b/scripts/pipeline/check_ecr_scan_results/templates/finding.j2
@@ -17,7 +17,14 @@
     "type": "section",
     "text": {
         "type": "mrkdwn",
-        "text": "*CVE*: {{ item.cve_tag }}"
+        "text": "*Title*: {{ item.title }}"
+    }
+},
+{
+    "type": "section",
+    "text": {
+        "type": "mrkdwn",
+        "text": "*Type*: {{ item.type }}"
     }
 },
 {
@@ -26,14 +33,6 @@
         "type": "mrkdwn",
         "text": "*Description*:\n {{ item.description }}"
     }
-},
-{
-    "type": "section",
-    "text": {
-        "type": "mrkdwn",
-        "text": "*Link*: {{ item.cve_link }}"
-    }
-
 },
 {
     "type": "divider"

--- a/scripts/pipeline/check_ecr_scan_results/templates/header.j2
+++ b/scripts/pipeline/check_ecr_scan_results/templates/header.j2
@@ -8,22 +8,6 @@
 {
     "type" : "section",
     "text" : {
-        "type" : "mrkdwn",
-        "text" : "*Counts by Severity:*"
-    }
-},
-{% for value in counts.items() %}
-{
-    "type" : "section",
-    "text" : {
-        "type" : "mrkdwn",
-        "text" : "Severity {{ key }}: *{{ value }}*"
-    }
-},
-{% endfor %}
-{
-    "type" : "section",
-    "text" : {
         "type" : "plain_text",
         "text" : "Displaying the first {{ report_limit }} findings:"
 


### PR DESCRIPTION
## Purpose

Fixes a fault with ECR Scan after AWS inspector Upgrade. 
Findings are different.

Fixes LPAL-656


## Approach

- fix Python script.
- fix templates as some info no longer easy to get.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
