### PR TITLE
LPAL-709 remove account level rds subscription

### DIFF
--- a/terraform/account/pagerduty.tf
+++ b/terraform/account/pagerduty.tf
@@ -46,11 +46,3 @@ resource "aws_sns_topic_subscription" "cloudwatch_account_ops_sns_subscription" 
   endpoint_auto_confirms = true
   endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration.integration_key}/enqueue"
 }
-
-
-resource "aws_sns_topic_subscription" "rds_events_sns_subscription" {
-  topic_arn              = aws_sns_topic.rds_events.arn
-  protocol               = "https"
-  endpoint_auto_confirms = true
-  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.db_alerts_integration.integration_key}/enqueue"
-}

--- a/terraform/account/sns.tf
+++ b/terraform/account/sns.tf
@@ -14,13 +14,3 @@ resource "aws_sns_topic" "cloudwatch_to_account_ops_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-account-ops-alert"
   tags = merge(local.default_tags, local.shared_component_tag)
 }
-
-resource "aws_sns_topic" "rds_events" {
-  name = "${local.account_name}-rds-events"
-  tags = merge(local.default_tags, local.db_component_tag)
-}
-
-resource "aws_db_event_subscription" "rds_events" {
-  name      = "${local.account_name}-rds-event-sub"
-  sns_topic = aws_sns_topic.rds_events.arn
-}


### PR DESCRIPTION
## Purpose

Remove redundant account level subscription for DB alerts. 

Fixes LPAL-709

## Approach

update account level terraform to remove entries no longer required.

## Learning

N/A
## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
