### PR TITLE
LPAL-651 Prevent raw 500 page when newly-signed-up user changes email/password 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,5 +241,5 @@ restitch:
 # this requires a globally-installed cypress
 .PHONY: cypress-open
 cypress-open:
-	aws-vault exec moj-lpa-dev -- python3 cypress/S3Monitor.py &
+	aws-vault exec moj-lpa-dev -- python3 cypress/S3Monitor.py -v &
 	CYPRESS_userNumber=`node cypress/userNumber.js` ./node_modules/.bin/cypress open --project ./

--- a/cypress/integration/SignupAndChangeDetails.feature
+++ b/cypress/integration/SignupAndChangeDetails.feature
@@ -33,5 +33,14 @@ Feature: SignupAndChangeDetails
         And I visit the your details page
         And I visit link containing "Your details"
         And I visit link containing "Change Password"
-        When I try to change password with a mismatch
+        When I try to change password for "SignupAndChangeDetailsUser" with a mismatch
         Then I see "Enter matching passwords" in the page text
+
+    @focus
+    Scenario: Mismatched email addresses in email change screen result in error message instead of raw 500 page (LPAL-651)
+        Given I log in as "SignupAndChangeDetailsUser" test user
+        And I visit the your details page
+        And I visit link containing "Your details"
+        And I visit link containing "Change Email Address"
+        When I try to change email address for "SignupAndChangeDetailsUser" with a mismatch
+        Then I see "The emails did not match" in the page text

--- a/cypress/integration/SignupAndChangeDetails.feature
+++ b/cypress/integration/SignupAndChangeDetails.feature
@@ -1,0 +1,28 @@
+@SignUp
+Feature: SignupAndChangeDetails
+
+    I want to be able to sign up and immediately change my password and email address
+
+    Background:
+        Given I ignore application exceptions
+
+    @focus
+    Scenario: Sign up with automatically generated test username and password
+        Given I sign up "SignupAndChangeDetailsUser" test user with password "Pass1234"
+        When I use activation email for "SignupAndChangeDetailsUser" to visit the link
+        Then I see "Account activated" in the title
+
+    @focus
+    Scenario: Enter valid "About You" details
+        Given I log in as "SignupAndChangeDetailsUser" test user
+        When I select "Mr" on "name-title"
+        And I force fill out
+          | name-first| Hammer |
+          | name-last| Vortigax |
+          | dob-date-day| 1 |
+          | dob-date-month| 12 |
+          | dob-date-year| 1978 |
+          | address-address1| 12 PARANOIA CLOSE |
+          | address-postcode| PC45 9JA |
+        And I click "save"
+        Then I am taken to the lpa type page

--- a/cypress/integration/SignupAndChangeDetails.feature
+++ b/cypress/integration/SignupAndChangeDetails.feature
@@ -26,3 +26,12 @@ Feature: SignupAndChangeDetails
           | address-postcode| PC45 9JA |
         And I click "save"
         Then I am taken to the lpa type page
+
+    @focus
+    Scenario: Mismatched passwords in password change screen result in error message instead of raw 500 page (LPAL-651)
+        Given I log in as "SignupAndChangeDetailsUser" test user
+        And I visit the your details page
+        And I visit link containing "Your details"
+        And I visit link containing "Change Password"
+        When I try to change password with a mismatch
+        Then I see "Enter matching passwords" in the page text

--- a/cypress/integration/SignupAndChangeDetails.feature
+++ b/cypress/integration/SignupAndChangeDetails.feature
@@ -43,4 +43,4 @@ Feature: SignupAndChangeDetails
         And I visit link containing "Your details"
         And I visit link containing "Change Email Address"
         When I try to change email address for "SignupAndChangeDetailsUser" with a mismatch
-        Then I see "The emails did not match" in the page text
+        Then I see "Enter matching email addresses" in the page text

--- a/cypress/integration/UserPersonalDetails.feature
+++ b/cypress/integration/UserPersonalDetails.feature
@@ -15,7 +15,7 @@ Feature: Change User Personal Details
         Then I am taken to "/user/change-email-address"
         And I see in the page text
             | There is a problem |
-            | The emails did not match |
+            | Enter matching email addresses |
         And I see "Error" in the title
 
         When I try to change to invalid email address

