### PR TITLE
LPAL-739 add runbook for custom event transform db

### DIFF
--- a/docs/runbooks/pager_duty_custom_event_handler/development_custom_event.js
+++ b/docs/runbooks/pager_duty_custom_event_handler/development_custom_event.js
@@ -1,0 +1,24 @@
+//dev
+var rawBody = PD.inputRequest.rawBody;
+var obj = JSON.parse(JSON.parse(unescape(rawBody)).Message);
+
+var incident_key = obj[ 'Source ARN' ];
+var event_type = PD.Trigger;
+var event_message = obj['Event Message'];
+
+if (event_message.includes('The DB cluster') ||
+    event_message.includes('Scaling DB cluster')) {
+
+  PD.fail("Backup events do not need to be triggered");
+
+}
+else{
+
+  var normalized_event = {
+    incident_key: incident_key,
+    event_type: event_type,
+    description: obj['Source ID'] + ": " + obj['Event Message'],
+    details: obj
+  };
+  PD.emitGenericEvents([normalized_event]);
+}

--- a/docs/runbooks/pager_duty_custom_event_handler/preproduction_custom_event.js
+++ b/docs/runbooks/pager_duty_custom_event_handler/preproduction_custom_event.js
@@ -1,0 +1,15 @@
+//preprod
+var rawBody = PD.inputRequest.rawBody;
+var obj = JSON.parse(JSON.parse(unescape(rawBody)).Message);
+
+
+var incident_key = obj[ 'Source ARN' ];
+var event_type = PD.Trigger;
+
+var normalized_event = {
+  	 incident_key: incident_key,
+     event_type: event_type,
+     description: obj['Source ID'] + ": " + obj['Event Message'],
+     details: obj
+};
+PD.emitGenericEvents([normalized_event]);

--- a/docs/runbooks/pager_duty_custom_event_handler/production_custom_event.js
+++ b/docs/runbooks/pager_duty_custom_event_handler/production_custom_event.js
@@ -1,0 +1,27 @@
+//production
+
+var rawBody = PD.inputRequest.rawBody;
+var obj = JSON.parse(JSON.parse(unescape(rawBody)).Message);
+
+var incident_key = obj[ 'Source ARN' ];
+var event_type = PD.Trigger;
+var event_message = obj['Event Message'];
+
+if (event_message.includes('Backing up DB instance') ||
+    event_message.includes('Automated snapshot created') ||
+    event_message.includes('Creating automated snapshot') ||
+   	event_message.includes('Finished DB Instance backup')){
+
+  PD.fail("Backup events do not need to be triggered");
+
+}
+else{
+
+  var normalized_event = {
+    incident_key: incident_key,
+    event_type: event_type,
+    description: obj['Source ID'] + ": " + obj['Event Message'],
+    details: obj
+  };
+  PD.emitGenericEvents([normalized_event]);
+}

--- a/docs/runbooks/pager_duty_custom_event_handler/readme.md
+++ b/docs/runbooks/pager_duty_custom_event_handler/readme.md
@@ -6,18 +6,18 @@ This is to be used in advanced scenarios e.g. DR or during an incident, or to re
 
 ## Context
 
-On rare occasions, for example when running DR, Pager Duty will need to be manually setup to interpret events coming from the DB Events sns topic properly, as they are not usable in thier raw format. We cannot do this via terraform easily, so we will have to:
+On rare occasions, for example when running DR, Pager Duty will need to be manually setup to interpret events coming from the DB Events SNS topic properly, as they are unusable in thier raw format. We cannot do this via terraform easily, so we will have to do the following:
 
-- Step 1: Confirm event subscription manually on PagerDuty on initial creation
+- Step 1: Confirm event subscription manually on PagerDuty upon initial creation
 - Step 2: Update the custom event transform code manually into the relevant integration.
 
