### PR TITLE
LAPL-675 restrict case number on repeat application to 12 chars

### DIFF
--- a/cypress/integration/RepeatApplicationPF.feature
+++ b/cypress/integration/RepeatApplicationPF.feature
@@ -29,8 +29,9 @@ Feature: Repeat Application for a Property and Finance LPA
         Then I see in the page text
             | There is a problem |
             | Case Number must be twelve letters or fewer |
-        # for PF we test typing in a case number. The other scenario where this is not a repeat, is covered in HW feature
-        When I type "12345678" into "repeatCaseNumber"
+            # for PF we test typing in a case number. The other scenario where this is not a repeat, is covered in HW feature
+        When I clear the value in "repeatCaseNumber"
+        And I type "12345678" into "repeatCaseNumber"
         And I click "save"
         Then I can see popup
         When I click element marked "Confirm and continue"

--- a/cypress/integration/RepeatApplicationPF.feature
+++ b/cypress/integration/RepeatApplicationPF.feature
@@ -23,13 +23,14 @@ Feature: Repeat Application for a Property and Finance LPA
         Then I see in the page text
             | There is a problem |
             | If you are making a repeat application, you need to enter the case number given to you by the Office of the Public Guardian. | 
+        # test more than 12 digits in case number
         When I type "12345678910121213" into "repeatCaseNumber"
         And I click "save"
         When I click element marked "Confirm and continue"
         Then I see in the page text
             | There is a problem |
-            | Case Number must be twelve letters or fewer |
-            # for PF we test typing in a case number. The other scenario where this is not a repeat, is covered in HW feature
+            | Case Number must be twelve digits or fewer |
+       # for PF we test typing in a case number. The other scenario where this is not a repeat, is covered in HW feature
         When I clear the value in "repeatCaseNumber"
         And I type "12345678" into "repeatCaseNumber"
         And I click "save"

--- a/cypress/integration/RepeatApplicationPF.feature
+++ b/cypress/integration/RepeatApplicationPF.feature
@@ -29,10 +29,18 @@ Feature: Repeat Application for a Property and Finance LPA
         When I click element marked "Confirm and continue"
         Then I see in the page text
             | There is a problem |
-            | Case Number must be twelve digits or fewer |
+            | Case Number must be twelve digits |
+        # test less than 12 digits in case number
+        When I clear the value in "repeatCaseNumber"
+        And I type "1234" into "repeatCaseNumber"
+        And I click "save"
+        When I click element marked "Confirm and continue"
+        Then I see in the page text
+            | There is a problem |
+            | Case Number must be twelve digits |
        # for PF we test typing in a case number. The other scenario where this is not a repeat, is covered in HW feature
         When I clear the value in "repeatCaseNumber"
-        And I type "12345678" into "repeatCaseNumber"
+        And I type "123456789012" into "repeatCaseNumber"
         And I click "save"
         Then I can see popup
         When I click element marked "Confirm and continue"

--- a/cypress/integration/RepeatApplicationPF.feature
+++ b/cypress/integration/RepeatApplicationPF.feature
@@ -2,7 +2,7 @@
 Feature: Repeat Application for a Property and Finance LPA
 
     I want to set Repeat Application for a Property and Finance LPA
-
+ 
     Background:
         Given I ignore application exceptions
         And I create PF LPA test fixture with donor, attorneys, replacement attorneys, cert provider, people to notify, instructions, preferences, applicant, correspondent, who are you

--- a/cypress/integration/RepeatApplicationPF.feature
+++ b/cypress/integration/RepeatApplicationPF.feature
@@ -23,6 +23,12 @@ Feature: Repeat Application for a Property and Finance LPA
         Then I see in the page text
             | There is a problem |
             | If you are making a repeat application, you need to enter the case number given to you by the Office of the Public Guardian. | 
+        When I type "12345678910121213" into "repeatCaseNumber"
+        And I click "save"
+        When I click element marked "Confirm and continue"
+        Then I see in the page text
+            | There is a problem |
+            | Case Number must be twelve letters or fewer |
         # for PF we test typing in a case number. The other scenario where this is not a repeat, is covered in HW feature
         When I type "12345678" into "repeatCaseNumber"
         And I click "save"

--- a/service-front/module/Application/src/Form/Lpa/RepeatApplicationForm.php
+++ b/service-front/module/Application/src/Form/Lpa/RepeatApplicationForm.php
@@ -3,6 +3,7 @@
 namespace Application\Form\Lpa;
 
 use Opg\Lpa\DataModel\Lpa\Lpa;
