### PR TITLE
LPAL-730 adjust ADR for internal domains

### DIFF
--- a/terraform/environment/modules/environment/dns.tf
+++ b/terraform/environment/modules/environment/dns.tf
@@ -9,7 +9,11 @@ data "aws_route53_zone" "live_service_lasting_power_of_attorney" {
 }
 
 locals {
-  dns_namespace_internal = var.account_name == "development" ? "${var.account_name}.${var.environment_name}.internal" : "${var.environment_name}-internal"
+  dns_namespace_internal = (
+    var.account_name == "development" ?
+    "${var.environment_name}.${var.account_name}.opg.lpa.api.ecs.internal" :
+    "${var.environment_name}-internal"
+  )
 }
 
 resource "aws_service_discovery_private_dns_namespace" "internal" {

--- a/terraform/region/modules/region/dns_firewall.tf
+++ b/terraform/region/modules/region/dns_firewall.tf
@@ -36,7 +36,7 @@ locals {
     "secretsmanager.${data.aws_region.current.name}.amazonaws.com.${data.aws_region.current.name}.compute.internal.",
     "${replace(aws_elasticache_replication_group.front_cache.primary_endpoint_address, "master", "*")}.",
     "311462405659.dkr.ecr.eu-west-1.amazonaws.com.",
-    "${var.account_name}.internal.",
+    "${var.account_name}.opg.lpa.api.ecs.internal.",
     "api.${var.account_name}-internal."
   ]
 }


### PR DESCRIPTION
## Purpose

Following on from discussions with the Community Of Practice regarding internally named domains, Adjust to match better naming convention. See ADR 0009 (updated in this PR) for details of the amendments

Fixes LPAL-730

## Approach
- Amend ADR 0009
- Adjust internal DNS Namespace with new convention for Dev only
- Update DNS Resolver rule to cover changes

Note - there is a follow up ticket which will roll these changes through to production, but these require a down time slot.

## Learning

- Multiline ternaries in Terraform require brackets!

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
