### PR TITLE
Lpal 726 docker api non root run

### DIFF
--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -1,7 +1,9 @@
 FROM composer:2.1.11 AS composer
 
-COPY service-api/composer.json /app/composer.json
-COPY service-api/composer.lock /app/composer.lock
+RUN adduser -D -g '' appuser
+
+COPY --chown=appuser:appuser service-admin/composer.json /app/composer.json
+COPY --chown=appuser:appuser service-admin/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
@@ -16,7 +18,7 @@ RUN apk add --update --no-cache postgresql-libs
 RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS postgresql-dev \
   && docker-php-ext-install pgsql pdo_pgsql \
   && docker-php-ext-install bcmath \
-  && docker-php-ext-install opcache 
+  && docker-php-ext-install opcache
 
 # Default for AWS. Should be set to 1 for local development.
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
@@ -37,13 +39,16 @@ RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
 # Clean up build dependencies, but only after everything else we need has been installed
 RUN apk del .build-dependencies
 
-COPY service-api /app
-COPY shared/logging /shared/logging
-COPY --from=composer /app/vendor /app/vendor
-COPY service-api/docker/app/app-php.ini /usr/local/etc/php/conf.d/
-COPY service-api/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
+COPY --chown=appuser:appuser service-api /app
+COPY --chown=appuser:appuser shared/logging /shared/logging
+COPY --chown=appuser:appuser --from=composer /app/vendor /app/vendor
+COPY --chown=appuser:appuser service-api/docker/app/app-php.ini /usr/local/etc/php/conf.d/
+COPY --chown=appuser:appuser service-api/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
+
+RUN chmod +x /app/docker/app/db-migrations.sh
 
 WORKDIR /app
 
-CMD chmod +x /app/docker/app/db-migrations.sh && /app/docker/app/db-migrations.sh \
-  && php-fpm
+USER appuser
+
+CMD  /app/docker/app/db-migrations.sh && php-fpm

--- a/service-api/docker/web/Dockerfile
+++ b/service-api/docker/web/Dockerfile
@@ -1,11 +1,19 @@
 FROM nginx:stable-alpine
 
+RUN chown -R nginx:nginx /var/cache/nginx && \
+    chown -R nginx:nginx /var/log/nginx && \
+    chown -R nginx:nginx /etc/nginx/conf.d && \
+    touch /run/nginx.pid && \
+    chown -R nginx:nginx /run/nginx.pid && \
+    chmod -R 777 /etc/nginx/conf.d
 # Add Confd to configure nginx on start
 ENV CONFD_VERSION="0.16.0"
-RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64" \
-  && chmod +x /usr/local/bin/confd
+RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64" && \
+    chown -R nginx:nginx /usr/local/bin/confd && \
+    chmod +x /usr/local/bin/confd
 
-COPY service-api/docker/web/etc /etc
+USER nginx
+COPY --chown=nginx:nginx service-api/docker/web/etc /etc
 
-CMD confd -onetime -backend env \
-  && nginx -g "daemon off;"
+CMD confd -onetime -backend env  && \
+    nginx -g "daemon off;"


### PR DESCRIPTION
## Purpose

Following on from #873 implement the non root execution of containers in API Layer

Fixes LPAL-726

## Approach

- SEE #873 for details of changes, they are similar here.

## Learning

#873 

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
