### PR TITLE
Lpal 553 waiting msg, LPAL-669 remove covid link, LPAL-648 fix password mismatch msg for forgot password

### DIFF
--- a/cypress/integration/Password.feature
+++ b/cypress/integration/Password.feature
@@ -49,6 +49,14 @@ Feature: Password
       Then I see "We've emailed a link" in the page text
       And I see standard test user in the page text
       And I use password reset email to visit the link
+
+      # first try a mismatch 
+      When I try to change password with a mismatch
+      Then I see in the page text
+          | There is a problem |
+          | Enter matching passwords |
+
+      # second use a valid new password
       When I choose a new password
       Then I am taken to the login page
       And I see "Password successfully reset" in the page text

--- a/cypress/integration/Password.feature
+++ b/cypress/integration/Password.feature
@@ -51,7 +51,7 @@ Feature: Password
       And I use password reset email to visit the link
 
       # first try a mismatch 
-      When I try to change password with a mismatch
+      When I try to change password with a mismatch on forgotten password link
       Then I see in the page text
           | There is a problem |
           | Enter matching passwords |

--- a/cypress/integration/common/password.js
+++ b/cypress/integration/common/password.js
@@ -24,6 +24,13 @@ When("I try to change password with a mismatch", () => {
         cy.OPGCheckA11y();
 });
 
+When("I try to change password with a mismatch on forgotten password link", () => {
+        cy.get("[data-cy=password]").clear().type("mismatchedpassword2345");
+        cy.get("[data-cy=password_confirm]").clear().type("mismatchedpassword1234");
+        cy.get('[data-cy=reset-my-password]').click();
+        cy.OPGCheckA11y();
+});
+
 When("I change password back to my old one", () => {
     // change from new password back to original cypress password
         cy.get("[data-cy=password_current]").clear().type(newPassword);

--- a/service-front/content/guidance/People_Correspondent.md
+++ b/service-front/content/guidance/People_Correspondent.md
@@ -1,9 +1,5 @@
 ## Correspondent
 
-<div class="moj-banner moj-banner__message">
-    <p class="bold-small">Read our guidance on <a href="https://www.gov.uk/guidance/making-and-registering-an-lpa-during-the-coronavirus-outbreak#think-carefully-about-who-should-be-sent-the-registered-lpa">being a correspondent during the coronavirus outbreak</a></p>
-</div>
-
 The correspondent is the person we’ll send the LPA to once it is registered.
 
 They’re also the person we’ll contact if we need to:

--- a/service-front/module/Application/view/application/authenticated/lpa/status/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/status/index.twig
@@ -57,21 +57,17 @@
                 <h2 class="heading-xlarge">We're waiting to receive the LPA</h2>
             </div>
             <div>
-                <p class="lede">You've completed the online application and we're now waiting to receive the LPA.</p>
-                <p>If you have not posted the LPA to us yet, <a href="/contact#postal-address">here's the address to send it to</a>.</p>
-
                 {% if canGenerateLPA120 == 'true' %}
-                    <p>Please take postage and processing times into account, which may be slower at the moment.</p>
                     <p> We’re currently asking customers to allow 30 working days for us to receive the LPA, enter it on to our system and update this message.</p>
                     <p>If we need more information about the application to pay a reduced or no fee, we'll write to {{ lpa.document.correspondent.name.title }} {{ lpa.document.correspondent.name.first }} {{ lpa.document.correspondent.name.last }}. We will not start processing the LPA or update this message until
                         we've heard back from {{ lpa.document.correspondent.name.title }} {{ lpa.document.correspondent.name.first }} {{ lpa.document.correspondent.name.last }}.</p>
                 {% else %}
-                    <p>Please take postage and processing times into account, which may be slower at the moment.</p>
                         <p>We’re currently asking customers to allow 30 working days for us to receive the LPA, enter it on to our system and update this message.</p>
                 {% endif %}
 
                 <p>If you think we should have received your LPA by now, please call 0300 456 0300.</p>
                 <p>Opening times: Monday, Tuesday, Thursday, Friday 9.30am to 5pm. Wednesday 10am to 5pm.</p>
+                <p>If you have not posted the LPA to us yet, <a href="/contact#postal-address">here's the address to send it to</a>.</p>
             </div>
 
         {% elseif status == 'processed' %}

--- a/service-front/module/Application/view/application/general/forgot-password/partials/reset-password-error-summary.twig
+++ b/service-front/module/Application/view/application/general/forgot-password/partials/reset-password-error-summary.twig
@@ -7,9 +7,9 @@
         'must-include-digit' : 'Your password must include at least one digit (0-9)',
         'must-include-lower-case' : 'Your password must include at least one lower case letter (a-z)',
         'must-include-upper-case' : 'Your password must include at least one capital letter (A-Z)',
+        'did-not-match' : 'The passwords did not match'
     },
     'password_confirm' : {
-        'did-not-match' : 'The passwords did not match',
         'cannot-be-empty' : 'Confirm your password'
     }
 }) %}

--- a/service-front/module/Application/view/application/general/forgot-password/partials/reset-password-error-summary.twig
+++ b/service-front/module/Application/view/application/general/forgot-password/partials/reset-password-error-summary.twig
@@ -7,7 +7,7 @@
         'must-include-digit' : 'Your password must include at least one digit (0-9)',
         'must-include-lower-case' : 'Your password must include at least one lower case letter (a-z)',
         'must-include-upper-case' : 'Your password must include at least one capital letter (A-Z)',
-        'did-not-match' : 'The passwords did not match'
+        'did-not-match' : 'Enter matching passwords'
     },
     'password_confirm' : {
         'cannot-be-empty' : 'Confirm your password'


### PR DESCRIPTION
## Purpose

_LPAL 553 to re-order the waiting msg, LPAL-669 to remove covid-related link from correspondent help page, LPAL-648 to fix issue with password mismatch message_

## Approach

_Minor tweaks to relevant twig and md files. Improved cypress test to test a mismatch in forgot password link too_ 

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