+use Laminas\Validator\StringLength;
 
 class RepeatApplicationForm extends AbstractMainFlowForm
 {
@@ -39,7 +40,16 @@ class RepeatApplicationForm extends AbstractMainFlowForm
             'validators' => [
                 [
                     'name' => 'Digits',
-                ]
+                ],
+                [
+                    'name'    => 'StringLength',
+                    'options' => [
+                        'max'      => 12,
+                        'messages' => [
+                            StringLength::TOO_LONG => 'max-length-%max%',
+                        ],
+                    ],
+                ],
             ],
         ],
     ];

--- a/service-front/module/Application/src/Form/Lpa/RepeatApplicationForm.php
+++ b/service-front/module/Application/src/Form/Lpa/RepeatApplicationForm.php
@@ -50,6 +50,15 @@ class RepeatApplicationForm extends AbstractMainFlowForm
                         ],
                     ],
                 ],
+                [
+                    'name'    => 'StringLength',
+                    'options' => [
+                        'min'      => 12,
+                        'messages' => [
+                            StringLength::TOO_SHORT => 'min-length-%min%',
+                        ],
+                    ],
+                ],
             ],
         ],
     ];

--- a/service-front/module/Application/tests/Form/Lpa/RepeatApplicationFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/RepeatApplicationFormTest.php
@@ -39,7 +39,7 @@ class RepeatApplicationFormTest extends MockeryTestCase
     {
         $this->form->setData(array_merge([
             'isRepeatApplication' => 'is-repeat',
-            'repeatCaseNumber'    => 12345678,
+            'repeatCaseNumber'    => 123456789012,
         ], $this->getCsrfData()));
 
         $this->assertTrue($this->form->isValid());

--- a/service-front/module/Application/view/application/authenticated/lpa/repeat-application/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/repeat-application/index.twig
@@ -13,7 +13,8 @@
     },
     'repeatCaseNumber': {
         "Value is required and can't be empty": "If you are making a repeat application, you need to enter the case number given to you by the Office of the Public Guardian.",
-        "max-length-12" : 'Case Number must be twelve letters or fewer'
+        "max-length-12" : 'Case Number must be twelve digits',
+        "min-length-12" : 'Case Number must be twelve digits'
     }
 }) %}
 

--- a/service-front/module/Application/view/application/authenticated/lpa/repeat-application/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/repeat-application/index.twig
@@ -13,6 +13,7 @@
     },
     'repeatCaseNumber': {
         "Value is required and can't be empty": "If you are making a repeat application, you need to enter the case number given to you by the Office of the Public Guardian.",
+        "must-be-less-than-or-equal:12" : 'Case Number must be twelve letters or fewer'
     }
 }) %}
 

--- a/service-front/module/Application/view/application/authenticated/lpa/repeat-application/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/repeat-application/index.twig
@@ -12,7 +12,7 @@
         "Value is required and can't be empty": 'Select if donor is or is not making a repeat application',
     },
     'repeatCaseNumber': {
-        "Value is required and can't be empty": "If you are making a repeat application, you need to enter the case number given to you by the Office of the Public Guardian.",
+        "cannot-be-blank": "If you are making a repeat application, you need to enter the case number given to you by the Office of the Public Guardian.",
         "must-be-less-than-or-equal:12" : 'Case Number must be twelve letters or fewer'
     }
 }) %}

--- a/service-front/module/Application/view/application/authenticated/lpa/repeat-application/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/repeat-application/index.twig
@@ -12,8 +12,8 @@
         "Value is required and can't be empty": 'Select if donor is or is not making a repeat application',
     },
     'repeatCaseNumber': {
-        "cannot-be-blank": "If you are making a repeat application, you need to enter the case number given to you by the Office of the Public Guardian.",
-        "must-be-less-than-or-equal:12" : 'Case Number must be twelve letters or fewer'
+        "Value is required and can't be empty": "If you are making a repeat application, you need to enter the case number given to you by the Office of the Public Guardian.",
+        "max-length-12" : 'Case Number must be twelve letters or fewer'
     }
 }) %}
 
@@ -52,6 +52,7 @@
 {{ repeatCaseNumber.setAttributes({
     id: 'repeatCaseNumber',
     type: 'text',
+    size: 12,
     class: 'form-control',
     inputmode: 'numeric',
     pattern: '[0-9]*',


### PR DESCRIPTION
## Purpose

_Case number on repeat application needs to be restricted to 12 chars no more no less_

## Approach

_Minor change to validator in php, and formErrorExchange in twig, with addition to cypress test. Change existing tests which only had 8 chars which is invalid 😂  _ 

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