-generally, this is a one off process, only used when setting up a new region. Note: each account has differeing code to filter out noise, dev having the most noise, but production also having some filtering too e.g. for backups.
+Generally, this is a one off process, only used when setting up a new region. Note: each account has differing code to filter out noise, dev having the most noise. Production also has some filtering too, e.g. for backups.
 
-However, you may also want to follow step 2 if you want to alter some of the snippets to change the code for example imporve filtering, refactor it etc. after initial creation.
+However, follow step 2 any time we need to alter some of the snippets to change the code. for example to improve filtering, refactor it etc. after initial creation.
 
 ## Prerequisites
 
-- You will need to have access to PagerDuty for LPA team. if not please ask operations engineering in the relevant channel. if in doubt ask you WebOps engineer to assist.
+- Access to PagerDuty for LPA team. if you do not have this, please ask operations engineering in the relevant channel. If in doubt ask a WebOps engineer to assist.
 
 ## Step 1. Initial setup of DB alerts
 
@@ -25,8 +25,8 @@ upon first setup i.e. `terraform apply` at `terraform/region` level to an empty 
 
 1. Log in to Pager Duty
 2. Within pagerduty ,and as soon as possible (less than a minute) under  `open incidents` locate the last alert named `Custom Event Transform`.
-3. click click on its `title`.
-4. in the alert there will be a link to click in the `rawBody` portion of the incident. *note sensitive details are marked redacted*:
+3. Click on its `title`.
+4. In the alert there will be a link to click in the `rawBody` portion of the incident. *note sensitive details are marked redacted*:
 
     ```json
     {
@@ -44,16 +44,16 @@ upon first setup i.e. `terraform apply` at `terraform/region` level to an empty 
     ```
 
 5. Click on the link next to `SubscribeUrl`. This will open an xml page confirming subscription.
-   1. If this doesn't get done in time i.e. more than 1 minute, the `terraform apply` in that region will fail with a timeout, and you will have to rerun the build or reapply the terraform.
+   1. If this doesn't get done in time i.e. more than 1 minute, the `terraform apply` in that region will fail with a timeout, and  reapplying the terraform will be required.
 
 ## Step 2: Update the custom event transform code
 
 1. Locate the service in the service Directory:
-   1. Production - Production Make a Lasting Power of Attorney Database Alerts
-   2. Dev or Preproduction - Non-Production Make a Lasting Power of Attorney Database Alerts
-. click on the integrations tab
-2. locate the region alerts of interest e.g. for dev in london its `development eu-west-2 Region DB Alerts`
-3. click on the cog icon
-4. locate the edit integration button.
-5. in the `The code you want to execute` text area, replace the relevant js content, from the code snippet e.g. `development_custom_event.js` for dev. these snippets are also in the same folder as this ReadMe.
-6. click `Save changes`.
+   1. Production - Production Make a Lasting Power of Attorney Database Alerts.
+   2. Dev or Preproduction - Non-Production Make a Lasting Power of Attorney Database Alerts.
+2. Click on the integrations tab
+3. Locate the region alerts of interest e.g. for dev in london its `development eu-west-2 Region DB Alerts`
+4. Click on the cog icon
+5. Locate the edit integration button.
+6. In the `The code you want to execute` text area, replace the relevant js content, from the code snippet e.g. `development_custom_event.js` for dev. these snippets are also in the same folder as this ReadMe.
+7. Click `Save changes`.

--- a/docs/runbooks/pager_duty_custom_event_handler/readme.md
+++ b/docs/runbooks/pager_duty_custom_event_handler/readme.md
@@ -13,7 +13,7 @@ On rare occasions, for example when running DR, Pager Duty will need to be manua
 
 Generally, this is a one off process, only used when setting up a new region. Note: each account has differing code to filter out noise, dev having the most noise. Production also has some filtering too, e.g. for backups.
 
-However, follow step 2 any time we need to alter some of the snippets to change the code. for example to improve filtering, refactor it etc. after initial creation.
+However, follow step 2 any time we need to alter some of the snippets for example to improve filtering, refactor it etc. after initial creation.
 
 ## Prerequisites
 

