### PR TITLE
LPAL-719 update readme to include repo standards badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The Office of the Public Guardian Lasting Power of Attorney online service: Managed by opg-org-infra &amp; Terraform.
 
+[![repo standards badge](https://img.shields.io/badge/dynamic/json?color=blue&style=for-the-badge&logo=github&label=MoJ%20Compliant&query=%24.data%5B%3F%28%40.name%20%3D%3D%20%22opg-lpa%22%29%5D.status&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fgithub_repositories)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/github_repositories#opg-lpa "Link to report")
+
 ## Pre-requisites for Local Development
 
 Set up software on your machine required to run the application locally:
@@ -157,15 +159,17 @@ The load tests are located in `tests/load`. They are written using [locust](http
 
 To run the load tests:
 
-1.  Start the stack (see above).
-1.  Create a virtualenv: `virtualenv -p python3 ~/.loadtestsvenv` (substitute your preferred
+1. Start the stack (see above).
+1. Create a virtualenv: `virtualenv -p python3 ~/.loadtestsvenv` (substitute your preferred
 path for the virtual environment).
-1.  Install dependencies:
+1. Install dependencies:
+
     ```bash
     cd tests/load
     pip install -e .
     ```
-1.  Run the test suite: `run_load_tests.sh tests/suite.py`
+
+1. Run the test suite: `run_load_tests.sh tests/suite.py`
     The tests run indefinitely until you interrupt them. Reports are written to `build/load_tests`.
     Running `run_load_tests.sh` without arguments shows the available switches.
 


### PR DESCRIPTION
## Purpose
To add badge for repo readme that shows compliance with MOJ Repo standards.
Fixes LPAL-719

Note we also fixed the repo in org infra under a separate PR: https://github.com/ministryofjustice/opg-org-infra/pull/1465

## Approach

add badge to readme.

## Learning

See https://github.com/ministryofjustice/github-repository-standards 
## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
