### PR TITLE
LPAL-721 update script to use amazon-linux-extras and psql10

### DIFF
--- a/docs/runbooks/cloud9/cloud9_init.sh
+++ b/docs/runbooks/cloud9/cloud9_init.sh
@@ -8,7 +8,8 @@ function main() {
 }
 
 function install_tools() {
- sudo amazon-linux-extras install postgresql10 -y
+  sudo amazon-linux-extras install postgresql10 jq -y
+  sudo yum install jq -y
 }
 
 function infer_account() {

--- a/docs/runbooks/cloud9/cloud9_init.sh
+++ b/docs/runbooks/cloud9/cloud9_init.sh
@@ -8,7 +8,7 @@ function main() {
 }
 
 function install_tools() {
-  sudo amazon-linux-extras install postgresql10 jq -y
+  sudo amazon-linux-extras install postgresql10 -y
   sudo yum install jq -y
 }
 

--- a/docs/runbooks/cloud9/cloud9_init.sh
+++ b/docs/runbooks/cloud9/cloud9_init.sh
@@ -8,9 +8,7 @@ function main() {
 }
 
 function install_tools() {
-  #update to 9.6 - to match rds version deployed
-  #this may need further adjusting as the environments may have a newer one e.g. 10.3
-  sudo yum install postgresql96 jq -y
+ sudo amazon-linux-extras install postgresql10 -y
 }
 
 function infer_account() {


### PR DESCRIPTION
## Purpose

Update the tooling for Cloud9 instances

Fixes LPAL-721

## Approach
- use amazon-linux-extras
- use PSQL10

## Learning

https://aws.amazon.com/premiumsupport/knowledge-center/ec2-install-extras-library-software/

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
