### PR TITLE
LPAL-554 remove no longer wanted text from password reset page

### DIFF
--- a/service-front/module/Application/view/application/general/forgot-password/email-sent.twig
+++ b/service-front/module/Application/view/application/general/forgot-password/email-sent.twig
@@ -7,7 +7,7 @@
 <div class="text">
     <p class="lede">We've emailed a link to <span class="bold-medium">{{ email }}</span> so that you can {{ accountNotActivated ? "verify your email address" : "reset your password" }}.</p>
     <p>If you have not received the email within a few minutes, please check your spam, bulk or junk email folder &ndash; your email system may have blocked it by mistake.</p>
-    <p>We'll only send a password reset link to the email address belonging to an account.</p>
+    <p>We'll only send a password reset link to the email address belonging to an activated account.</p>
 </div>
 
 {% endblock content %}

--- a/service-front/module/Application/view/application/general/forgot-password/email-sent.twig
+++ b/service-front/module/Application/view/application/general/forgot-password/email-sent.twig
@@ -7,7 +7,7 @@
 <div class="text">
     <p class="lede">We've emailed a link to <span class="bold-medium">{{ email }}</span> so that you can {{ accountNotActivated ? "verify your email address" : "reset your password" }}.</p>
     <p>If you have not received the email within a few minutes, please check your spam, bulk or junk email folder &ndash; your email system may have blocked it by mistake.</p>
-    <p>If it does not arrive at all, please check that you've given us the correct email address for your existing LPA account &ndash; we'll only send a password reset link to the email address belonging to an account.</p>
+    <p>We'll only send a password reset link to the email address belonging to an account.</p>
 </div>
 
 {% endblock content %}


### PR DESCRIPTION
## Purpose

_Content change on password reset page to remove no longer wanted paragraph_

## Approach

_twig tweak to remove 1 para and add 1 word to last para _ 


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