--- a/docs/runbooks/pager_duty_custom_event_handler/readme.md
+++ b/docs/runbooks/pager_duty_custom_event_handler/readme.md
@@ -1,0 +1,59 @@
+# Setup custom event handlers
+
+## Audience
+
+This is to be used in advanced scenarios e.g. DR or during an incident, or to reduce noise. Guidance from webops engineers is recommended.
+
+## Context
+
+On rare occasions, for example when running DR, Pager Duty will need to be manually setup to interpret events coming from the DB Events sns topic properly, as they are not usable in thier raw format. We cannot do this via terraform easily, so we will have to:
+
+- Step 1: Confirm event subscription manually on PagerDuty on initial creation
+- Step 2: Update the custom event transform code manually into the relevant integration.
+
+generally, this is a one off process, only used when setting up a new region. Note: each account has differeing code to filter out noise, dev having the most noise, but production also having some filtering too e.g. for backups.
+
+However, you may also want to follow step 2 if you want to alter some of the snippets to change the code for example imporve filtering, refactor it etc. after initial creation.
+
+## Prerequisites
+
+- You will need to have access to PagerDuty for LPA team. if not please ask operations engineering in the relevant channel. if in doubt ask you WebOps engineer to assist.
+
+## Step 1. Initial setup of DB alerts
+
+upon first setup i.e. `terraform apply` at `terraform/region` level to an empty region e.g. London:
+
+1. Log in to Pager Duty
+2. Within pagerduty ,and as soon as possible (less than a minute) under  `open incidents` locate the last alert named `Custom Event Transform`.
+3. click click on its `title`.
+4. in the alert there will be a link to click in the `rawBody` portion of the incident. *note sensitive details are marked redacted*:
+
+    ```json
+    {
+    "Type" : "SubscriptionConfirmation",
+    "MessageId" : "redacted",
+    "Token" : "redacted",
+    "TopicArn" : "arn:aws:sns:eu-west-2:redacted:preproduction-eu-west-2-rds-events",
+    "Message" : "You have chosen to subscribe to the topic arn:aws:sns:eu-west-2:redacted:preproduction-eu-west-2-rds-events.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
+    "SubscribeURL" : "https://sns.eu-west-2.amazonaws.com/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:eu-west-2:redacted:preproduction-eu-west-2-rds-events&Token=redacted",
+    "Timestamp" : "2022-04-26T10:36:59.239Z",
+    "SignatureVersion" : "1",
+    "Signature" : "redacted",
+    "SigningCertURL" : "https://sns.eu-west-2.amazonaws.com/SimpleNotificationService-redacted.pem"
+    }
+    ```
+
+5. Click on the link next to `SubscribeUrl`. This will open an xml page confirming subscription.
+   1. If this doesn't get done in time i.e. more than 1 minute, the `terraform apply` in that region will fail with a timeout, and you will have to rerun the build or reapply the terraform.
+
+## Step 2: Update the custom event transform code
+
+1. Locate the service in the service Directory:
+   1. Production - Production Make a Lasting Power of Attorney Database Alerts
+   2. Dev or Preproduction - Non-Production Make a Lasting Power of Attorney Database Alerts
+. click on the integrations tab
+2. locate the region alerts of interest e.g. for dev in london its `development eu-west-2 Region DB Alerts`
+3. click on the cog icon
+4. locate the edit integration button.
+5. in the `The code you want to execute` text area, replace the relevant js content, from the code snippet e.g. `development_custom_event.js` for dev. these snippets are also in the same folder as this ReadMe.
+6. click `Save changes`.


### PR DESCRIPTION
## Purpose

Add a runbook and code snippets examples for stting up PagerDuty DB alerts
Fixes LPAL-739

## Approach

- Add Readme
- Add 3 code snippets

## Learning

This is to capture this manual process, as it will be needed for future DR tests.

## Checklist

* [X] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
