### PR TITLE
LPAL-681 add db snapshot cross region encryption key

### DIFF
--- a/terraform/region/kms.tf
+++ b/terraform/region/kms.tf
@@ -2,7 +2,6 @@ resource "aws_kms_key" "multi_region_secrets_encryption_key" {
   enable_key_rotation = true
   provider            = aws.eu-west-1
   multi_region        = true
-
 }
 
 resource "aws_kms_alias" "multi_region_secrets_encryption_alias" {
@@ -14,5 +13,23 @@ resource "aws_kms_replica_key" "multi_region_secrets_encryption_key_replica" {
   description             = "secrets encryption replica key"
   deletion_window_in_days = 7
   primary_key_arn         = aws_kms_key.multi_region_secrets_encryption_key.arn
+  provider                = aws.eu-west-2
+}
+
+resource "aws_kms_key" "multi_region_db_snapshot_key" {
+  enable_key_rotation = true
+  provider            = aws.eu-west-1
+  multi_region        = true
+}
+
+resource "aws_kms_alias" "multi_region_db_snapshot_alias" {
+  name          = "alias/mrk_db_snapshot_key-${terraform.workspace}"
+  target_key_id = aws_kms_key.multi_region_db_snapshot_key.key_id
+}
+
+resource "aws_kms_replica_key" "multi_region_db_snapshot_key_replica" {
+  description             = "db snapshot replica key"
+  deletion_window_in_days = 7
+  primary_key_arn         = aws_kms_key.multi_region_db_snapshot_key.arn
   provider                = aws.eu-west-2
 }


### PR DESCRIPTION
## Purpose

Adds a multi region key for use with encryption of automated backup to another region

Supports LPAL-681

## Approach

Add MRK to support automated backup to another region. 

## Learning

Currently Terraform does not support cross region replication of RDS.  we will have to do this outside of the codebase.
however this issue https://github.com/hashicorp/terraform-provider-aws/issues/16708 is in flight and on the current quarter's roadmap, so should be available soon.
see https://github.com/hashicorp/terraform-provider-aws/blob/main/ROADMAP.md for details.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [x] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
