### PR TITLE
LPAL-709 create an events subscription at region level

### DIFF
--- a/terraform/region/modules/region/sns.tf
+++ b/terraform/region/modules/region/sns.tf
@@ -9,3 +9,13 @@ resource "aws_sns_topic" "cloudwatch_to_account_ops_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-${local.region_name}-ops-alert"
   tags = merge(local.default_tags, local.shared_component_tag)
 }
+
+resource "aws_sns_topic" "rds_events" {
+  name = "${local.account_name}-${local.region_name}-rds-events"
+  tags = merge(local.default_tags, local.db_component_tag)
+}
+
+resource "aws_db_event_subscription" "rds_events" {
+  name      = "${local.account_name}-${local.region_name}-rds-event-sub"
+  sns_topic = aws_sns_topic.rds_events.arn
+}


### PR DESCRIPTION
## Purpose

We need to move the DB events subscription to the region level, as this needs to be supported in all regions in case of a DR Situation.

Fixes LPAL-709 (partially) 
- will follow up with a second  PR to remove at account level.

## Approach

- create region level events subscription

## Learning

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
