### PR TITLE
LPAL-725 front docker as non root

### DIFF
--- a/service-admin/docker/web/Dockerfile
+++ b/service-admin/docker/web/Dockerfile
@@ -11,9 +11,10 @@ RUN chmod o+rwx /etc/nginx/conf.d
 
 # Add Confd to configure nginx on start
 ENV CONFD_VERSION="0.16.0"
-RUN  wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64"
+RUN  wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64" \
+  && chown -R nginx:nginx /usr/local/bin/confd \
+  && chmod +x /usr/local/bin/confd
 
-RUN   chown -R nginx:nginx /usr/local/bin/confd && chmod +x /usr/local/bin/confd
 USER nginx
 COPY --chown=nginx:nginx service-admin/public /web
 COPY --chown=nginx:nginx service-admin/docker/web/etc /etc

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -1,7 +1,9 @@
 FROM composer:2.1.11 AS composer
 
-COPY service-front/composer.json /app/composer.json
-COPY service-front/composer.lock /app/composer.lock
+RUN adduser -D -g '' appuser
+
+COPY --chown=appuser:appuser service-front/composer.json /app/composer.json
+COPY --chown=appuser:appuser service-front/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
@@ -13,14 +15,14 @@ RUN apk upgrade --available
 # security fix for expat
 RUN apk upgrade expat
 
-RUN apk add --update --no-cache icu 
+RUN apk add --update --no-cache icu
 
 RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS icu-dev \
         && pecl install redis \
         && docker-php-ext-enable redis \
         && docker-php-ext-install intl \
         && docker-php-ext-install bcmath \
-        && docker-php-ext-install opcache 
+        && docker-php-ext-install opcache
 
 # Default for AWS. Should be set to 1 for local development.
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
@@ -41,12 +43,14 @@ fi
 # Clean up build dependencies, but only after everything else we need has been installed
 RUN apk del .build-dependencies
 
-COPY service-front /app
-COPY shared/logging /shared/logging
-COPY --from=composer /app/vendor /app/vendor
-COPY service-front/docker/app/app-php.ini /usr/local/etc/php/conf.d/
-COPY service-front/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
+COPY --chown=appuser:appuser service-front /app
+COPY --chown=appuser:appuser shared/logging /shared/logging
+COPY --chown=appuser:appuser --from=composer /app/vendor /app/vendor
+COPY --chown=appuser:appuser service-front/docker/app/app-php.ini /usr/local/etc/php/conf.d/
+COPY --chown=appuser:appuser service-front/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
 WORKDIR /app
+
+USER appuser
 
 CMD php-fpm

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -8,6 +8,8 @@ COPY --chown=appuser:appuser service-front/composer.lock /app/composer.lock
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
 FROM php:8.0-fpm-alpine
+
+RUN adduser -D -g '' appuser
 #docker image on hub hasn't been upgraded yet - fixes CVE-2021-36159
 RUN apk add --upgrade apk-tools
 RUN apk upgrade --available

--- a/service-front/docker/web/Dockerfile
+++ b/service-front/docker/web/Dockerfile
@@ -14,8 +14,9 @@ RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/re
   && chown -R nginx:nginx /usr/local/bin/confd \
   && chmod +x /usr/local/bin/confd
 
-COPY service-front/public /web
-COPY service-front/docker/web/etc /etc
+USER nginx
+COPY --chown=nginx:nginx service-front/public /web
+COPY --chown=nginx:nginx service-front/docker/web/etc /etc
 
 CMD confd -onetime -backend env \
   && nginx -g "daemon off;"

--- a/service-front/docker/web/Dockerfile
+++ b/service-front/docker/web/Dockerfile
@@ -1,8 +1,17 @@
 FROM nginx:stable-alpine
 
+RUN chown -R nginx:nginx /var/cache/nginx && \
+        chown -R nginx:nginx /var/log/nginx && \
+        chown -R nginx:nginx /etc/nginx/conf.d && \
+        touch /run/nginx.pid && \
+        chown -R nginx:nginx /run/nginx.pid
+
+RUN chmod o+rwx /etc/nginx/conf.d
+
 # Add Confd to configure nginx on start
 ENV CONFD_VERSION="0.16.0"
 RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64" \
+  && chown -R nginx:nginx /usr/local/bin/confd \
   && chmod +x /usr/local/bin/confd
 
 COPY service-front/public /web


### PR DESCRIPTION
## Purpose

Update Service front to execute as non root on it's containers

Fixes LPAL-725

## Approach

Follow on from LPAL-723 and LPAL-725, update web and app containers.

## Learning
See #873  and #878 for further details.

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
