### PR TITLE
LPAL-697 - Update content on feedback form

### DIFF
--- a/service-front/module/Application/view/application/general/feedback/index.twig
+++ b/service-front/module/Application/view/application/general/feedback/index.twig
@@ -84,7 +84,7 @@
 
         <div class="form-group {{ email.getMessages|length >0 ? 'form-group-error'}}">
             <label class="heading-medium flush--top text" for="{{ email.getAttribute('id') }}">
-                Your email address (optional)
+                Your email address
             </label>
             {{ formElementErrorsV2(email) }}
             {{ formElement(email) }}
@@ -92,7 +92,7 @@
 
         <div class="form-group {{ phone.getMessages|length >0 ? 'form-group-error'}}">
             <label class="heading-medium flush--top text" for="{{ phone.getAttribute('id') }}">
-                Your phone number (optional)
+                Your phone number
             </label>
             {{ formElementErrorsV2(phone) }}
             {{ formElement(phone) }}

--- a/service-front/module/Application/view/application/general/feedback/index.twig
+++ b/service-front/module/Application/view/application/general/feedback/index.twig
@@ -59,7 +59,7 @@
 
     <fieldset>
         <div class="text">
-            <p>We will not respond to your feedback directly but will use it to improve this service. If you're happy to be contacted to give further feedback, please leave your email address or phone number.</p>
+            <p>We will not respond to your feedback directly but will use it to improve this service.</p>
             <p>If you have a question about your LPA, please email <a href="mailto:customerservices@publicguardian.gov.uk">customerservices@publicguardian.gov.uk</a> who will be able to help.</p>
         </div>
 
@@ -80,9 +80,11 @@
             {{ formElement(details) }}
         </div>
 
+        <p class="heading-medium">If you’re happy to take part in research about this service, please leave your preferred contact details.</p>
+
         <div class="form-group {{ email.getMessages|length >0 ? 'form-group-error'}}">
             <label class="heading-medium flush--top text" for="{{ email.getAttribute('id') }}">
-                Your email address (optional)
+                Your email address
             </label>
             {{ formElementErrorsV2(email) }}
             {{ formElement(email) }}
@@ -90,7 +92,7 @@
 
         <div class="form-group {{ phone.getMessages|length >0 ? 'form-group-error'}}">
             <label class="heading-medium flush--top text" for="{{ phone.getAttribute('id') }}">
-                Your phone number (optional)
+                Your phone number
             </label>
             {{ formElementErrorsV2(phone) }}
             {{ formElement(phone) }}

--- a/service-front/module/Application/view/application/general/feedback/index.twig
+++ b/service-front/module/Application/view/application/general/feedback/index.twig
@@ -84,7 +84,7 @@
 
         <div class="form-group {{ email.getMessages|length >0 ? 'form-group-error'}}">
             <label class="heading-medium flush--top text" for="{{ email.getAttribute('id') }}">
-                Your email address
+                Your email address (optional)
             </label>
             {{ formElementErrorsV2(email) }}
             {{ formElement(email) }}
@@ -92,7 +92,7 @@
 
         <div class="form-group {{ phone.getMessages|length >0 ? 'form-group-error'}}">
             <label class="heading-medium flush--top text" for="{{ phone.getAttribute('id') }}">
-                Your phone number
+                Your phone number (optional)
             </label>
             {{ formElementErrorsV2(phone) }}
             {{ formElement(phone) }}


### PR DESCRIPTION
## Purpose

Service feedback page is to be amended so users happy to take part in UR can be identified ([LPAL-697](https://opgtransform.atlassian.net/browse/LPAL-697)).

- 1st para : remove 2nd sentence starting ' If you’re happy…' 
- Below comments free text box:  add ‘If you’re happy to take part in research about this service, please leave your preferred contact details.’
- Remove ‘(optional)' from ‘Your email address’ and ‘Your phone number’. However, both ARE optional - the should be able to submit the form with either both, one or neither or these fields completed. 

(This task is to follow the release of survey link being removed from the homepage, which it now has been)


## Approach

Removes and adds content as specified


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
