### PR TITLE
Lpal 603 make MRK available to the environment level  

### DIFF
--- a/terraform/environment/modules/environment/ecs_cluster.tf
+++ b/terraform/environment/modules/environment/ecs_cluster.tf
@@ -120,7 +120,7 @@ data "aws_iam_policy_document" "execution_role" {
     resources = [
       data.aws_kms_alias.secrets_encryption_alias.target_key_arn,
       data.aws_kms_alias.multi_region_secrets_encryption_alias.target_key_arn
-      ]
+    ]
 
     actions = [
       "kms:Decrypt",

--- a/terraform/environment/modules/environment/ecs_cluster.tf
+++ b/terraform/environment/modules/environment/ecs_cluster.tf
@@ -117,7 +117,10 @@ data "aws_iam_policy_document" "execution_role" {
   statement {
     effect = "Allow"
 
-    resources = [data.aws_kms_alias.secrets_encryption_alias.target_key_arn]
+    resources = [
+      data.aws_kms_alias.secrets_encryption_alias.target_key_arn,
+      data.aws_kms_alias.multi_region_secrets_encryption_alias.target_key_arn
+      ]
 
     actions = [
       "kms:Decrypt",

--- a/terraform/environment/modules/environment/shared_data_sources.tf
+++ b/terraform/environment/modules/environment/shared_data_sources.tf
@@ -37,3 +37,7 @@ data "aws_iam_role" "ecs_autoscaling_service_role" {
 data "aws_kms_alias" "secrets_encryption_alias" {
   name = "alias/secrets_encryption_key-${var.account_name}"
 }
+
+data "aws_kms_alias" "multi_region_secrets_encryption_alias" {
+  name = "alias/mrk_secrets_encryption_key-${var.account_name}"
+}


### PR DESCRIPTION
## Purpose

to make the MRK data source available to the environment level.

part of LPAL-603 work

## Approach

- Add datasource for MRK
- Add relevant permissions
 
this will make it smoother to move the secrets to  this key.
## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