--- a/cypress/integration/common/activation_email.js
+++ b/cypress/integration/common/activation_email.js
@@ -11,13 +11,21 @@ Then(`I use password reset email to visit the link`, () => {
     openEmailAndVisitLink('passwordreset');
 })
 
-function openEmailAndVisitLink(type){
-    var filename = activation_email_path + Cypress.env("userNumber") + '.' + type;
+Then(`I use activation email for {string} to visit the link`, (name) => {
+    openEmailAndVisitLink('activation', Cypress.env(name + "-identifier"));
+})
+
+function openEmailAndVisitLink(type, identifier) {
+    if (!identifier) {
+        identifier = Cypress.env("userNumber");
+    }
+
+    var filename = activation_email_path + identifier + '.' + type;
     cy.log('Trying to open: ' + filename);
-   
+
     cy.readFile(filename, { timeout: 100000 }).then(text => {
         var content = text;
-        cy.log(text); 
+        cy.log(text);
         cy.log('Orig Content: ' + content);
         var contentStr = content;
 

--- a/cypress/integration/common/i_change_details.js
+++ b/cypress/integration/common/i_change_details.js
@@ -7,6 +7,14 @@ When("I try to change email address with a mismatch", () => {
         cy.get('[data-cy=save-new-email]').click();
 });
 
+When("I try to change email address for {string} with a mismatch", (name) => {
+        let password = Cypress.env(name + "-password");
+        cy.get("[data-cy=password_current]").clear().type(password);
+        cy.get("[data-cy=email]").clear().type('anewemail@digital.justice.gov.uk');
+        cy.get("[data-cy=email_confirm]").clear().type("mismatched@digital.justice.gov.uk");
+        cy.get('[data-cy=save-new-email]').click();
+});
+
 When("I try to change to invalid email address", () => {
         cy.get("[data-cy=password_current]").clear().type(Cypress.env('seeded_password'));
         cy.get("[data-cy=email]").clear().type('notavalidaddress');
@@ -20,4 +28,3 @@ When("I try to change email address correctly", () => {
         cy.get("[data-cy=email_confirm]").clear().type("anewemail@digital.justice.gov.uk");
         cy.get('[data-cy=save-new-email]').click();
 });
-

--- a/cypress/integration/common/i_log_in.js
+++ b/cypress/integration/common/i_log_in.js
@@ -1,5 +1,11 @@
 import { When } from "cypress-cucumber-preprocessor/steps";
 
+When(`I log in as {string} test user`, (name) => {
+    let user = Cypress.env(name + "-user");
+    let password = Cypress.env(name + "-password");
+    logIn(user, password)
+})
+
 When(`I log in with user {string} password {string}`, (user, password) => {
     logIn(user, password);
 })

--- a/cypress/integration/common/i_sign_up.js
+++ b/cypress/integration/common/i_sign_up.js
@@ -6,7 +6,23 @@ Given(`I sign up standard test user`, () => {
 
 Given(`I sign up with email {string} and password {string}`, (email, password) => {
     signUp(email, password);
-});
+})
+
+Given(`I sign up {string} test user with password {string}`, (name, password) => {
+    // Create unique identifier based on the name
+    let identifier = "" + (new Date()).getTime() + Math.floor(Math.random() * 999999999);
+
+    // Create unique email/username based on the identifier
+    let user = "caspertests+" + identifier + "@lpa.opg.service.justice.gov.uk";
+
+    // Store the identifier, username and password in the cypress session;
+    // they can be retrieved using the name+suffix in subsequent tests
+    Cypress.env(name + "-identifier", identifier);
+    Cypress.env(name + "-user", user);
+    Cypress.env(name + "-password", password);
+
+    signUp(user, password);
+})
 
 function signUp(user, password){
     cy.visit("/signup").title().should('include','Create an account');

--- a/cypress/integration/common/i_visit.js
+++ b/cypress/integration/common/i_visit.js
@@ -14,6 +14,10 @@ Then(`I visit the dashboard`, () => {
     cy.visit('/user/dashboard');
 })
 
+Then(`I visit the your details page`, () => {
+    cy.visit('/user/about-you');
+})
+
 Then(`I visit the type page`, () => {
     cy.visitWithChecks('/lpa/type');
 })

--- a/cypress/integration/common/password.js
+++ b/cypress/integration/common/password.js
@@ -55,3 +55,12 @@ When("I log in with new password", () => {
         cy.get('[data-cy=login-submit-button]').click();
         cy.OPGCheckA11y();
 });
+
+When("I try to change password for {string} with a mismatch", (name) => {
+        let password = Cypress.env(name + "-password");
+        cy.get("[data-cy=password_current]").clear().type(password);
+        cy.get("[data-cy=password]").clear().type("mismatchedPassword2345");
+        cy.get("[data-cy=password_confirm]").clear().type("mismatchedPassword1234");
+        cy.get('[data-cy=save-new-password]').click();
+        cy.OPGCheckA11y();
+});

--- a/service-front/module/Application/src/View/Helper/AccountInfo.php
+++ b/service-front/module/Application/src/View/Helper/AccountInfo.php
@@ -10,9 +10,12 @@ use Laminas\Router\RouteMatch;
 use Laminas\Session\Container;
 use Laminas\View\Helper\AbstractHelper;
 use Laminas\View\Model\ViewModel;
+use MakeLogger\Logging\LoggerTrait;
 
 class AccountInfo extends AbstractHelper
 {
+    use LoggerTrait;
+
     /**
      * @var AuthenticationService
      */
@@ -110,7 +113,8 @@ class AccountInfo extends AbstractHelper
             $this->userDetailsSession->hasOneOrMoreLPAs == false
         ) {
             $lpasSummaries = $this->lpaApplicationService->getLpaSummaries();
-            $this->userDetailsSession->hasOneOrMoreLPAs = ($lpasSummaries['total'] > 0);
+            $this->userDetailsSession->hasOneOrMoreLPAs =
+                (array_key_exists('total', $lpasSummaries) && $lpasSummaries['total'] > 0);
         }
 
         $params['hasOneOrMoreLPAs'] = $this->userDetailsSession->hasOneOrMoreLPAs;

--- a/service-front/module/Application/view/application/authenticated/change-email-address/partials/index-error-summary.twig
+++ b/service-front/module/Application/view/application/authenticated/change-email-address/partials/index-error-summary.twig
@@ -10,7 +10,7 @@
     },
     'email_confirm' : {
         'cannot-be-empty' : 'Confirm your new email address',
-        'did-not-match' : 'The emails did not match'
+        'did-not-match' : 'Enter matching email addresses'
     }
 }) %}
 

--- a/service-front/module/Application/view/application/general/register/partials/index-error-summary.twig
+++ b/service-front/module/Application/view/application/general/register/partials/index-error-summary.twig
@@ -6,7 +6,7 @@
     },
     'email_confirm' : {
         'cannot-be-empty' : 'Confirm your email address',
-        'did-not-match' : 'The emails did not match'
+        'did-not-match' : 'Enter matching email addresses'
     },
     'password' : {
         'cannot-be-empty' : 'Enter your password',

--- a/service-front/module/Application/view/application/partials/confirm-email-error-summary.twig
+++ b/service-front/module/Application/view/application/partials/confirm-email-error-summary.twig
@@ -6,7 +6,7 @@
     },
     'email_confirm' : {
         'cannot-be-empty' : 'Confirm your email address',
-        'did-not-match' : 'The emails did not match'
+        'did-not-match' : 'Enter matching email addresses'
     }
 }) %}
 


### PR DESCRIPTION
## Purpose

Fixes [LPAL-651]()

## Approach

* Prevent RuntimeError breaking template rendering by instead returning empty data object
* Modify cypress scripts so we can sign up multiple users during test suite run
* Add test for mismatched password change and mismatched email change

## Learning

I didn't get to the bottom of why we were getting a runtime error when trying to get the LPA applications for the current logged-in user. However, I could see it happening. It's generally a bad idea to do this, though: better to return the equivalent of a [null object](https://en.wikipedia.org/wiki/Null_object_pattern) instead of breaking the template with an unexpected exception because an HTTP request failed. Also, shouldn't really be doing HTTP requests from view helpers, but that's another issue.

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [x] The product team have tested these changes
