### PR TITLE
LPAL-734 update to 2.2.12 as per CVE

### DIFF
--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.1.11 AS composer
+FROM composer:2.2.12 AS composer
 
 RUN adduser -D -g '' appuser
 

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.1.11 AS composer
+FROM composer:2.2.12 AS composer
 
 RUN adduser -D -g '' appuser
 


### PR DESCRIPTION
## Purpose

Fix composer versions to a fixed version 2.2.12 as per CVE mentioned in LPAL-734.

Fixes LPAL-734

## Approach

update PDF and Front  2.1.11 -> 2.2.12 

## Learning

https://blog.packagist.com/cve-2022-24828-composer-command-injection-vulnerability/

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
