### PR TITLE
LPAL-727 update pdf container to exec as non root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ hard-reset-front:
 	docker-compose build --no-cache front-app
 
 .PHONY: soft-reset-front
-# soft reset only the front app container without no-cache option.  quickest rebuild but runs risk of some staleness if not every change is picked up 
+# soft reset only the front app container without no-cache option.  quickest rebuild but runs risk of some staleness if not every change is picked up
 soft-reset-front:
 	@${MAKE} dc-down
 	docker-compose build front-app
@@ -205,6 +205,14 @@ functional-local:
 integration-api-local:
 	docker build -f ./service-api/docker/app/Dockerfile -t integration-api-tests .;\
 	docker run -it --network="host" --rm integration-api-tests  sh -c "cd /app/tests/integration && php ../../vendor/bin/phpunit -v"
+
+.PHONY: test-pdf-local
+test-pdf-local:
+	docker build -f ./service-pdf/docker/app/Dockerfile -t pdf-tests .;\
+	docker run -d --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name pdf-test-run pdf-tests; \
+	docker exec pdf-test-run /app/vendor/bin/phpunit -d memory_limit=256M; \
+	docker stop pdf-test-run;
+	docker rm pdf-test-run;
 
 .PHONY: cypress-local
 cypress-local:

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -1,11 +1,15 @@
 FROM composer:2.1.11 AS composer
 
-COPY service-pdf/composer.json /app/composer.json
-COPY service-pdf/composer.lock /app/composer.lock
+RUN adduser -D -g '' appuser
+
+COPY --chown=appuser:appuser service-pdf/composer.json /app/composer.json
+COPY --chown=appuser:appuser service-pdf/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
 FROM php:8.0-cli-alpine
+
+RUN adduser -D -g '' appuser
 
 RUN apk add --upgrade apk-tools
 RUN apk upgrade --available
@@ -15,7 +19,7 @@ RUN apk upgrade expat
 
 RUN apk update \
     && apk add --no-cache openjdk8-jre gcc make musl-dev pkgconfig bash\
-    && apk add --no-cache --update --virtual buildDeps autoconf 
+    && apk add --no-cache --update --virtual buildDeps autoconf
 
 # Enable debug if needed. Should only be used locally.
 ARG ENABLE_XDEBUG=0
@@ -39,13 +43,15 @@ WORKDIR /usr/local/bin/
 
 RUN wget https://gitlab.com/pdftk-java/pdftk/-/jobs/812582458/artifacts/raw/build/libs/pdftk-all.jar
 
-COPY service-pdf/bin/pdftk pdftk
-RUN chmod +x pdftk
+COPY --chown=appuser:appuser service-pdf/bin/pdftk pdftk
+COPY --chown=appuser:appuser shared/logging /shared/logging
+COPY --chown=appuser:appuser service-pdf /app
+COPY --chown=appuser:appuser --from=composer /app/vendor /app/vendor
 
-COPY shared/logging /shared/logging
-COPY service-pdf /app
-COPY --from=composer /app/vendor /app/vendor
+RUN chmod o+x pdftk
 
 WORKDIR /app
+
+USER appuser
 
 CMD /app/bin/start.sh

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -52,7 +52,7 @@ RUN chmod o+x pdftk
 # user doesn't have access to tmp
 
 WORKDIR /app
-RUN chown -R appuser:app /tmp
+RUN chown -R appuser:appuser /tmp
 RUN chmod ugo+rwx /tmp
 
 USER appuser

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -50,7 +50,7 @@ COPY --chown=appuser:appuser --from=composer /app/vendor /app/vendor
 
 RUN chmod o+x pdftk
 # user doesn't have access to tmp
-RUN chown -R appuser:appuser /tmp && chmod o+rw /tmp
+RUN  chmod +rwx /tmp
 WORKDIR /app
 
 USER appuser

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -52,7 +52,7 @@ RUN chmod o+x pdftk
 # user doesn't have access to tmp
 
 WORKDIR /app
-RUN chown -R appuser:appuser /tmp
+RUN mkdir /tmp && chown -R appuser:appuser /tmp
 RUN chmod ugo+rwx /tmp
 
 USER appuser

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -50,8 +50,10 @@ COPY --chown=appuser:appuser --from=composer /app/vendor /app/vendor
 
 RUN chmod o+x pdftk
 # user doesn't have access to tmp
-RUN  chmod ugo+rwx /tmp
+
 WORKDIR /app
+RUN chown -R appuser:app /tmp
+RUN chmod ugo+rwx /tmp
 
 USER appuser
 

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -49,7 +49,8 @@ COPY --chown=appuser:appuser service-pdf /app
 COPY --chown=appuser:appuser --from=composer /app/vendor /app/vendor
 
 RUN chmod o+x pdftk
-
+# user doesn't have access to tmp
+RUN chown -R appuser:appuser /tmp && chmod o+rw /tmp
 WORKDIR /app
 
 USER appuser

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -50,7 +50,7 @@ COPY --chown=appuser:appuser --from=composer /app/vendor /app/vendor
 
 RUN chmod o+x pdftk
 # user doesn't have access to tmp
-RUN  chmod +rwx /tmp
+RUN  chmod ugo+rwx /tmp
 WORKDIR /app
 
 USER appuser

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -48,12 +48,10 @@ COPY --chown=appuser:appuser shared/logging /shared/logging
 COPY --chown=appuser:appuser service-pdf /app
 COPY --chown=appuser:appuser --from=composer /app/vendor /app/vendor
 
-RUN chmod o+x pdftk
+RUN chmod u+x pdftk
 # user doesn't have access to tmp
 
 WORKDIR /app
-RUN mkdir /tmp && chown -R appuser:appuser /tmp
-RUN chmod ugo+rwx /tmp
 
 USER appuser
 


### PR DESCRIPTION
## Purpose

Following on from Admin , API and Front, update so that pdf container runs as non root.

Fixes LPAL-727

## Approach

Same aproach as LPAL-723, LPAL-725, LPAL-726 as the changes are similar.
added an additional PDF testing make entry.

## Learning

see PRS:
- #873 
- #878 
- #886

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
