### PR TITLE
LPAL-677 add policy fo cloudwatch encryption key

### DIFF
--- a/terraform/region/modules/region/kms.tf
+++ b/terraform/region/modules/region/kms.tf
@@ -20,6 +20,8 @@ resource "aws_kms_alias" "lpa_pdf_cache" {
   target_key_id = aws_kms_key.lpa_pdf_cache.key_id
 }
 
+# See the following link for further information
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
 resource "aws_kms_key" "cloudwatch_encryption" {
   description             = "encryption key for cloudwatch"
   deletion_window_in_days = 7

--- a/terraform/region/modules/region/kms.tf
+++ b/terraform/region/modules/region/kms.tf
@@ -25,9 +25,76 @@ resource "aws_kms_key" "cloudwatch_encryption" {
   deletion_window_in_days = 7
   tags                    = merge(local.default_tags, local.pdf_component_tag)
   enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.cloudwatch_encryption_kms.json
+
 }
 
 resource "aws_kms_alias" "cloudwatch_encryption" {
   name          = "alias/cloudwatch_encryption-${terraform.workspace}"
   target_key_id = aws_kms_key.cloudwatch_encryption.key_id
+}
+
+
+data "aws_iam_policy_document" "cloudwatch_encryption_kms" {
+  statement {
+    sid       = "Enable Root account permissions on Key"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+      ]
+    }
+  }
+
+  statement {
+    sid       = "Allow Key to be used for Encryption"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "events.amazonaws.com"
+      ]
+    }
+  }
+
+  statement {
+    sid       = "Key Administrator"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass"]
+    }
+  }
 }


### PR DESCRIPTION
## Purpose

Add a kms resource policy to allow encryption and decryption rights for new encryption kms key

Allows:
- root key permissions
- encryption decryption of logs/ events
- Key administration alowed for breakglass

assists LPAL-677

## Approach

Add a policy to allow use of the KMS key in the terraform

## Learning
Key policies: https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
