### PR TITLE
LPAL-674 Remove timestamp element of pay ref on fees page of LPA

### DIFF
--- a/service-front/module/Application/src/Model/Service/Payment/Helper/LpaIdHelper.php
+++ b/service-front/module/Application/src/Model/Service/Payment/Helper/LpaIdHelper.php
@@ -1,9 +1,11 @@
 <?php
+
 namespace Application\Model\Service\Payment\Helper;
+
 class LpaIdHelper
 {
-    const LPA_ID_LENGTH = 11;
-    
+    public const LPA_ID_LENGTH = 11;
+
     /**
      * Helper function to construct the transaction ID
      * based on the LPA ID
@@ -13,7 +15,7 @@ class LpaIdHelper
      */
     public static function constructPaymentTransactionId($lpaId)
     {
-        return self::padLpaId($lpaId) . '-' . time();
+        return self::padLpaId($lpaId);
     }
 
     public static function padLpaId($lpaId)
@@ -21,8 +23,7 @@ class LpaIdHelper
         if (strlen($lpaId) > self::LPA_ID_LENGTH) {
             throw new \Exception('LPA ID is too long');
         }
-        
+
         return str_pad($lpaId, self::LPA_ID_LENGTH, '0', STR_PAD_LEFT);
     }
-   
 }

--- a/service-front/module/Application/tests/Model/Service/Payment/Helper/LpaIdHelperTest.php
+++ b/service-front/module/Application/tests/Model/Service/Payment/Helper/LpaIdHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ApplicationTest\Model\Service\Payment\Helper;
 
 use Laminas\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
@@ -12,7 +13,7 @@ class PaymentTest extends AbstractHttpControllerTestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
     }
@@ -57,15 +58,11 @@ class PaymentTest extends AbstractHttpControllerTestCase
     {
         $id = LpaIdHelper::constructPaymentTransactionId('123');
 
-        $parts = explode('-', $id);
-
-        $this->assertTrue(count($parts) == 2);
-
         $this->assertEquals(
             '00000000123',
-            $parts[0]
+            $id
         );
 
-        $this->assertTrue(is_numeric($parts[1]));
+        $this->assertTrue(is_numeric($id));
     }
 }


### PR DESCRIPTION
## Purpose

To support work to be done in Sirius migrations, the the time stamp element of the pay reference number is to be removed from the fees page.

Only the A-ref is to be visible here. (The A-ref is to remain visible next to the barcode)

Fixes LPAL-674

## Approach

_Explain how your code addresses the purpose of the change_ 

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
<s>   I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant</s>
* [x] I have added tests to prove my work
<s>  I have added mandatory tags to terraformed resources, where possible</s>
<s>  If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`</s>
* [x] The product team have tested these changes
