### PR TITLE
LPAL-447 Service api psalm lint and upgrade to PHP 8.1

### DIFF
--- a/.github/workflows/psalm-scan.yml
+++ b/.github/workflows/psalm-scan.yml
@@ -18,8 +18,6 @@ jobs:
       fail-fast: true
       matrix:
         scan:
-          - name: service-api
-            path: "./service-api"
           - name: service-admin
             path: "./service-admin"
           - name: service-front
@@ -43,6 +41,44 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.0"
+          tools: vimeo/psalm
+      - name: Composer install
+        if: steps.filter.outputs.check == 'true'
+        run: composer install --prefer-dist --optimize-autoloader --no-suggest --no-interaction --no-scripts
+      - name: Run psalm
+        if: steps.filter.outputs.check == 'true'
+        run: psalm --output-format=github --taint-analysis --report=psalm-results.sarif
+      - name: Upload Security Analysis results to GitHub
+        if: steps.filter.outputs.check == 'true'
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: ${{ matrix.scan.path }}/psalm-results.sarif
+  psalm_api:
+    name: psalm-scan
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        scan:
+          - name: service-api
+            path: "./service-api"
+    defaults:
+      run:
+        working-directory: ${{ matrix.scan.path }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: path filters
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            check: '${{ matrix.scan.path }}/**'
+      - name: Setup PHP with tools
+        if: steps.filter.outputs.check == 'true'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.1"
           tools: vimeo/psalm
       - name: Composer install
         if: steps.filter.outputs.check == 'true'

--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.3.5 AS composer
+FROM composer:2.3 AS composer
 
 RUN adduser -D -g '' appuser
 
@@ -7,7 +7,7 @@ COPY --chown=appuser:appuser service-admin/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:8.0-fpm-alpine
+FROM php:8.0-fpm-alpine3.15
 
 RUN adduser -D -g '' appuser
 

--- a/service-api/composer.json
+++ b/service-api/composer.json
@@ -33,7 +33,7 @@
         "robmorgan/phinx": "^0.12.9",
         "laminas/laminas-db": "^2.13.4",
         "league/csv": "^9.7.3",
-        "laminas/laminas-cli": "^1.2",
+        "laminas/laminas-cli": "^1.4",
         "nategood/commando": "^0.4.0"
     },
     "replace": {
@@ -51,7 +51,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",
-        "mockery/mockery": "^1.4.4"
+        "mockery/mockery": "^1.4.4",
+        "vimeo/psalm": "^4.22"
     },
     "autoload": {
         "psr-4": {

--- a/service-api/composer.json
+++ b/service-api/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.1",
         "aws/aws-sdk-php": "^3.204.5",
-        "ministryofjustice/opg-lpa-datamodels": "^13.8",
+        "ministryofjustice/opg-lpa-datamodels": "^14.0",
         "laminas/laminas-authentication": "^2.8",
         "laminas/laminas-cache": "^3.1.2",
         "laminas/laminas-cache-storage-adapter-memory": "2.0",

--- a/service-api/composer.json
+++ b/service-api/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "aws/aws-sdk-php": "^3.204.5",
         "ministryofjustice/opg-lpa-datamodels": "^13.8",
         "laminas/laminas-authentication": "^2.8",

--- a/service-api/composer.lock
+++ b/service-api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "538dfea3418701e83b0383d80f39a0b5",
+    "content-hash": "237f69a6559a04a3f200f6b1372e813f",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -115,16 +115,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.221.0",
+            "version": "3.222.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "6ef06165ef815358d3e60872b4c9f6c10deb3816"
+                "reference": "632621d97180e82d3adc1245a7b272774c30dbf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6ef06165ef815358d3e60872b4c9f6c10deb3816",
-                "reference": "6ef06165ef815358d3e60872b4c9f6c10deb3816",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/632621d97180e82d3adc1245a7b272774c30dbf5",
+                "reference": "632621d97180e82d3adc1245a7b272774c30dbf5",
                 "shasum": ""
             },
             "require": {
@@ -200,9 +200,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.221.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.222.1"
             },
-            "time": "2022-04-26T18:19:33+00:00"
+            "time": "2022-04-28T18:17:24+00:00"
         },
         {
             "name": "brick/varexporter",
@@ -2507,16 +2507,16 @@
         },
         {
             "name": "laminas/laminas-log",
-            "version": "2.15.0",
+            "version": "2.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-log.git",
-                "reference": "91964dd3afec183c09cca5bc2b21a930a56d5237"
+                "reference": "c46d9eb2ad226f9ed27ea3f5de4bbafa9b98368f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-log/zipball/91964dd3afec183c09cca5bc2b21a930a56d5237",
-                "reference": "91964dd3afec183c09cca5bc2b21a930a56d5237",
+                "url": "https://api.github.com/repos/laminas/laminas-log/zipball/c46d9eb2ad226f9ed27ea3f5de4bbafa9b98368f",
+                "reference": "c46d9eb2ad226f9ed27ea3f5de4bbafa9b98368f",
                 "shasum": ""
             },
             "require": {
@@ -2591,7 +2591,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-12-04T19:23:31+00:00"
+            "time": "2022-04-29T05:55:10+00:00"
         },
         {
             "name": "laminas/laminas-math",
@@ -3676,25 +3676,25 @@
         },
         {
             "name": "ministryofjustice/opg-lpa-datamodels",
-            "version": "13.8.0",
+            "version": "14.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ministryofjustice/opg-lpa-datamodels",
-                "reference": "e20e0f799c88455e2af0e88f6193f1ce85e78bc1"
+                "reference": "070543818972f1309191331038ad50432e35866a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ministryofjustice/opg-lpa-datamodels/zipball/e20e0f799c88455e2af0e88f6193f1ce85e78bc1",
-                "reference": "e20e0f799c88455e2af0e88f6193f1ce85e78bc1",
+                "url": "https://api.github.com/repos/ministryofjustice/opg-lpa-datamodels/zipball/070543818972f1309191331038ad50432e35866a",
+                "reference": "070543818972f1309191331038ad50432e35866a",
                 "shasum": ""
             },
             "require": {
                 "egulias/email-validator": "~1.2",
-                "php": "^7.1 | ^8.0",
+                "php": "^8.0 | ^8.1",
                 "symfony/validator": "^4.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "autoload": {
@@ -3706,7 +3706,7 @@
                 "MIT"
             ],
             "description": "PHP data models that represent a Lasting Power of Attorney",
-            "time": "2021-04-13T12:33:09+00:00"
+            "time": "2022-04-29T14:25:28+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -4546,16 +4546,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v6.0.7",
+            "version": "v6.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "22850bfdd2b6090568ad05dece6843c859d933b7"
+                "reference": "6ac50d559aa64c8e7b5b17640c46241e4accb487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/22850bfdd2b6090568ad05dece6843c859d933b7",
-                "reference": "22850bfdd2b6090568ad05dece6843c859d933b7",
+                "url": "https://api.github.com/repos/symfony/config/zipball/6ac50d559aa64c8e7b5b17640c46241e4accb487",
+                "reference": "6ac50d559aa64c8e7b5b17640c46241e4accb487",
                 "shasum": ""
             },
             "require": {
@@ -4604,7 +4604,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v6.0.7"
+                "source": "https://github.com/symfony/config/tree/v6.0.8"
             },
             "funding": [
                 {
@@ -4620,20 +4620,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-22T16:12:04+00:00"
+            "time": "2022-04-12T16:11:42+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.7",
+            "version": "v6.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "70dcf7b2ca2ea08ad6ebcc475f104a024fb5632e"
+                "reference": "0d00aa289215353aa8746a31d101f8e60826285c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/70dcf7b2ca2ea08ad6ebcc475f104a024fb5632e",
-                "reference": "70dcf7b2ca2ea08ad6ebcc475f104a024fb5632e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0d00aa289215353aa8746a31d101f8e60826285c",
+                "reference": "0d00aa289215353aa8746a31d101f8e60826285c",
                 "shasum": ""
             },
             "require": {
@@ -4699,7 +4699,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.7"
+                "source": "https://github.com/symfony/console/tree/v6.0.8"
             },
             "funding": [
                 {
@@ -4715,7 +4715,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-31T17:18:25+00:00"
+            "time": "2022-04-20T15:01:42+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5749,16 +5749,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.3",
+            "version": "v6.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "522144f0c4c004c80d56fa47e40e17028e2eefc2"
+                "reference": "ac0aa5c2282e0de624c175b68d13f2c8f2e2649d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/522144f0c4c004c80d56fa47e40e17028e2eefc2",
-                "reference": "522144f0c4c004c80d56fa47e40e17028e2eefc2",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ac0aa5c2282e0de624c175b68d13f2c8f2e2649d",
+                "reference": "ac0aa5c2282e0de624c175b68d13f2c8f2e2649d",
                 "shasum": ""
             },
             "require": {
@@ -5814,7 +5814,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.3"
+                "source": "https://github.com/symfony/string/tree/v6.0.8"
             },
             "funding": [
                 {
@@ -5830,7 +5830,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2022-04-22T08:18:02+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -5912,16 +5912,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v4.4.40",
+            "version": "v4.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "86464b6f16c888514b32ffd64fb9a2ad64dc3965"
+                "reference": "b79a7830b8ead3fb0a2a0080ba6f5b2a0861c28c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/86464b6f16c888514b32ffd64fb9a2ad64dc3965",
-                "reference": "86464b6f16c888514b32ffd64fb9a2ad64dc3965",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/b79a7830b8ead3fb0a2a0080ba6f5b2a0861c28c",
+                "reference": "b79a7830b8ead3fb0a2a0080ba6f5b2a0861c28c",
                 "shasum": ""
             },
             "require": {
@@ -5998,7 +5998,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v4.4.40"
+                "source": "https://github.com/symfony/validator/tree/v4.4.41"
             },
             "funding": [
                 {
@@ -6014,7 +6014,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-28T08:53:28+00:00"
+            "time": "2022-04-14T15:50:15+00:00"
         },
         {
             "name": "webimpress/safe-writer",

--- a/service-api/composer.lock
+++ b/service-api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f41441633775c288100cfe816b114067",
+    "content-hash": "538dfea3418701e83b0383d80f39a0b5",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -115,16 +115,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.220.3",
+            "version": "3.221.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "fbb2d7349916c15758ee02dfd001a714883a9adf"
+                "reference": "6ef06165ef815358d3e60872b4c9f6c10deb3816"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/fbb2d7349916c15758ee02dfd001a714883a9adf",
-                "reference": "fbb2d7349916c15758ee02dfd001a714883a9adf",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6ef06165ef815358d3e60872b4c9f6c10deb3816",
+                "reference": "6ef06165ef815358d3e60872b4c9f6c10deb3816",
                 "shasum": ""
             },
             "require": {
@@ -200,9 +200,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.220.3"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.221.0"
             },
-            "time": "2022-04-22T18:18:31+00:00"
+            "time": "2022-04-26T18:19:33+00:00"
         },
         {
             "name": "brick/varexporter",
@@ -6190,6 +6190,500 @@
     ],
     "packages-dev": [
         {
+            "name": "amphp/amp",
+            "version": "v2.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "9d5100cebffa729aaffecd3ad25dc5aeea4f13bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/9d5100cebffa729aaffecd3ad25dc5aeea4f13bb",
+                "reference": "9d5100cebffa729aaffecd3ad25dc5aeea4f13bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^7 | ^8 | ^9",
+                "psalm/phar": "^3.11@dev",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "https://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v2.6.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-20T17:52:18+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.4",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6 || ^7 || ^8",
+                "psalm/phar": "^3.11.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v1.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-30T17:13:30+00:00"
+        },
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
+                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-17T14:14:24+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-25T20:21:48+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.4",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-01T19:23:25+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ced299686f41dce890debac69273b47ffe98a40c",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-25T21:32:43+00:00"
+        },
+        {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.1",
             "source": {
@@ -6258,6 +6752,107 @@
                 }
             ],
             "time": "2022-03-03T08:28:38+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "php": "^7.1 || ^8.0",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
+            },
+            "time": "2021-06-11T22:34:44+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "v1.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/6e82196ffd7c62f7794d778ca52b69feec9f2842",
+                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.2"
+            },
+            "time": "2022-03-02T22:36:06+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -6440,6 +7035,110 @@
                 }
             ],
             "time": "2022-03-03T13:19:32+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
+                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.5 || ~8.0 || ~9.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.0.0"
+            },
+            "time": "2020-12-01T19:48:11+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "support": {
+                "issues": "https://github.com/nullivex/lib-array2xml/issues",
+                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
+            },
+            "time": "2019-03-29T20:06:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -8213,6 +8912,163 @@
                 }
             ],
             "time": "2021-07-28T10:34:58+00:00"
+        },
+        {
+            "name": "vimeo/psalm",
+            "version": "4.22.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "fc2c6ab4d5fa5d644d8617089f012f3bb84b8703"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/fc2c6ab4d5fa5d644d8617089f012f3bb84b8703",
+                "reference": "fc2c6ab4d5fa5d644d8617089f012f3bb84b8703",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.4.2",
+                "amphp/byte-stream": "^1.5",
+                "composer/package-versions-deprecated": "^1.8.0",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^1.1 || ^2.0 || ^3.0",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.5",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "nikic/php-parser": "^4.13",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.1|^8",
+                "sebastian/diff": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
+                "brianium/paratest": "^4.0||^6.0",
+                "ext-curl": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpdocumentor/reflection-docblock": "^5",
+                "phpmyadmin/sql-parser": "5.1.0||dev-master",
+                "phpspec/prophecy": ">=1.9.0",
+                "phpunit/phpunit": "^9.0",
+                "psalm/plugin-phpunit": "^0.16",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.3 || ^5.0 || ^6.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "suggest": {
+                "ext-curl": "In order to send data to shepherd",
+                "ext-igbinary": "^2.0.5 is required, used to serialize caching data"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalter"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/spl_object_id.php"
+                ],
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm/tree/4.22.0"
+            },
+            "time": "2022-02-24T20:34:05+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
+            "abandoned": "symfony/filesystem",
+            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "aliases": [],
@@ -8221,7 +9077,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -7,7 +7,7 @@ COPY --chown=appuser:appuser service-api/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:8.0-fpm-alpine3.15
+FROM php:8.1-fpm-alpine3.15
 
 RUN adduser -D -g '' appuser
 

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.3.5 AS composer
+FROM composer:2.3 AS composer
 
 RUN adduser -D -g '' appuser
 
@@ -7,7 +7,7 @@ COPY --chown=appuser:appuser service-api/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:8.0-fpm-alpine3.14
+FROM php:8.0-fpm-alpine3.15
 
 RUN adduser -D -g '' appuser
 

--- a/service-api/module/Application/src/Command/AccountCleanupCommand.php
+++ b/service-api/module/Application/src/Command/AccountCleanupCommand.php
@@ -8,7 +8,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-
 /**
  * This command is triggered daily from a cron job.
  *
@@ -46,8 +45,8 @@ class AccountCleanupCommand extends Command
     /**
      * Required method implementation
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->accountCleanupService->cleanup();
+        return $this->accountCleanupService->cleanup();
     }
 }

--- a/service-api/module/Application/src/Command/GenerateStatsCommand.php
+++ b/service-api/module/Application/src/Command/GenerateStatsCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Application\Command;
 
 use Application\Model\Service\System\Stats as StatsService;
@@ -6,7 +7,6 @@ use Laminas\ServiceManager\ServiceManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-
 
 /**
  * laminas-cli command to generate stats.
@@ -44,8 +44,12 @@ class GenerateStatsCommand extends Command
     /**
      * Required method implementation
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->statsService->generate();
+        $success = $this->statsService->generate();
+        if ($success) {
+            return 0;
+        }
+        return 1;
     }
 }

--- a/service-api/module/Application/src/Controller/PingController.php
+++ b/service-api/module/Application/src/Controller/PingController.php
@@ -61,8 +61,7 @@ class PingController extends AbstractRestfulController
         string $queueUrl,
         string $trackMyLpaEndpoint,
         HttpClient $httpClient
-    )
-    {
+    ) {
         $this->database = $database;
         $this->sqsClient = $sqsClient;
         $this->sqsQueueUrl = $queueUrl;
@@ -79,17 +78,7 @@ class PingController extends AbstractRestfulController
     public function elbAction()
     {
         $response = $this->getResponse();
-
-        // Include a sanity check on ssl certs
-        $path = '/etc/ssl/certs/b204d74a.0';
-
-        if (!is_link($path) | !is_readable($path) || !is_link($path) || empty(file_get_contents($path))) {
-            $response->setStatusCode(500);
-            $response->setContent('Sad face');
-        } else {
-            $response->setContent('Happy face');
-        }
-
+        $response->setContent('Happy face');
         return $response;
     }
 
@@ -117,13 +106,13 @@ class PingController extends AbstractRestfulController
         // PDF Queue / SQS
 
         try {
-
             $result = $this->sqsClient->getQueueAttributes([
                 'QueueUrl' => $this->sqsQueueUrl,
                 'AttributeNames' => ['ApproximateNumberOfMessages', 'ApproximateNumberOfMessagesNotVisible'],
             ]);
 
-            if (!isset($result['Attributes']['ApproximateNumberOfMessages'])
+            if (
+                !isset($result['Attributes']['ApproximateNumberOfMessages'])
                 || !isset($result['Attributes']['ApproximateNumberOfMessagesNotVisible'])
             ) {
                 throw new Exception('Invalid count returned');
@@ -141,24 +130,23 @@ class PingController extends AbstractRestfulController
             ];
 
             $queueOk = ($count < 50);
-        } catch (Exception $ignore) {}
+        } catch (Exception $ignore) {
+        }
 
         //---------------------------------------------
         // Main database
 
         try {
-
             $this->database->getDriver()->getConnection()->connect();
 
             $zendDbOk = true;
-
-        } catch (Exception $ignore) {}
+        } catch (Exception $ignore) {
+        }
 
         //---------------------------------------------
         // OPG Gateway
 
         try {
-
             $url = new Uri($this->trackMyLpaEndpoint . 'A00000000000');
 
             $request = new Request('GET', $url, $headers = [
@@ -179,8 +167,8 @@ class PingController extends AbstractRestfulController
             if ($response->getStatusCode() === 404) {
                 $opgGateway = true;
             }
-
-        } catch (Exception $ignore) {}
+        } catch (Exception $ignore) {
+        }
 
         //---------------------------------------------
 

--- a/service-api/module/Application/src/Controller/Version2/Auth/AbstractAuthController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/AbstractAuthController.php
@@ -102,14 +102,14 @@ abstract class AbstractAuthController extends AbstractRestfulController
      * Get data from the body content of the request
      *
      * @param $varName
-     * @return array|null|string
+     * @return mixed|null
      */
     protected function getBodyContent($varName = null)
     {
         $data = $this->processBodyContent($this->getRequest());
 
         if (is_string($varName)) {
-            //  Try to get the specific variable from the data
+            // Try to get the specific variable from the data
             return (array_key_exists($varName, $data) ? $data[$varName] : null);
         }
 

--- a/service-api/module/Application/src/Controller/Version2/Auth/AbstractAuthController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/AbstractAuthController.php
@@ -53,13 +53,13 @@ abstract class AbstractAuthController extends AbstractRestfulController
     /**
      * Execute the request
      *
-     * @param MvcEvent $event
+     * @param MvcEvent $e
      * @return mixed|ApiProblem|ApiProblemResponse
      * @throws ApiProblemException
      */
-    public function onDispatch(MvcEvent $event)
+    public function onDispatch(MvcEvent $e)
     {
-        $return = parent::onDispatch($event);
+        $return = parent::onDispatch($e);
 
         if ($return instanceof ApiProblem) {
             return new ApiProblemResponse($return);

--- a/service-api/module/Application/src/Controller/Version2/Auth/AuthenticateController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/AuthenticateController.php
@@ -111,6 +111,11 @@ class AuthenticateController extends AbstractAuthController
      */
     public function sessionExpiryAction()
     {
+        // Suppress psalm errors caused by bug in laminas-mvc;
+        // see https://github.com/laminas/laminas-mvc/issues/77
+        /**
+         * @psalm-suppress UndefinedInterfaceMethod
+         */
         $token = $this->getRequest()->getHeader('CheckedToken');
 
         if ($token == null) {
@@ -138,6 +143,11 @@ class AuthenticateController extends AbstractAuthController
      */
     public function setSessionExpiryAction()
     {
+        // Suppress psalm errors caused by bug in laminas-mvc;
+        // see https://github.com/laminas/laminas-mvc/issues/77
+        /**
+         * @psalm-suppress UndefinedInterfaceMethod
+         */
         $token = $this->getRequest()->getHeader('CheckedToken');
 
         if ($token == null) {

--- a/service-api/module/Application/src/Controller/Version2/Auth/AuthenticateController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/AuthenticateController.php
@@ -2,21 +2,20 @@
 
 namespace Application\Controller\Version2\Auth;
 
-use \DateTime;
+use DateTime;
+use Application\Model\Service\AbstractService;
 use Laminas\View\Model\JsonModel;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
+use RuntimeException;
 
 class AuthenticateController extends AbstractAuthController
 {
     /**
-     * TODO - Refactor later...
-     * NOTE - Present to satisfy requirement in AbstractAuthController
-     *
-     * @return null
+     * @return AbstractService
      */
     protected function getService()
     {
-        return null;
+        throw new RuntimeException('getService method not implemented for AuthenticateController');
     }
 
     /**
@@ -114,7 +113,7 @@ class AuthenticateController extends AbstractAuthController
     {
         $token = $this->getRequest()->getHeader('CheckedToken');
 
-        if($token == null) {
+        if ($token == null) {
             return new ApiProblem(400, 'No CheckedToken was specified in the header');
         }
 

--- a/service-api/module/Application/src/Controller/Version2/Auth/EmailController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/EmailController.php
@@ -60,7 +60,7 @@ class EmailController extends AbstractAuthController
 
         // Map DateTimes to strings
         $result = array_map(function ($v) {
-            return ( $v instanceof \DateTime ) ? $v->format('Y-m-d\TH:i:sO') : $v;
+            return ($v instanceof \DateTime) ? $v->format('Y-m-d\TH:i:sO') : $v;
         }, $result);
 
         $this->getLogger()->info("User successfully requested update email token", [
@@ -103,6 +103,11 @@ class EmailController extends AbstractAuthController
         ]);
 
         // Return 204 - No Content
+        // Suppress psalm errors caused by bug in laminas-mvc;
+        // see https://github.com/laminas/laminas-mvc/issues/77
+        /**
+         * @psalm-suppress UndefinedInterfaceMethod
+         */
         $this->response->setStatusCode(204);
 
         return new JsonModel();

--- a/service-api/module/Application/src/Controller/Version2/Auth/PasswordController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/PasswordController.php
@@ -115,6 +115,11 @@ class PasswordController extends AbstractAuthController
         ]);
 
         //  Return 204 - No Content
+        // Suppress psalm errors caused by bug in laminas-mvc;
+        // see https://github.com/laminas/laminas-mvc/issues/77
+        /**
+         * @psalm-suppress UndefinedInterfaceMethod
+         */
         $this->response->setStatusCode(204);
 
         return new JsonModel();
@@ -143,7 +148,7 @@ class PasswordController extends AbstractAuthController
 
         // Map DateTimes to strings
         $result = array_map(function ($v) {
-            return ( $v instanceof \DateTime ) ? $v->format('Y-m-d\TH:i:sO') : $v;
+            return ($v instanceof \DateTime) ? $v->format('Y-m-d\TH:i:sO') : $v;
         }, $result);
 
         //  Determine the token value for the logging message

--- a/service-api/module/Application/src/Controller/Version2/Auth/UsersController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/UsersController.php
@@ -68,6 +68,16 @@ class UsersController extends AbstractAuthController
         ]);
 
         // Return 204 - No Content
+        // Note: The Laminas AbstractRestfulController response member
+        // variable is an instance of Laminas\Stdlib\ResponseInterface, which doesn't
+        // have a setStatusCode() method. However, in the getResponse() method of
+        // AbstractRestfulController, we see this member variable being populated
+        // with a Laminas\Http\Response instance, which does.
+        // psalm doesn't like this, which is why we mark this as "ignored", until
+        // Laminas fixes the bug - see https://github.com/laminas/laminas-mvc/issues/77
+        /**
+         * @psalm-suppress UndefinedInterfaceMethod
+         */
         $this->response->setStatusCode(204);
 
         return new JsonModel();

--- a/service-api/module/Application/src/Controller/Version2/Lpa/AbstractLpaController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/AbstractLpaController.php
@@ -64,14 +64,14 @@ abstract class AbstractLpaController extends AbstractRestfulController
     /**
      * Execute the request
      *
-     * @param MvcEvent $event
+     * @param MvcEvent $e
      * @return mixed|ApiProblem|ApiProblemResponse
      * @throws ApiProblemException
      */
-    public function onDispatch(MvcEvent $event)
+    public function onDispatch(MvcEvent $e)
     {
         //  If possible get the user and LPA from the ID values in the route
-        $this->routeUserId = $event->getRouteMatch()->getParam('userId');
+        $this->routeUserId = $e->getRouteMatch()->getParam('userId');
 
         if (empty($this->routeUserId)) {
             //  userId MUST be present in the URL
@@ -79,13 +79,13 @@ abstract class AbstractLpaController extends AbstractRestfulController
         }
 
         //  The lpaId MAY be present in the URL
-        $this->lpaId = $event->getRouteMatch()->getParam('lpaId');
+        $this->lpaId = $e->getRouteMatch()->getParam('lpaId');
 
         try {
-            $return = parent::onDispatch($event);
-        } catch (UnauthorizedException $e) {
+            $return = parent::onDispatch($e);
+        } catch (UnauthorizedException $ex) {
             $return = new ApiProblem(401, 'Access Denied');
-        } catch (LockedException $e) {
+        } catch (LockedException $ex) {
             $return = new ApiProblem(403, 'LPA has been locked');
         }
 
@@ -105,7 +105,10 @@ abstract class AbstractLpaController extends AbstractRestfulController
             throw new LaminasUnauthorizedException('You need to be authenticated to access this service');
         }
 
-        if (!$this->authorizationService->isGranted('isAuthorizedToManageUser', $this->routeUserId) && !$this->authorizationService->isGranted('admin')) {
+        if (
+            !$this->authorizationService->isGranted('isAuthorizedToManageUser', $this->routeUserId) &&
+            !$this->authorizationService->isGranted('admin')
+        ) {
             throw new LaminasUnauthorizedException('You do not have permission to access this service');
         }
     }

--- a/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
@@ -49,7 +49,7 @@ class ApplicationController extends AbstractLpaController
     }
 
     /**
-     * @return JsonResponse|NoContentResponse|Paginator
+     * @return JsonResponse|NoContentResponse|Paginator|ApiProblem
      */
     public function getList()
     {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
@@ -64,6 +64,8 @@ class ApplicationController extends AbstractLpaController
         //  If the page param is invalid then just get the first page
         if (!is_numeric($page) || $page < 1) {
             $page = 1;
+        } else {
+            $page = intval($page);
         }
 
         //  Create the filtered query by excluding the page query data - this should just leave the search parameter
@@ -80,14 +82,14 @@ class ApplicationController extends AbstractLpaController
             return new NoContentResponse();
         }
 
-        //  The applications collection was a success - it will be a paginator
-        /** @var Collection $result */
+        // The applications collection was a success - it will be a paginator
+        /* @var Collection $result */
 
         //  Set the page number and per page count (if valid)
         $result->setCurrentPageNumber($page);
 
         if (is_numeric($perPage) && $perPage > 0) {
-            $result->setItemCountPerPage($perPage);
+            $result->setItemCountPerPage(intval($perPage));
         }
 
         return new JsonResponse($result->toArray());

--- a/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
@@ -116,6 +116,14 @@ class ApplicationController extends AbstractLpaController
     }
 
     /**
+     * For whatever reason, laminas-mvc's (v3.3) return type for patch()
+     * is array rather than mixed (like all the other REST methods).
+     * Because we treat responses uniformly and return a response type
+     * from patch(), psalm complains about this, so that's what we're
+     * suppressing here.
+     *
+     * @psalm-suppress ImplementedReturnTypeMismatch
+     *
      * @param $id
      * @param $data
      * @return JsonResponse|ApiProblem

--- a/service-api/module/Application/src/Controller/Version2/Lpa/PdfController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/PdfController.php
@@ -27,7 +27,7 @@ class PdfController extends AbstractLpaController
 
     /**
      * @param mixed $id
-     * @return JsonResponse|NoContentResponse|ApiProblem
+     * @return JsonResponse|NoContentResponse|ApiProblem|FileResponse
      */
     public function get($id)
     {

--- a/service-api/module/Application/src/ControllerFactory/AuthControllerAbstractFactory.php
+++ b/service-api/module/Application/src/ControllerFactory/AuthControllerAbstractFactory.php
@@ -29,14 +29,17 @@ class AuthControllerAbstractFactory implements AbstractFactoryInterface
      */
     public function canCreate(ContainerInterface $container, $requestedName)
     {
-        return (class_exists($requestedName) && is_subclass_of($requestedName, AuthControllers\AbstractAuthController::class));
+        return (
+            class_exists($requestedName) &&
+            is_subclass_of($requestedName, AuthControllers\AbstractAuthController::class)
+        );
     }
 
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
      * @param array|null $options
-     * @return mixed
+     * @return object
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {

--- a/service-api/module/Application/src/ControllerFactory/LpaControllerAbstractFactory.php
+++ b/service-api/module/Application/src/ControllerFactory/LpaControllerAbstractFactory.php
@@ -14,26 +14,28 @@ class LpaControllerAbstractFactory implements AbstractFactoryInterface
      * @var array
      */
     private $serviceMappings = [
-        LpaControllers\ApplicationController::class                   => Service\Applications\Service::class,
-        LpaControllers\CertificateProviderController::class           => Service\CertificateProvider\Service::class,
-        LpaControllers\CorrespondentController::class                 => Service\Correspondent\Service::class,
-        LpaControllers\DonorController::class                         => Service\Donor\Service::class,
-        LpaControllers\InstructionController::class                   => Service\Instruction\Service::class,
-        LpaControllers\LockController::class                          => Service\Lock\Service::class,
-        LpaControllers\NotifiedPeopleController::class                => Service\NotifiedPeople\Service::class,
-        LpaControllers\PaymentController::class                       => Service\Payment\Service::class,
-        LpaControllers\PdfController::class                           => Service\Pdfs\Service::class,
-        LpaControllers\PreferenceController::class                    => Service\Preference\Service::class,
-        LpaControllers\PrimaryAttorneyController::class               => Service\AttorneysPrimary\Service::class,
-        LpaControllers\PrimaryAttorneyDecisionsController::class      => Service\AttorneyDecisionsPrimary\Service::class,
-        LpaControllers\RepeatCaseNumberController::class              => Service\RepeatCaseNumber\Service::class,
-        LpaControllers\ReplacementAttorneyController::class           => Service\AttorneysReplacement\Service::class,
-        LpaControllers\ReplacementAttorneyDecisionsController::class  => Service\AttorneyDecisionsReplacement\Service::class,
-        LpaControllers\SeedController::class                          => Service\Seed\Service::class,
-        LpaControllers\TypeController::class                          => Service\Type\Service::class,
-        LpaControllers\UserController::class                          => Service\Users\Service::class,
-        LpaControllers\WhoAreYouController::class                     => Service\WhoAreYou\Service::class,
-        LpaControllers\WhoIsRegisteringController::class              => Service\WhoIsRegistering\Service::class,
+        LpaControllers\ApplicationController::class => Service\Applications\Service::class,
+        LpaControllers\CertificateProviderController::class => Service\CertificateProvider\Service::class,
+        LpaControllers\CorrespondentController::class => Service\Correspondent\Service::class,
+        LpaControllers\DonorController::class => Service\Donor\Service::class,
+        LpaControllers\InstructionController::class => Service\Instruction\Service::class,
+        LpaControllers\LockController::class => Service\Lock\Service::class,
+        LpaControllers\NotifiedPeopleController::class => Service\NotifiedPeople\Service::class,
+        LpaControllers\PaymentController::class => Service\Payment\Service::class,
+        LpaControllers\PdfController::class => Service\Pdfs\Service::class,
+        LpaControllers\PreferenceController::class => Service\Preference\Service::class,
+        LpaControllers\PrimaryAttorneyController::class => Service\AttorneysPrimary\Service::class,
+        LpaControllers\PrimaryAttorneyDecisionsController::class
+            => Service\AttorneyDecisionsPrimary\Service::class,
+        LpaControllers\RepeatCaseNumberController::class => Service\RepeatCaseNumber\Service::class,
+        LpaControllers\ReplacementAttorneyController::class => Service\AttorneysReplacement\Service::class,
+        LpaControllers\ReplacementAttorneyDecisionsController::class
+            => Service\AttorneyDecisionsReplacement\Service::class,
+        LpaControllers\SeedController::class => Service\Seed\Service::class,
+        LpaControllers\TypeController::class => Service\Type\Service::class,
+        LpaControllers\UserController::class => Service\Users\Service::class,
+        LpaControllers\WhoAreYouController::class => Service\WhoAreYou\Service::class,
+        LpaControllers\WhoIsRegisteringController::class => Service\WhoIsRegistering\Service::class,
     ];
 
     /**
@@ -45,14 +47,17 @@ class LpaControllerAbstractFactory implements AbstractFactoryInterface
      */
     public function canCreate(ContainerInterface $container, $requestedName)
     {
-        return (class_exists($requestedName) && is_subclass_of($requestedName, LpaControllers\AbstractLpaController::class));
+        return (
+            class_exists($requestedName) &&
+            is_subclass_of($requestedName, LpaControllers\AbstractLpaController::class)
+        );
     }
 
     /**
      * @param ContainerInterface $container
      * @param string $requestedName
      * @param array|null $options
-     * @return mixed
+     * @return object
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {

--- a/service-api/module/Application/src/Library/ApiProblem/ValidationApiProblem.php
+++ b/service-api/module/Application/src/Library/ApiProblem/ValidationApiProblem.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Application\Library\ApiProblem;
 
 use Opg\Lpa\DataModel\Validator\ValidatorResponseInterface;
@@ -9,11 +10,10 @@ use Opg\Lpa\DataModel\Validator\ValidatorResponseInterface;
  * Class ValidationApiProblem
  * @package Application\Library\ApiProblem
  */
-class ValidationApiProblem extends ApiProblem {
-
-
-    public function __construct( ValidatorResponseInterface $response ){
-
+class ValidationApiProblem extends ApiProblem
+{
+    public function __construct(ValidatorResponseInterface $response)
+    {
         parent::__construct(
             400,
             'Your request could not be processed due to validation error',
@@ -21,8 +21,12 @@ class ValidationApiProblem extends ApiProblem {
             'Bad Request'
         );
 
-        $this->additionalDetails = array_merge( $this->additionalDetails, [ 'validation'=>$response->getArrayCopy() ] );
+        $validationResult = ['validation' => $response->getArrayCopy()];
 
-    } // function
-
-} // class
+        if ($this->additionalDetails === null) {
+            $this->additionalDetails = $validationResult;
+        } else {
+            $this->additionalDetails = array_merge($validationResult, array($this->additionalDetails));
+        }
+    }
+}

--- a/service-api/module/Application/src/Library/ApiProblem/ValidationApiProblem.php
+++ b/service-api/module/Application/src/Library/ApiProblem/ValidationApiProblem.php
@@ -23,10 +23,10 @@ class ValidationApiProblem extends ApiProblem
 
         $validationResult = ['validation' => $response->getArrayCopy()];
 
-        if ($this->additionalDetails === null) {
+        if (!is_array($this->additionalDetails)) {
             $this->additionalDetails = $validationResult;
         } else {
-            $this->additionalDetails = array_merge($validationResult, array($this->additionalDetails));
+            $this->additionalDetails = array_merge($validationResult, $this->additionalDetails);
         }
     }
 }

--- a/service-api/module/Application/src/Library/Authentication/Adapter/LpaAuth.php
+++ b/service-api/module/Application/src/Library/Authentication/Adapter/LpaAuth.php
@@ -39,6 +39,12 @@ class LpaAuth implements AdapterInterface
     }
 
     /**
+     * psalm complains about catching an interface in this method; however, this is
+     * because the Laminas ExceptionInterface does not implement Throwable
+     * or extend Exception (i.e. issue is nothing to do with our code)
+     *
+     * @psalm-suppress InvalidCatch
+     *
      * @return Result
      */
     public function authenticate(): Result

--- a/service-api/module/Application/src/Library/Authentication/Adapter/LpaAuth.php
+++ b/service-api/module/Application/src/Library/Authentication/Adapter/LpaAuth.php
@@ -17,27 +17,21 @@ class LpaAuth implements AdapterInterface
 {
     use LoggerTrait;
 
-    /**
-     * @var AuthenticationService
-     */
-    private $authenticationService;
+    /* @var AuthenticationService */
+    private AuthenticationService $authenticationService;
 
-    /**
-     * @var string
-     */
-    private $token;
+    /* @var string */
+    private string $token;
 
-    /**
-     * @var array
-     */
-    private $adminAccounts;
+    /* @var array */
+    private array $adminAccounts;
 
     /**
      * @param AuthenticationService $authenticationService
-     * @param $token
+     * @param string $token
      * @param array $adminAccounts
      */
-    public function __construct(AuthenticationService $authenticationService, $token, array $adminAccounts)
+    public function __construct(AuthenticationService $authenticationService, string $token, array $adminAccounts)
     {
         $this->authenticationService = $authenticationService;
         $this->token = $token;
@@ -47,7 +41,7 @@ class LpaAuth implements AdapterInterface
     /**
      * @return Result
      */
-    public function authenticate()
+    public function authenticate(): Result
     {
         // Database errors during authentication are converted into a general 500 response from the API
         try {

--- a/service-api/module/Application/src/Library/Authentication/AuthenticationListener.php
+++ b/service-api/module/Application/src/Library/Authentication/AuthenticationListener.php
@@ -34,6 +34,11 @@ class AuthenticationListener
          *
          * This will leave the standard 'Authorization' namespace free for when OAuth is done properly.
          */
+        // Suppress psalm errors caused by bug in laminas-mvc;
+        // see https://github.com/laminas/laminas-mvc/issues/77
+        /**
+         * @psalm-suppress UndefinedInterfaceMethod
+         */
         $token = $e->getRequest()->getHeader('Token');
 
         if (!$token) {

--- a/service-api/module/Application/src/Library/Authorization/Assertions/IsAuthorizedToManageUser.php
+++ b/service-api/module/Application/src/Library/Authorization/Assertions/IsAuthorizedToManageUser.php
@@ -13,14 +13,14 @@ use LmcRbacMvc\Service\AuthorizationService;
  */
 class IsAuthorizedToManageUser implements AssertionInterface
 {
-    public function assert(AuthorizationService $authorization, $routeUserId = null)
+    public function assert(AuthorizationService $authorizationService, $routeUserId = null)
     {
         // We can only authorize is there's a route user...
         if (!is_string($routeUserId)) {
             return false;
         }
 
-        $tokenUser = $authorization->getIdentity();
+        $tokenUser = $authorizationService->getIdentity();
 
         //  Otherwise we can only authorize if we can get the user's id from the Identity...
         if (!is_callable([$tokenUser, 'id'])) {

--- a/service-api/module/Application/src/Library/DateTime.php
+++ b/service-api/module/Application/src/Library/DateTime.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Application\Library;
 
 use DateTimeZone;
@@ -11,18 +12,16 @@ use DateTimeZone;
  * Class DateTime
  * @package Application\Library
  */
-class DateTime extends \DateTime {
-
-    public function __construct ($time='now', DateTimeZone $timezone=null) {
-
-        if( $time == 'now' && (is_null($timezone) || $timezone->getName() == 'UTC') ){
+class DateTime extends \DateTime
+{
+    public function __construct($time = 'now', DateTimeZone $timezone = null)
+    {
+        if ($time == 'now' && (is_null($timezone) || $timezone->getName() == 'UTC')) {
             $t = microtime(true);
-            $micro = sprintf("%06d",($t - floor($t)) * 1000000);
-            $time = date('Y-m-d H:i:s.'.$micro,$t);
+            $micro = sprintf("%06d", ($t - floor($t)) * 1000000);
+            $time = date('Y-m-d H:i:s.' . $micro, intval($t));
         }
 
-        parent::__construct( $time, $timezone );
-
-    } // function
-
-} // class
+        parent::__construct($time, $timezone);
+    }
+}

--- a/service-api/module/Application/src/Library/Http/Response/File.php
+++ b/service-api/module/Application/src/Library/Http/Response/File.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Application\Library\Http\Response;
 
 use Laminas\Http\Response;
@@ -9,14 +10,15 @@ use Laminas\Http\Response;
  * Class NoContent
  * @package Application\Library\Http\Response
  */
-class File extends Response {
-
-    const TYPE_PDF = 'application/pdf';
+class File extends Response
+{
+    public const TYPE_PDF = 'application/pdf';
 
     protected $contentType;
 
-    public function __construct( $data, $contentType ){
-        $this->setContent( $data );
+    public function __construct($data, $contentType)
+    {
+        $this->setContent($data);
         $this->contentType = $contentType;
     }
 
@@ -33,11 +35,10 @@ class File extends Response {
         $headers = parent::getHeaders();
 
         $headers->clearHeaders()
-            ->addHeaderLine( 'Content-Type', $this->contentType)
-            ->addHeaderLine( 'Content-Disposition', 'attachment')
-            ->addHeaderLine( 'Content-Length', strlen( $this->getContent() ) );
+            ->addHeaderLine('Content-Type', $this->contentType)
+            ->addHeaderLine('Content-Disposition', 'attachment')
+            ->addHeaderLine('Content-Length', '' . strlen($this->getContent()));
 
         return $headers;
     }
-
-} // class
+}

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/DbWrapper.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/DbWrapper.php
@@ -103,7 +103,7 @@ class DbWrapper
      *     ],
      * ]
      *
-     * @return ResultInterface<mixed>
+     * @return ResultInterface
      */
     public function select(string $tableName, array $criteria = [], array $options = []): ResultInterface
     {

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/DbWrapper.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/DbWrapper.php
@@ -52,7 +52,7 @@ class DbWrapper
     /**
      * Perform a raw SQL query via the adapter.
      * @param string $query Raw SQL string to execute on adapter
-     * @return Driver\StatementInterface|ResultSet\ResultSet
+     * @return \Laminas\Db\Adapter\Driver\StatementInterface|ResultSet
      */
     public function rawQuery(string $query)
     {
@@ -84,8 +84,8 @@ class DbWrapper
      * Perform a SQL SELECT against the db.
      *
      * @param string $tableName Name of table to select against
-     * @param array<string, string|ExpressionInterface> $criteria Added to the WHERE clause; the "search"
-     * key is escaped and used for a regex match if present
+     * @param array<string, string|ExpressionInterface>|array $criteria Added to the WHERE clause;
+     *     the "search" key is escaped and used for a regex match if present
      * @param array<string, array|int|string> $options Used to set columns, LIMIT, OFFSET and SORT
      *
      * Example options:

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/UserData.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/UserData.php
@@ -317,7 +317,7 @@ class UserData extends AbstractBase implements UserRepository\UserRepositoryInte
      * NB: When an account is deleted, the document it kept, leaving only _id and a new deletedAt field.
      *
      * @param $id
-     * @return bool|null
+     * @return bool
      */
     public function delete(string $id): bool
     {
@@ -348,7 +348,7 @@ class UserData extends AbstractBase implements UserRepository\UserRepositoryInte
      * Activates a user account
      *
      * @param $token
-     * @return bool|null
+     * @return bool
      */
     public function activate(string $token): bool
     {
@@ -686,20 +686,20 @@ class UserData extends AbstractBase implements UserRepository\UserRepositoryInte
     /**
      * Updates a user's profile. If it doesn't already exist, it's created.
      *
-     * @param ProfileUserModel $user
+     * @param ProfileUserModel $data
      * @return bool
      */
-    public function saveProfile(ProfileUserModel $user): bool
+    public function saveProfile(ProfileUserModel $data): bool
     {
-        $data = $user->toArray();
+        $user = $data->toArray();
 
         // Remove unwarned fields
-        unset($data['id'], $data['createdAt'], $data['updatedAt']);
+        unset($user['id'], $user['createdAt'], $user['updatedAt']);
 
         return $this->updateRow(
-            ['id' => $user->getId()],
+            ['id' => $data->getId()],
             [
-                'profile' => json_encode($data),
+                'profile' => json_encode($user),
             ]
         );
     }

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/UserData.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/UserData.php
@@ -6,6 +6,7 @@ use PDOException;
 use DateTime;
 use Laminas\Db\Sql\Expression as SqlExpression;
 use Laminas\Db\Sql\Sql;
+use Laminas\Db\Sql\TableIdentifier;
 use Laminas\Db\Sql\Predicate\Operator;
 use Laminas\Db\Sql\Predicate\Expression;
 use Laminas\Db\Sql\Predicate\IsNull;
@@ -129,7 +130,7 @@ class UserData extends AbstractBase implements UserRepository\UserRepositoryInte
         $sql = $this->dbWrapper->createSql();
 
         // count applications by user
-        $subselect = $sql->select(['a' => ApplicationData::APPLICATIONS_TABLE])
+        $subselect = $sql->select()->from(['a' => ApplicationData::APPLICATIONS_TABLE])
             ->columns(['user', 'numberOfLpas' => new SqlExpression('COUNT(*)')])
             ->group(['user']);
 
@@ -146,7 +147,7 @@ class UserData extends AbstractBase implements UserRepository\UserRepositoryInte
         // main query
         // WARNING join type is "FULL" here as using Select::JOIN_OUTER produces
         // invalid SQL; but this potentially locks the code to Postgres
-        $select = $sql->select(['u' => self::USERS_TABLE])
+        $select = $sql->select()->from(['u' => self::USERS_TABLE])
             ->join(
                 ['a' => $subselect],
                 'u.id = a.user',

--- a/service-api/module/Application/src/Model/DataAccess/Repository/Application/ApplicationRepositoryInterface.php
+++ b/service-api/module/Application/src/Model/DataAccess/Repository/Application/ApplicationRepositoryInterface.php
@@ -1,12 +1,13 @@
 <?php
+
 namespace Application\Model\DataAccess\Repository\Application;
 
 use DateTime;
 use Traversable;
 use Opg\Lpa\DataModel\Lpa\Lpa;
 
-interface ApplicationRepositoryInterface {
-
+interface ApplicationRepositoryInterface
+{
     /**
      * Get an LPA by ID, and user ID if provided
      *
@@ -14,7 +15,16 @@ interface ApplicationRepositoryInterface {
      * @param string $userId
      * @return array|null
      */
-    public function getById(int $id, ?string $userId = null) : ?array;
+    public function getById(int $id, ?string $userId = null): ?array;
+
+    /**
+     * Get LPAs whose IDs are in $lpaIds for the specified user
+     *
+     * @param array $lpaIds Array of LPA IDs which must be matched
+     * @param string $userId ID of the user to get LPAs for
+     * @return Traversable containing LPA items
+     */
+    public function getByIdsAndUser(array $lpaIds, string $userId): Traversable;
 
     /**
      * Counts the number of results for the given criteria.
@@ -22,27 +32,27 @@ interface ApplicationRepositoryInterface {
      * @param array $criteria
      * @return int
      */
-    public function count(array $criteria) : int;
+    public function count(array $criteria): int;
 
     /**
      * @param array $criteria
      * @param array $options
      * @return Traversable
      */
-    public function fetch(array $criteria, array $options = []) : Traversable;
+    public function fetch(array $criteria, array $options = []): Traversable;
 
     /**
      * @param string $userId
      * @param array $options
      * @return Traversable
      */
-    public function fetchByUserId(string $userId, array $options = []) : Traversable;
+    public function fetchByUserId(string $userId, array $options = []): Traversable;
 
     /**
      * @param Lpa $lpa
      * @return bool
      */
-    public function insert(Lpa $lpa) : bool;
+    public function insert(Lpa $lpa): bool;
 
     /**
      * Update the LPA
@@ -50,14 +60,14 @@ interface ApplicationRepositoryInterface {
      * @param Lpa $lpa
      * @return bool
      */
-    public function update(Lpa $lpa) : bool;
+    public function update(Lpa $lpa): bool;
 
     /**
      * @param int $lpaId
      * @param string $userId
      * @return bool
      */
-    public function deleteById(int $lpaId, string $userId) : bool;
+    public function deleteById(int $lpaId, string $userId): bool;
 
     /**
      * Get the count of LPAs between two dates for the timestamp field name provided
@@ -74,7 +84,7 @@ interface ApplicationRepositoryInterface {
      * @param string $timestampFieldName
      * @return int
      */
-    public function countBetween(Datetime $start, Datetime $end, string $timestampFieldName) : int;
+    public function countBetween(Datetime $start, Datetime $end, string $timestampFieldName): int;
 
     /**
      * Count the number of LPAs started but not created for a given LPA type
@@ -82,7 +92,7 @@ interface ApplicationRepositoryInterface {
      * @param $lpaType
      * @return int
      */
-    public function countStartedForType(string $lpaType) : int;
+    public function countStartedForType(string $lpaType): int;
 
     /**
      * Count the number of LPAs created but not completed for a given LPA type
@@ -90,7 +100,7 @@ interface ApplicationRepositoryInterface {
      * @param $lpaType
      * @return int
      */
-    public function countCreatedForType(string $lpaType) : int;
+    public function countCreatedForType(string $lpaType): int;
 
     /**
      * Count the number of LPAs waiting for a given LPA type
@@ -98,7 +108,7 @@ interface ApplicationRepositoryInterface {
      * @param $lpaType
      * @return int
      */
-    public function countWaitingForType(string $lpaType) : int;
+    public function countWaitingForType(string $lpaType): int;
 
     /**
      * Count the number of LPAs being checked for a given LPA type
@@ -106,7 +116,7 @@ interface ApplicationRepositoryInterface {
      * @param $lpaType
      * @return int
      */
-    public function countCheckingForType(string $lpaType) : int;
+    public function countCheckingForType(string $lpaType): int;
 
     /**
      * Count the number of LPAs received for a given LPA type
@@ -114,7 +124,7 @@ interface ApplicationRepositoryInterface {
      * @param $lpaType
      * @return int
      */
-    public function countReceivedForType(string $lpaType) : int;
+    public function countReceivedForType(string $lpaType): int;
 
     /**
      * Count the number of LPAs processed for a given LPA type
@@ -122,7 +132,7 @@ interface ApplicationRepositoryInterface {
      * @param $lpaType
      * @return int
      */
-    public function countProcessedForType(string $lpaType) : int;
+    public function countProcessedForType(string $lpaType): int;
 
     /**
      * Count the number of LPAs completed for a given LPA type
@@ -130,14 +140,14 @@ interface ApplicationRepositoryInterface {
      * @param $lpaType
      * @return int
      */
-    public function countCompletedForType(string $lpaType) : int;
+    public function countCompletedForType(string $lpaType): int;
 
     /**
      * Count the number of deleted LPAs
      *
      * @return int
      */
-    public function countDeleted() : int;
+    public function countDeleted(): int;
 
     /**
      * Returns a list of lpa counts and user counts, in order to
@@ -148,7 +158,7 @@ interface ApplicationRepositoryInterface {
      *
      * @return array
      */
-    public function getLpasPerUser() : array;
+    public function getLpasPerUser(): array;
 
     /**
      * Get the number of completed LPAs - with additional criteria if provided
@@ -158,7 +168,7 @@ interface ApplicationRepositoryInterface {
      * @param array $additionalCriteria
      * @return int
      */
-    public function countCompletedBetween(Datetime $start, Datetime $end, array $additionalCriteria = []) : int;
+    public function countCompletedBetween(Datetime $start, Datetime $end, array $additionalCriteria = []): int;
 
     /**
      * Get the number of completed LPAs with a correspondent that has entered an email address
@@ -167,7 +177,7 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countCompletedBetweenCorrespondentEmail(Datetime $start, Datetime $end) : int;
+    public function countCompletedBetweenCorrespondentEmail(Datetime $start, Datetime $end): int;
 
     /**
      * Get the number of completed LPAs with a correspondent that has entered phone number
@@ -176,7 +186,7 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countCompletedBetweenCorrespondentPhone(Datetime $start, Datetime $end) : int;
+    public function countCompletedBetweenCorrespondentPhone(Datetime $start, Datetime $end): int;
 
     /**
      * Get the number of completed LPAs with a correspondent that has entered a postal address
@@ -185,7 +195,7 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countCompletedBetweenCorrespondentPost(Datetime $start, Datetime $end) : int;
+    public function countCompletedBetweenCorrespondentPost(Datetime $start, Datetime $end): int;
 
     /**
      * Get the number of completed LPAs with a correspondent that has requested to be contacted in English
@@ -194,7 +204,7 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countCompletedBetweenCorrespondentEnglish(Datetime $start, Datetime $end) : int;
+    public function countCompletedBetweenCorrespondentEnglish(Datetime $start, Datetime $end): int;
 
     /**
      * Get the number of completed LPAs with a correspondent that has requested to be contacted in Welsh
@@ -203,7 +213,7 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countCompletedBetweenCorrespondentWelsh(Datetime $start, Datetime $end) : int;
+    public function countCompletedBetweenCorrespondentWelsh(Datetime $start, Datetime $end): int;
 
     /**
      * Get the number of completed LPAs with preferences
@@ -212,7 +222,7 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countCompletedBetweenWithPreferences(Datetime $start, Datetime $end) : int;
+    public function countCompletedBetweenWithPreferences(Datetime $start, Datetime $end): int;
 
     /**
      * Get the number of completed LPAs with instructions
@@ -221,7 +231,7 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countCompletedBetweenWithInstructions(Datetime $start, Datetime $end) : int;
+    public function countCompletedBetweenWithInstructions(Datetime $start, Datetime $end): int;
 
     /**
      * Get the number of completed LPAs by LPA type
@@ -231,7 +241,7 @@ interface ApplicationRepositoryInterface {
      * @param string $lpaType
      * @return int
      */
-    public function countCompletedBetweenByType(Datetime $start, Datetime $end, string $lpaType) : int;
+    public function countCompletedBetweenByType(Datetime $start, Datetime $end, string $lpaType): int;
 
     /**
      * Get the number of completed LPAs by canSign response
@@ -241,7 +251,7 @@ interface ApplicationRepositoryInterface {
      * @param bool $canSignValue
      * @return int
      */
-    public function countCompletedBetweenByCanSign(Datetime $start, Datetime $end, bool $canSignValue) : int;
+    public function countCompletedBetweenByCanSign(Datetime $start, Datetime $end, bool $canSignValue): int;
 
     /**
      * Get the number of completed LPAs with at least one of the actor type defined
@@ -251,7 +261,7 @@ interface ApplicationRepositoryInterface {
      * @param string $actorType
      * @return int
      */
-    public function countCompletedBetweenHasActors(Datetime $start, Datetime $end, string $actorType) : int;
+    public function countCompletedBetweenHasActors(Datetime $start, Datetime $end, string $actorType): int;
 
     /**
      * Get the number of completed LPAs with none of the actor type
@@ -261,7 +271,7 @@ interface ApplicationRepositoryInterface {
      * @param string $actorType
      * @return int
      */
-    public function countCompletedBetweenHasNoActors(Datetime $start, Datetime $end, string $actorType) : int;
+    public function countCompletedBetweenHasNoActors(Datetime $start, Datetime $end, string $actorType): int;
 
     /**
      * Get the number of completed LPAs with multiple actors of the type
@@ -271,7 +281,7 @@ interface ApplicationRepositoryInterface {
      * @param string $actorType
      * @return int
      */
-    public function countCompletedBetweenHasMultipleActors(Datetime $start, Datetime $end, string $actorType) : int;
+    public function countCompletedBetweenHasMultipleActors(Datetime $start, Datetime $end, string $actorType): int;
 
     /**
      * Get the number of completed LPAs where the donor is registering
@@ -280,7 +290,7 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countCompletedBetweenDonorRegistering(Datetime $start, Datetime $end) : int;
+    public function countCompletedBetweenDonorRegistering(Datetime $start, Datetime $end): int;
 
     /**
      * Get the number of completed LPAs where an attorney is registering
@@ -289,7 +299,7 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countCompletedBetweenAttorneyRegistering(Datetime $start, Datetime $end) : int;
+    public function countCompletedBetweenAttorneyRegistering(Datetime $start, Datetime $end): int;
 
     /**
      * Get the number of completed LPAs with a case number
@@ -299,7 +309,7 @@ interface ApplicationRepositoryInterface {
      * @param bool $hasCaseNumber
      * @return int
      */
-    public function countCompletedBetweenCaseNumber(Datetime $start, Datetime $end, bool $hasCaseNumber) : int;
+    public function countCompletedBetweenCaseNumber(Datetime $start, Datetime $end, bool $hasCaseNumber): int;
 
     /**
      * Get the number of completed LPAs with the fee options set as provided
@@ -312,7 +322,14 @@ interface ApplicationRepositoryInterface {
      * @param ?bool $reducedFeeUniversalCredit
      * @return int
      */
-    public function countCompletedBetweenFeeType(Datetime $start, Datetime $end, ?bool $reducedFeeReceivesBenefits, ?bool $reducedFeeAwardedDamages, ?bool $reducedFeeLowIncome, ?bool $reducedFeeUniversalCredit) : int;
+    public function countCompletedBetweenFeeType(
+        Datetime $start,
+        Datetime $end,
+        ?bool $reducedFeeReceivesBenefits,
+        ?bool $reducedFeeAwardedDamages,
+        ?bool $reducedFeeLowIncome,
+        ?bool $reducedFeeUniversalCredit
+    ): int;
 
     /**
      * Get the number of completed LPAs with the payment type defined
@@ -322,10 +339,15 @@ interface ApplicationRepositoryInterface {
      * @param string $paymentType
      * @return int
      */
-    public function countCompletedBetweenPaymentType(Datetime $start, Datetime $end, string $paymentType) : int;
+    public function countCompletedBetweenPaymentType(
+        Datetime $start,
+        Datetime $end,
+        string $paymentType
+    ): int;
 
     /**
-     * Get the number of completed LPAs with the attorney decisions (primary or replacement) set to the type and value provided
+     * Get the number of completed LPAs with the attorney decisions
+     * (primary or replacement) set to the type and value provided
      *
      * @param Datetime $start
      * @param Datetime $end
@@ -334,7 +356,13 @@ interface ApplicationRepositoryInterface {
      * @param string $decisionValue
      * @return int
      */
-    public function countCompletedBetweenWithAttorneyDecisions(Datetime $start, Datetime $end, string $attorneyDecisionsType, string $decisionType, string $decisionValue) : int;
+    public function countCompletedBetweenWithAttorneyDecisions(
+        Datetime $start,
+        Datetime $end,
+        string $attorneyDecisionsType,
+        string $decisionType,
+        string $decisionValue
+    ): int;
 
     /**
      * Get the number of completed LPAs with a trust set as an attorney
@@ -344,7 +372,7 @@ interface ApplicationRepositoryInterface {
      * @param string $attorneyType
      * @return int
      */
-    public function countCompletedBetweenWithTrust(Datetime $start, Datetime $end, string $attorneyType) : int;
+    public function countCompletedBetweenWithTrust(Datetime $start, Datetime $end, string $attorneyType): int;
 
     /**
      * Get the number of completed LPAs where the certificate provider is skipped or not
@@ -354,7 +382,11 @@ interface ApplicationRepositoryInterface {
      * @param bool $isSkipped
      * @return int
      */
-    public function countCompletedBetweenCertificateProviderSkipped(Datetime $start, Datetime $end, bool $isSkipped) : int;
+    public function countCompletedBetweenCertificateProviderSkipped(
+        Datetime $start,
+        Datetime $end,
+        bool $isSkipped
+    ): int;
 
     /**
      * Get the number of returned LPAs
@@ -363,7 +395,7 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countReturnedBetween(Datetime $start, Datetime $end) : int;
+    public function countReturnedBetween(Datetime $start, Datetime $end): int;
 
     /**
      * Get the number of returned LPAs
@@ -373,7 +405,7 @@ interface ApplicationRepositoryInterface {
      * @param array $additionalCriteria
      * @return int
      */
-    public function countReturned(Datetime $start, Datetime $end, array $additionalCriteria = []) : int;
+    public function countReturned(Datetime $start, Datetime $end, array $additionalCriteria = []): int;
 
     /**
      * Get the number of LPAs being checked
@@ -382,7 +414,7 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countCheckedBetween(Datetime $start, Datetime $end) : int;
+    public function countCheckedBetween(Datetime $start, Datetime $end): int;
 
     /**
      * Get the number of LPAs being checked
@@ -392,7 +424,7 @@ interface ApplicationRepositoryInterface {
      * @param array $additionalCriteria
      * @return int
      */
-    public function countChecking(Datetime $start, Datetime $end, array $additionalCriteria = []) : int;
+    public function countChecking(Datetime $start, Datetime $end, array $additionalCriteria = []): int;
 
     /**
      * Get the number of LPAs received
@@ -401,7 +433,7 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countReceivedBetween(Datetime $start, Datetime $end) : int;
+    public function countReceivedBetween(Datetime $start, Datetime $end): int;
 
     /**
      * Get the number of LPAs received
@@ -411,7 +443,7 @@ interface ApplicationRepositoryInterface {
      * @param array $additionalCriteria
      * @return int
      */
-    public function countReceived(Datetime $start, Datetime $end, array $additionalCriteria = []) : int;
+    public function countReceived(Datetime $start, Datetime $end, array $additionalCriteria = []): int;
 
     /**
      * Get the number of LPAs waiting
@@ -420,5 +452,5 @@ interface ApplicationRepositoryInterface {
      * @param Datetime $end
      * @return int
      */
-    public function countWaitingBetween(Datetime $start, Datetime $end) : int;
+    public function countWaitingBetween(Datetime $start, Datetime $end): int;
 }

--- a/service-api/module/Application/src/Model/DataAccess/Repository/User/UserRepositoryInterface.php
+++ b/service-api/module/Application/src/Model/DataAccess/Repository/User/UserRepositoryInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Application\Model\DataAccess\Repository\User;
 
 use DateTime;
@@ -6,14 +7,13 @@ use Opg\Lpa\DataModel\User\User as UserModel;
 
 interface UserRepositoryInterface
 {
-
     /**
      * Returns a single user by username (email address).
      *
      * @param $username
      * @return UserInterface|null
      */
-    public function getByUsername(string $username) : ?UserInterface;
+    public function getByUsername(string $username): ?UserInterface;
 
     /**
      * Returns zero or more users whose username (email address) approximately
@@ -23,31 +23,31 @@ interface UserRepositoryInterface
      * @param $options - optional query criteria
      * @return iterable
      */
-    public function matchUsers(string $query, array $options) : iterable;
+    public function matchUsers(string $query, array $options): iterable;
 
     /**
      * @param $id
      * @return UserInterface|null
      */
-    public function getById(string $id) : ?UserInterface;
+    public function getById(string $id): ?UserInterface;
 
     /**
      * @param $token
      * @return UserInterface|null
      */
-    public function getByAuthToken(string $token) : ?UserInterface;
+    public function getByAuthToken(string $token): ?UserInterface;
 
     /**
      * @param $token
      * @return UserInterface|null
      */
-    public function getByResetToken(string $token) : ?UserInterface;
+    public function getByResetToken(string $token): ?UserInterface;
 
     /**
      * @param $id
      * @return bool
      */
-    public function updateLastLoginTime(string $id) : bool;
+    public function updateLastLoginTime(string $id): bool;
 
     /**
      * Resets the user's failed login counter to zero.
@@ -55,7 +55,7 @@ interface UserRepositoryInterface
      * @param $id
      * @return bool
      */
-    public function resetFailedLoginCounter(string $id) : bool;
+    public function resetFailedLoginCounter(string $id): bool;
 
     /**
      * Increments the user's failed login counter by 1.
@@ -63,7 +63,7 @@ interface UserRepositoryInterface
      * @param $id
      * @return bool
      */
-    public function incrementFailedLoginCounter(string $id) : bool;
+    public function incrementFailedLoginCounter(string $id): bool;
 
     /**
      * Creates a new user account
@@ -72,7 +72,7 @@ interface UserRepositoryInterface
      * @param array $details
      * @return bool
      */
-    public function create(string $id, array $details) : bool;
+    public function create(string $id, array $details): bool;
 
     /**
      * Delete the account for the passed user.
@@ -80,9 +80,9 @@ interface UserRepositoryInterface
      * NB: When an account is deleted, the document it kept, leaving only _id and a new deletedAt field.
      *
      * @param $id
-     * @return bool|null
+     * @return bool
      */
-    public function delete(string $id) : bool;
+    public function delete(string $id): bool;
 
     /**
      * Activates a user account
@@ -90,7 +90,7 @@ interface UserRepositoryInterface
      * @param $token
      * @return bool|null
      */
-    public function activate(string $token) : bool;
+    public function activate(string $token): bool|null;
 
     /**
      * Updates a user's password.
@@ -99,7 +99,7 @@ interface UserRepositoryInterface
      * @param $passwordHash
      * @return bool
      */
-    public function setNewPassword(string $userId, string $passwordHash) : bool;
+    public function setNewPassword(string $userId, string $passwordHash): bool;
 
     /**
      * Sets a new auth token.
@@ -109,7 +109,7 @@ interface UserRepositoryInterface
      * @param $token
      * @return bool
      */
-    public function setAuthToken(string $userId, DateTime $expires, string $token) : bool;
+    public function setAuthToken(string $userId, DateTime $expires, string $token): bool;
 
     /**
      * Updates the authentication token expiry datetime.
@@ -118,21 +118,21 @@ interface UserRepositoryInterface
      * @param DateTime $expires
      * @return bool
      */
-    public function updateAuthTokenExpiry(string $userId, DateTime $expires) : bool;
+    public function updateAuthTokenExpiry(string $userId, DateTime $expires): bool;
 
     /**
      * @param $id
      * @param array $token
      * @return bool
      */
-    public function addPasswordResetToken(string $id, array $token) : bool;
+    public function addPasswordResetToken(string $id, array $token): bool;
 
     /**
      * @param $token
      * @param $passwordHash
      * @return UpdatePasswordUsingTokenError
      */
-    public function updatePasswordUsingToken(string $token, string $passwordHash) : ?UpdatePasswordUsingTokenError;
+    public function updatePasswordUsingToken(string $token, string $passwordHash): ?UpdatePasswordUsingTokenError;
 
     /**
      * @param $id
@@ -140,13 +140,13 @@ interface UserRepositoryInterface
      * @param $newEmail
      * @return bool
      */
-    public function addEmailUpdateTokenAndNewEmail(string $id, array $token, string $newEmail) : bool;
+    public function addEmailUpdateTokenAndNewEmail(string $id, array $token, string $newEmail): bool;
 
     /**
      * @param $token
      * @return UpdateEmailUsingTokenResponse
      */
-    public function updateEmailUsingToken(string $token) : UpdateEmailUsingTokenResponse;
+    public function updateEmailUsingToken(string $token): UpdateEmailUsingTokenResponse;
 
     /**
      * Returns all accounts that have not been logged into since $since.
@@ -157,7 +157,7 @@ interface UserRepositoryInterface
      * @param string $excludeFlag
      * @return iterable
      */
-    public function getAccountsInactiveSince(DateTime $since, ?string $excludeFlag = null) : iterable;
+    public function getAccountsInactiveSince(DateTime $since, ?string $excludeFlag = null): iterable;
 
     /**
      * Adds a new inactivity flag to an account.
@@ -166,7 +166,7 @@ interface UserRepositoryInterface
      * @param $flag
      * @return bool
      */
-    public function setInactivityFlag(string $userId, string $flag) : bool;
+    public function setInactivityFlag(string $userId, string $flag): bool;
 
     /**
      * Returns all accounts create before date $olderThan and that have not been activated.
@@ -174,14 +174,14 @@ interface UserRepositoryInterface
      * @param DateTime $olderThan
      * @return iterable
      */
-    public function getAccountsUnactivatedOlderThan(DateTime $olderThan) : iterable;
+    public function getAccountsUnactivatedOlderThan(DateTime $olderThan): iterable;
 
     /**
      * Counts the number of account in the system.
      *
      * @return int Account count
      */
-    public function countAccounts() : int;
+    public function countAccounts(): int;
 
     /**
      * Counts the number of ACTIVATED account in the system.
@@ -189,14 +189,14 @@ interface UserRepositoryInterface
      * @param DateTime|null $since only include accounts activated $since
      * @return int Account count
      */
-    public function countActivatedAccounts(DateTime $since = null) : int;
+    public function countActivatedAccounts(DateTime $since = null): int;
 
     /**
      * Counts the number of accounts that have been deleted.
      *
      * @return int Account count
      */
-    public function countDeletedAccounts() : int;
+    public function countDeletedAccounts(): int;
 
     /**
      * Return a user's profile details
@@ -204,7 +204,7 @@ interface UserRepositoryInterface
      * @param $id
      * @return UserModel
      */
-    public function getProfile($id) : ?UserModel;
+    public function getProfile($id): ?UserModel;
 
     /**
      * Updates a user's profile. If it doesn't already exist, it's created.
@@ -212,5 +212,5 @@ interface UserRepositoryInterface
      * @param UserModel $data
      * @return bool
      */
-    public function saveProfile(UserModel $data) : bool;
+    public function saveProfile(UserModel $data): bool;
 }

--- a/service-api/module/Application/src/Model/Service/Applications/Collection.php
+++ b/service-api/module/Application/src/Model/Service/Applications/Collection.php
@@ -16,7 +16,7 @@ class Collection extends Paginator
 
         //  Get the full details of the LPA
         foreach ($lpas as $lpa) {
-            /** @var $lpa Lpa */
+            /* @var $lpa Lpa */
             $applications[] = $lpa->toArray();
         }
 

--- a/service-api/module/Application/src/Model/Service/Authentication/Service.php
+++ b/service-api/module/Application/src/Model/Service/Authentication/Service.php
@@ -16,12 +16,12 @@ class Service extends AbstractService
     /**
      * The maximum number of consecutive login attempts before an account is locked.
      */
-    const MAX_ALLOWED_LOGIN_ATTEMPTS = 5;
+    public const MAX_ALLOWED_LOGIN_ATTEMPTS = 5;
 
     /**
      * Default number of seconds before an auth token expires.
      */
-    const TOKEN_TTL = 4500; // 75 minutes
+    public const TOKEN_TTL = 4500; // 75 minutes
 
     /**
      * The actual number of seconds before an auth token expires.
@@ -31,7 +31,7 @@ class Service extends AbstractService
     /**
      * The number of minutes to lock an account for after x failed login consecutive attempts.
      */
-    const ACCOUNT_LOCK_TIME = 900; // 15 minutes
+    public const ACCOUNT_LOCK_TIME = 900; // 15 minutes
 
     public function __construct($tokenTtl = self::TOKEN_TTL)
     {
@@ -56,9 +56,10 @@ class Service extends AbstractService
 
         if ($user->failedLoginAttempts() >= self::MAX_ALLOWED_LOGIN_ATTEMPTS) {
             // Unlock the account after 15 minutes
-            if ($user->lastFailedLoginAttemptAt() instanceof DateTime
-                && $user->lastFailedLoginAttemptAt() > new DateTime('-' . self::ACCOUNT_LOCK_TIME . " seconds")) {
-
+            if (
+                $user->lastFailedLoginAttemptAt() instanceof DateTime
+                && $user->lastFailedLoginAttemptAt() > new DateTime('-' . self::ACCOUNT_LOCK_TIME . " seconds")
+            ) {
                 return 'account-locked/max-login-attempts';
             } else {
                 // Reset field failed login counter
@@ -103,7 +104,7 @@ class Service extends AbstractService
                 // Use base62 for shorter tokens
                 $authToken = BigInteger::factory('bcmath')->baseConvert($authToken, 16, 62);
 
-                $created = (bool)$this->getUserRepository()->setAuthToken(
+                $created = $this->getUserRepository()->setAuthToken(
                     $user->id(),
                     $expires,
                     $authToken
@@ -190,13 +191,11 @@ class Service extends AbstractService
             // if we need to update, use the default expiry
             if ($needsUpdate) {
                 $expiresAt = $maxExpiresAt;
-            }
-            // not updating, just get the token's current expiresAt
-            else {
+            } else {
+                // not updating, just get the token's current expiresAt
                 $expiresAt = $token->expiresAt();
             }
-        }
-        else {
+        } else {
             // limit how far ahead expiry is set to <= the TTL for this service
             $expiresAt = min($maxExpiresAt, $expiresAt);
         }

--- a/service-api/module/Application/src/Model/Service/Feedback/Service.php
+++ b/service-api/module/Application/src/Model/Service/Feedback/Service.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Application\Model\Service\Feedback;
 
 use DateTime;
@@ -10,7 +11,7 @@ class Service extends AbstractService
 {
     use FeedbackRepositoryTrait;
 
-    const FEEDBACK_TTL = '-2 years';
+    public const FEEDBACK_TTL = '-2 years';
 
     /**
      * @var DateTime
@@ -23,7 +24,7 @@ class Service extends AbstractService
      * @param array $feedback
      * @return bool
      */
-    public function add(array $feedback) : bool
+    public function add(array $feedback): bool
     {
         // Filter out any 'non-allowed' fields
         $allowed = ['agent', 'fromPage', 'rating', 'details', 'email', 'phone'];
@@ -47,9 +48,9 @@ class Service extends AbstractService
      *
      * @param DateTime $from
      * @param DateTime $to
-     * @return iterable
+     * @return Traversable
      */
-    public function get(DateTime $from, DateTime $to) : Traversable
+    public function get(DateTime $from, DateTime $to): Traversable
     {
         // Prune old feedback
         $this->getFeedbackRepository()->prune($this->getPruneDate());
@@ -64,7 +65,8 @@ class Service extends AbstractService
      *
      * @return DateTime
      */
-    public function getPruneDate() {
+    public function getPruneDate()
+    {
         if (isset($this->pruneBeforeDate)) {
             return $this->pruneBeforeDate;
         }
@@ -73,5 +75,4 @@ class Service extends AbstractService
 
         return $this->pruneBeforeDate;
     }
-
 }

--- a/service-api/module/Application/src/Model/Service/Password/Service.php
+++ b/service-api/module/Application/src/Model/Service/Password/Service.php
@@ -15,7 +15,7 @@ class Service extends AbstractService
     use PasswordValidatorTrait;
     use UserRepositoryTrait;
 
-    const TOKEN_TTL = 86400; // 24 hours
+    public const TOKEN_TTL = 86400; // 24 hours
 
     /**
      * @var AuthenticationService
@@ -94,7 +94,7 @@ class Service extends AbstractService
     /**
      * @param $token
      * @param $newPassword
-     * @return bool|string
+     * @return string|null
      */
     public function updatePasswordUsingToken($token, $newPassword)
     {

--- a/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
+++ b/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
@@ -31,24 +31,16 @@ class Service extends AbstractService
         'Return - unpaid' => Lpa::SIRIUS_PROCESSING_STATUS_RETURNED
     ];
 
-    /**
-     * @var $httpClient HttpClient
-     */
+    /* @var $httpClient HttpClient */
     private $httpClient;
 
-    /**
-     * @var $credentials CredentialsInterface
-     */
+    /* @var $credentials CredentialsInterface */
     private $credentials;
 
-    /**
-     * @var $processingStatusServiceUri string
-     */
+    /* @var $processingStatusServiceUri string */
     private $processingStatusServiceUri;
 
-    /**
-     * @var $awsSignature SignatureV4
-     */
+    /* @var $awsSignature SignatureV4 */
     private $awsSignature;
 
     public function setClient(HttpClient $httpClient)
@@ -158,7 +150,7 @@ class Service extends AbstractService
 
                 default:
                     $this->getLogger()->err(
-                        'Unexpected response from Sirius gateway: ' . $statusCode. (string)$result->getBody()
+                        'Unexpected response from Sirius gateway: ' . $statusCode . (string)$result->getBody()
                     );
                     break;
             } //end switch

--- a/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
+++ b/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
@@ -170,7 +170,7 @@ class Service extends AbstractService
 
     private function handleResponse(ResponseInterface $result)
     {
-        $responseBody = json_decode($result->getBody(), true);
+        $responseBody = json_decode($result->getBody()->getContents(), true);
 
         if (is_null($responseBody)) {
             return null;

--- a/service-api/module/Application/src/Model/Service/Seed/Service.php
+++ b/service-api/module/Application/src/Model/Service/Seed/Service.php
@@ -28,11 +28,6 @@ class Service extends AbstractService
     {
         $lpa = $this->getLpa($lpaId);
 
-        if (!is_int($lpa->seed)) {
-            return new Entity(null);
-        }
-
-        //  TODO - Change this to just use the getLpa method in the parent abstract controller?
         $lpaEntity = $this->applicationsService->fetch($lpa->seed, $userId);
 
         if (!($lpaEntity instanceof DataModelEntity)) {
@@ -42,9 +37,8 @@ class Service extends AbstractService
         /** @var Lpa $seedLpa */
         $seedLpa = $lpaEntity->getData();
 
-        //  Should need to check this, but just to be safe...
         if ($seedLpa->user != $lpa->user) {
-            return new ApiProblem(400, 'Invalid LPA identifier to seed from');
+            return new ApiProblem(400, 'LPA user does not match fetched LPA\'s user');
         }
 
         return new Entity($seedLpa);

--- a/service-api/module/Application/src/Model/Service/ServiceAbstractFactory.php
+++ b/service-api/module/Application/src/Model/Service/ServiceAbstractFactory.php
@@ -76,14 +76,20 @@ class ServiceAbstractFactory implements AbstractFactoryInterface
      * @param ContainerInterface $container
      * @param string $requestedName
      * @param array|null $options
-     * @return mixed
+     * @return object
      * @throws ApiProblemException
      * @throws Exception
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         if (!$this->canCreate($container, $requestedName)) {
-            throw new Exception(sprintf('Abstract factory %s can not create the requested service %s', get_class($this), $requestedName));
+            throw new Exception(
+                sprintf(
+                    'Abstract factory %s can not create the requested service %s',
+                    get_class($this),
+                    $requestedName
+                )
+            );
         }
 
         // Use custom factory method for AuthenticationService;
@@ -91,8 +97,7 @@ class ServiceAbstractFactory implements AbstractFactoryInterface
         // service-api/module/Application/src/Module.php
         if ($requestedName === 'Application\Model\Service\Authentication\Service') {
             $service = $container->get('AppAuthenticationService');
-        }
-        else {
+        } else {
             $service = new $requestedName();
         }
 
@@ -117,19 +122,32 @@ class ServiceAbstractFactory implements AbstractFactoryInterface
             }
 
             if (in_array(ApplicationRepository\ApplicationRepositoryTrait::class, $traitsUsed)) {
-                $service->setApplicationRepository($container->get(ApplicationRepository\ApplicationRepositoryInterface::class));
+                $service->setApplicationRepository(
+                    $container->get(ApplicationRepository\ApplicationRepositoryInterface::class)
+                );
             }
 
             if (in_array(FeedbackRepository\FeedbackRepositoryTrait::class, $traitsUsed)) {
-                $service->setFeedbackRepository($container->get(FeedbackRepository\FeedbackRepositoryInterface::class));
+                $service->setFeedbackRepository(
+                    $container->get(FeedbackRepository\FeedbackRepositoryInterface::class)
+                );
             }
         }
 
         //  If required load any additional services into the service
-        if (array_key_exists($requestedName, $this->additionalServices) && is_array($this->additionalServices[$requestedName])) {
+        if (
+            array_key_exists($requestedName, $this->additionalServices) &&
+            is_array($this->additionalServices[$requestedName])
+        ) {
             foreach ($this->additionalServices[$requestedName] as $setterMethod => $additionalService) {
                 if (!method_exists($service, $setterMethod)) {
-                    throw new Exception(sprintf('The setter method %s does not exist on the requested service %s', $setterMethod, $requestedName));
+                    throw new Exception(
+                        sprintf(
+                            'The setter method %s does not exist on the requested service %s',
+                            $setterMethod,
+                            $requestedName
+                        )
+                    );
                 }
 
                 $service->$setterMethod($container->get($additionalService));

--- a/service-api/module/Application/src/Model/Service/System/Stats.php
+++ b/service-api/module/Application/src/Model/Service/System/Stats.php
@@ -32,7 +32,7 @@ class Stats extends AbstractService
     /**
      * @return bool
      */
-    public function generate()
+    public function generate(): bool
     {
         $stats = [];
 
@@ -105,8 +105,6 @@ class Stats extends AbstractService
 
         // Add the new data
         $this->getStatsRepository()->insert($stats);
-
-        //---
 
         return true;
     }

--- a/service-api/module/Application/src/Model/Service/Users/Service.php
+++ b/service-api/module/Application/src/Model/Service/Users/Service.php
@@ -3,7 +3,6 @@
 namespace Application\Model\Service\Users;
 
 use ArrayObject;
-
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Library\DateTime;
 use Application\Model\DataAccess\Repository\User\LogRepositoryTrait;
@@ -62,7 +61,7 @@ class Service extends AbstractService
             // Use base62 for shorter tokens
             $activationToken = BigInteger::factory('bcmath')->baseConvert($activationToken, 16, 62);
 
-            $created = (bool)$this->getUserRepository()->create($userId, [
+            $created = $this->getUserRepository()->create($userId, [
                 'identity'              => $username,
                 'active'                => false,
                 'activation_token'      => $activationToken,
@@ -251,7 +250,8 @@ class Service extends AbstractService
     /**
      * @param string $query to match against username
      * @param array $options See UserData.matchUsers()
-     * @return array of arrays (each subarray derived from a UserModel instance)
+     * @return ArrayObject<mixed, mixed> Array of arrays;
+     *     each subarray derived from a UserModel instance
      */
     public function matchUsers(string $query, array $options = [])
     {

--- a/service-api/module/Application/src/Module.php
+++ b/service-api/module/Application/src/Module.php
@@ -29,7 +29,7 @@ use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 
 class Module
 {
-    const VERSION = '3.0.3-dev';
+    public const VERSION = '3.0.3-dev';
 
     public function onBootstrap(MvcEvent $e)
     {
@@ -41,7 +41,7 @@ class Module
 
         if (!$request instanceof ConsoleRequest) {
             // Setup authentication listener...
-            $eventManager->attach(MvcEvent::EVENT_ROUTE, [new AuthenticationListener, 'authenticate'], 500);
+            $eventManager->attach(MvcEvent::EVENT_ROUTE, [new AuthenticationListener(), 'authenticate'], 500);
 
             // Register error handler for dispatch and render errors;
             // priority is set to 100 here so that the global MvcEventListener
@@ -92,7 +92,8 @@ class Module
                     }
 
                     $dbconf = $config['db']['postgres']['default'];
-                    $dsn = "{$dbconf['adapter']}:host={$dbconf['host']};port={$dbconf['port']};dbname={$dbconf['dbname']}";
+                    $dsn = "{$dbconf['adapter']}:host={$dbconf['host']};" .
+                        "port={$dbconf['port']};dbname={$dbconf['dbname']}";
 
                     return new ZendDbAdapter([
                         'dsn' => $dsn,
@@ -154,7 +155,7 @@ class Module
             ], // factories
 
         ];
-    } // function
+    }
 
     public function getConfig()
     {
@@ -165,10 +166,12 @@ class Module
      * Listen for and catch ApiProblemExceptions. Convert them to a standard ApiProblemResponse.
      *
      * @param MvcEvent $e
-     * @return ApiProblemResponse
+     * @return ApiProblemResponse|null
      */
     public function handleError(MvcEvent $e)
     {
+        $response = null;
+
         // Marshall an ApiProblem and view model based on the exception
         $exception = $e->getParam('exception');
 
@@ -179,8 +182,8 @@ class Module
             $e->stopPropagation();
             $response = new ApiProblemResponse($problem);
             $e->setResponse($response);
-
-            return $response;
         }
+
+        return $response;
     }
 }

--- a/service-api/module/Application/tests/Bootstrap.php
+++ b/service-api/module/Application/tests/Bootstrap.php
@@ -2,7 +2,7 @@
 
 date_default_timezone_set('UTC');
 
-error_reporting(E_ALL & ~ (E_DEPRECATED|E_USER_DEPRECATED));
+error_reporting(E_ALL & ~ (E_DEPRECATED | E_USER_DEPRECATED));
 
 /**
  * Simple autoloader function to dynamically load
@@ -14,11 +14,18 @@ spl_autoload_register(function ($class) {
     $baseDirs = [
         __DIR__ . '/',
         __DIR__ . '/../src/',
+        __DIR__ . '/../../../../shared/logging/module/MakeLogger/src/',
     ];
 
     //  Strip out any leading "ApplicationTest" if present
     if (strpos($class, 'ApplicationTest\\') === 0) {
         $class = str_replace('ApplicationTest\\', '', $class);
+    }
+
+    // Replace MakeLogger\Logging with Logging; this is so we can load
+    // files from the top-level shared
+    if (strpos($class, 'MakeLogger\\Logging') !== -1) {
+        $class = str_replace('MakeLogger\\Logging', '\\Logging', $class);
     }
 
     //  Loop through the base directories to try to find the requested class

--- a/service-api/module/Application/tests/Command/AccountCleanupCommandTest.php
+++ b/service-api/module/Application/tests/Command/AccountCleanupCommandTest.php
@@ -14,7 +14,7 @@ class AccountCleanupCommandTest extends MockeryTestCase
     public function testAccountCleanupCommandSuccess()
     {
         $cleanUpService = Mockery::mock(AccountCleanupService::class);
-        $cleanUpService->shouldReceive('cleanup')->andReturnNull();
+        $cleanUpService->shouldReceive('cleanup')->andReturn(0);
 
         $input = Mockery::mock(InputInterface::class);
         $output = Mockery::mock(OutputInterface::class);
@@ -24,6 +24,6 @@ class AccountCleanupCommandTest extends MockeryTestCase
 
         $result = $command->execute($input, $output);
 
-        $this->assertNull($result);
+        $this->assertEquals(0, $result);
     }
 }

--- a/service-api/module/Application/tests/Command/GenerateStatsCommandTest.php
+++ b/service-api/module/Application/tests/Command/GenerateStatsCommandTest.php
@@ -14,7 +14,7 @@ class GenerateStatsCommandTest extends MockeryTestCase
     public function testExecuteSuccess()
     {
         $statsService = Mockery::mock(StatsService::class);
-        $statsService->shouldReceive('generate')->andReturnNull();
+        $statsService->shouldReceive('generate')->andReturn(true);
 
         $input = Mockery::mock(InputInterface::class);
         $output = Mockery::mock(OutputInterface::class);
@@ -24,6 +24,6 @@ class GenerateStatsCommandTest extends MockeryTestCase
 
         $result = $command->execute($input, $output);
 
-        $this->assertNull($result);
+        $this->assertEquals(0, $result);
     }
 }

--- a/service-api/module/Application/tests/Library/ApiProblem/ValidationApiProblemTest.php
+++ b/service-api/module/Application/tests/Library/ApiProblem/ValidationApiProblemTest.php
@@ -8,7 +8,7 @@ use Opg\Lpa\DataModel\Validator\ValidatorResponseInterface;
 
 class ValidationApiProblemTest extends MockeryTestCase
 {
-    public function testConstructor() : void
+    public function testConstructor(): void
     {
         $validatorResponse = Mockery::mock(ValidatorResponseInterface::class);
         $validatorResponse->shouldReceive('getArrayCopy')->andReturn(['some error'])->once();
@@ -16,9 +16,18 @@ class ValidationApiProblemTest extends MockeryTestCase
         $validationApiProblem = new TestableValidationApiProblem($validatorResponse);
 
         $this->assertEquals(400, $validationApiProblem->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationApiProblem->getDetail());
+        $this->assertEquals(
+            'Your request could not be processed due to validation error',
+            $validationApiProblem->getDetail()
+        );
         $this->assertEquals('Bad Request', $validationApiProblem->getTitle());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationApiProblem->getType());
+        $this->assertEquals(
+            'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+            $validationApiProblem->getType()
+        );
+
+        print_r($validationApiProblem->getAdditionalDetails());
+
         $this->assertEquals(['validation' => ['some error']], $validationApiProblem->getAdditionalDetails());
     }
 }

--- a/service-api/module/Application/tests/Model/DataAccess/Postgres/UserDataTest.php
+++ b/service-api/module/Application/tests/Model/DataAccess/Postgres/UserDataTest.php
@@ -114,10 +114,16 @@ class UserDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             ->andReturn($sqlMock);
 
         $sqlMock->shouldReceive('select')
+            ->andReturn($sqlMock);
+
+        $sqlMock->shouldReceive('from')
             ->with(['a' => ApplicationData::APPLICATIONS_TABLE])
             ->andReturn($subselectMock);
 
         $sqlMock->shouldReceive('select')
+            ->andReturn($sqlMock);
+
+        $sqlMock->shouldReceive('from')
             ->with(['u' => UserData::USERS_TABLE])
             ->andReturn($selectMock);
 

--- a/service-api/module/Application/tests/Model/Service/AccountCleanup/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/AccountCleanup/ServiceTest.php
@@ -73,7 +73,7 @@ class ServiceTest extends AbstractServiceTest
      */
     private $logger;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -94,7 +94,11 @@ class ServiceTest extends AbstractServiceTest
         $this->setAccountsExpectations();
 
         $this->notifyClient->shouldReceive('sendEmail')
-            ->with(Mockery::type('string'), AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE, Mockery::type('array'))
+            ->with(
+                Mockery::type('string'),
+                AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE,
+                Mockery::type('array')
+            )
             // Should be called once per admin email address.
             ->times(count($this->config['admin']['account_cleanup_notification_recipients']));
 
@@ -138,7 +142,7 @@ class ServiceTest extends AbstractServiceTest
         $result = $service->cleanup();
 
         // Function doesn't return anything
-        $this->assertEquals(null, $result);
+        $this->assertEquals(1, $result);
     }
 
     public function testCleanupExpiredAccounts()
@@ -146,7 +150,11 @@ class ServiceTest extends AbstractServiceTest
         $this->setAccountsExpectations([new User(['id' => 1])]);
 
         $this->notifyClient->shouldReceive('sendEmail')
-            ->with(Mockery::type('string'), AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE, Mockery::type('array'));
+            ->with(
+                Mockery::type('string'),
+                AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE,
+                Mockery::type('array')
+            );
 
         $this->usersService->shouldReceive('delete')
             ->withArgs([1, 'expired']);
@@ -180,7 +188,11 @@ class ServiceTest extends AbstractServiceTest
         $this->setAccountsExpectations([new User(['id' => 1])]);
 
         $this->notifyClient->shouldReceive('sendEmail')
-            ->with(Mockery::type('string'), AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE, Mockery::type('array'));
+            ->with(
+                Mockery::type('string'),
+                AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE,
+                Mockery::type('array')
+            );
 
         $this->usersService->shouldReceive('delete')
             ->withArgs([1, 'expired']);
@@ -220,7 +232,11 @@ class ServiceTest extends AbstractServiceTest
         ])]);
 
         $this->notifyClient->shouldReceive('sendEmail')
-            ->with(Mockery::type('string'), AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE, Mockery::type('array'));
+            ->with(
+                Mockery::type('string'),
+                AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE,
+                Mockery::type('array')
+            );
 
         $lastLoginDate->add(DateInterval::createFromDateString('+9 months'));
 
@@ -259,7 +275,11 @@ class ServiceTest extends AbstractServiceTest
         ])]);
 
         $this->notifyClient->shouldReceive('sendEmail')
-            ->with(Mockery::type('string'), AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE, Mockery::type('array'));
+            ->with(
+                Mockery::type('string'),
+                AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE,
+                Mockery::type('array')
+            );
 
         $this->notifyClient->shouldReceive('sendEmail')
             ->once()
@@ -297,7 +317,11 @@ class ServiceTest extends AbstractServiceTest
         ])]);
 
         $this->notifyClient->shouldReceive('sendEmail')
-            ->with(Mockery::type('string'), AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE, Mockery::type('array'));
+            ->with(
+                Mockery::type('string'),
+                AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE,
+                Mockery::type('array')
+            );
 
         $this->notifyClient->shouldReceive('sendEmail')
             ->once()
@@ -337,7 +361,11 @@ class ServiceTest extends AbstractServiceTest
         ])]);
 
         $this->notifyClient->shouldReceive('sendEmail')
-            ->with(Mockery::type('string'), AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE, Mockery::type('array'));
+            ->with(
+                Mockery::type('string'),
+                AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE,
+                Mockery::type('array')
+            );
 
         $lastLoginDate->add(DateInterval::createFromDateString('+9 months'));
 
@@ -372,7 +400,11 @@ class ServiceTest extends AbstractServiceTest
         $this->setAccountsExpectations([], [], [], [new User(['id' => 1])]);
 
         $this->notifyClient->shouldReceive('sendEmail')
-            ->with(Mockery::type('string'), AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE, Mockery::type('array'));
+            ->with(
+                Mockery::type('string'),
+                AccountCleanupService::CLEANUP_NOTIFICATION_TEMPLATE,
+                Mockery::type('array')
+            );
 
         $this->usersService->shouldReceive('delete')
             ->withArgs([1, 'unactivated']);
@@ -393,8 +425,12 @@ class ServiceTest extends AbstractServiceTest
         $this->assertEquals(null, $result);
     }
 
-    private function setAccountsExpectations(array $expiredAccounts = [], array $oneWeekWarningAccounts = [], array $oneMonthWarningAccounts = [], array $unactivatedAccounts = [])
-    {
+    private function setAccountsExpectations(
+        array $expiredAccounts = [],
+        array $oneWeekWarningAccounts = [],
+        array $oneMonthWarningAccounts = [],
+        array $unactivatedAccounts = []
+    ) {
         $this->authUserRepository->shouldReceive('getAccountsInactiveSince')
             ->withArgs(function ($lastLoginBefore) {
                 return $lastLoginBefore < new DateTime('-9 months +1 week')

--- a/service-api/module/Application/tests/Model/Service/Applications/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Applications/ServiceTest.php
@@ -9,7 +9,7 @@ use Application\Library\DateTime;
 use Application\Model\Service\Applications\Collection;
 use Application\Model\Service\DataModelEntity;
 use ApplicationTest\Model\Service\AbstractServiceTest;
-use \EmptyIterator;
+use EmptyIterator;
 use Mockery\MockInterface;
 use Opg\Lpa\DataModel\Lpa\Document\Document;
 use Opg\Lpa\DataModel\Lpa\Formatter;
@@ -30,7 +30,7 @@ class ServiceTest extends AbstractServiceTest
      */
     private $service;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -622,14 +622,14 @@ class ServiceTest extends AbstractServiceTest
         $this->assertEquals(0, $response->count());
     }
 
-    public function testFilterByIdsAndUser_ApplicationRepositoryReturnsEmptyIterator()
+    public function testFilterByIdsAndUserApplicationRepositoryReturnsEmptyTraversable()
     {
         $lpaIds = ['1234', '5678'];
         $userId = 'user1';
 
         $this->applicationRepository->shouldReceive('getByIdsAndUser')
             ->withArgs([$lpaIds, $userId])
-            ->andReturn([]);
+            ->andReturn(new \ArrayObject());
 
         $serviceBuilder = new ServiceBuilder();
         $service = $serviceBuilder
@@ -641,7 +641,7 @@ class ServiceTest extends AbstractServiceTest
         $this->assertEquals([], $response);
     }
 
-    public function testFilterByIdsAndUser_ApplicationRepositoryReturnsLpas()
+    public function testFilterByIdsAndUserApplicationRepositoryReturnsLpas()
     {
         $lpaIds = ['1234', '5678'];
         $userId = 'user1';
@@ -650,7 +650,7 @@ class ServiceTest extends AbstractServiceTest
 
         $this->applicationRepository->shouldReceive('getByIdsAndUser')
             ->withArgs([$lpaIds, $userId])
-            ->andReturn([$hwLpa->toArray(), $pfLpa->toArray()]);
+            ->andReturn(new \ArrayObject([$hwLpa->toArray(), $pfLpa->toArray()]));
 
         $serviceBuilder = new ServiceBuilder();
         $service = $serviceBuilder
@@ -710,7 +710,6 @@ class ServiceTest extends AbstractServiceTest
         $this->applicationRepository->shouldReceive('update')
             ->once()
             ->andReturnUsing(function (Lpa $lpaIn) use ($existingLpa) {
-
                 $updateTimestamp = true;
                 if (!is_null($existingLpa)) {
                     $updateTimestamp = !$lpaIn->equalsIgnoreMetadata($existingLpa);
@@ -776,8 +775,7 @@ class ServiceTest extends AbstractServiceTest
             ->andReturn($lpasCount);
 
         if ($lpasCount > 0) {
-
-            $lpasArray = array_map(function (Lpa $lpa){
+            $lpasArray = array_map(function (Lpa $lpa) {
                 return $lpa->toArray();
             }, $lpas);
 

--- a/service-api/module/Application/tests/Model/Service/Seed/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Seed/ServiceTest.php
@@ -71,7 +71,7 @@ class ServiceTest extends AbstractServiceTest
 
         $this->assertTrue($entity instanceof ApiProblem);
         $this->assertEquals(400, $entity->getStatus());
-        $this->assertEquals('Invalid LPA identifier to seed from', $entity->getDetail());
+        $this->assertEquals('LPA user does not match fetched LPA\'s user', $entity->getDetail());
 
         $serviceBuilder->verify();
     }

--- a/service-api/psalm.xml
+++ b/service-api/psalm.xml
@@ -7,6 +7,7 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
+        <directory name="../shared/logging/module/MakeLogger/src" />
         <directory name="module/Application/src" />
         <ignoreFiles>
             <directory name="vendor" />

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.2.12 AS composer
+FROM composer:2.3 AS composer
 
 RUN adduser -D -g '' appuser
 
@@ -7,7 +7,7 @@ COPY --chown=appuser:appuser service-front/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:8.0-fpm-alpine
+FROM php:8.0-fpm-alpine3.15
 
 RUN adduser -D -g '' appuser
 #docker image on hub hasn't been upgraded yet - fixes CVE-2021-36159

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.2.12 AS composer
+FROM composer:2.3 AS composer
 
 RUN adduser -D -g '' appuser
 
@@ -7,7 +7,7 @@ COPY --chown=appuser:appuser service-pdf/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:8.0-cli-alpine
+FROM php:8.0-cli-alpine3.15
 
 RUN adduser -D -g '' appuser
 

--- a/shared/logging/module/MakeLogger/src/Logging/ErrorEventListener.php
+++ b/shared/logging/module/MakeLogger/src/Logging/ErrorEventListener.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace MakeLogger\Logging;
 
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\AbstractListenerAggregate;
 use Laminas\EventManager\Event;
 use Laminas\Mvc\MvcEvent;
-
 use MakeLogger\Logging\LoggerTrait;
 use MakeLogger\Logging\MvcEventProcessor;
 
@@ -18,7 +18,7 @@ class ErrorEventListener extends AbstractListenerAggregate
 
     /**
      * Magic method so this class can be its own factory
-     * @return EventLogger
+     * @return ErrorEventListener
      */
     public function __invoke(): self
     {

--- a/shared/logging/module/MakeLogger/src/Logging/HeadersProcessor.php
+++ b/shared/logging/module/MakeLogger/src/Logging/HeadersProcessor.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MakeLogger\Logging;
 
 use Laminas\Log\Processor\ProcessorInterface;
@@ -18,7 +19,7 @@ use Laminas\Log\Processor\ProcessorInterface;
  *    $this->getLogger()->err('an error', ['headers' => $headers]);
  *
  * This sets $extra to ['headers' => $headers], and this processor will receive
- * a $logEvent like:
+ * a $event like:
  *
  *     ['extra' => ['headers' => $headers]]
  *
@@ -48,14 +49,14 @@ class HeadersProcessor implements ProcessorInterface
 
     public const HEADERS_TO_STRIP = ['cookie', 'authorization', '_ga', '_gid', 'token'];
 
-    public function process(array $logEvent): array
+    public function process(array $event): array
     {
         // early return if there's no "headers" in $extra
-        if (!isset($logEvent['extra'][self::HEADERS_FIELD_NAME])) {
-            return $logEvent;
+        if (!isset($event['extra'][self::HEADERS_FIELD_NAME])) {
+            return $event;
         }
 
-        $headers = $logEvent['extra'][self::HEADERS_FIELD_NAME];
+        $headers = $event['extra'][self::HEADERS_FIELD_NAME];
 
         // headers; filter out any which potentially contain private data
         // and promote X-Trace-Id to top level property in $extra
@@ -70,8 +71,8 @@ class HeadersProcessor implements ProcessorInterface
         }
 
         // set fixed headers on $extra
-        $logEvent['extra'][self::HEADERS_FIELD_NAME] = $headersArray;
+        $event['extra'][self::HEADERS_FIELD_NAME] = $headersArray;
 
-        return $logEvent;
+        return $event;
     }
 }

--- a/shared/logging/module/MakeLogger/src/Logging/Logger.php
+++ b/shared/logging/module/MakeLogger/src/Logging/Logger.php
@@ -5,9 +5,11 @@ namespace MakeLogger\Logging;
 use Laminas\Log\Logger as LaminasLogger;
 use Laminas\Log\Writer\Stream as StreamWriter;
 use Laminas\Log\Formatter\Json as JsonFormatter;
+use Laminas\Stdlib\ArrayUtils;
 use MakeLogger\Logging\MvcEventProcessor;
 use MakeLogger\Logging\HeadersProcessor;
 use MakeLogger\Logging\TraceIdProcessor;
+use Traversable;
 
 /**
  * class Logger
@@ -39,11 +41,13 @@ class Logger extends LaminasLogger
      */
     public function log($priority, $message, $extra = [])
     {
-        $extra = array($extra);
+        if ($extra instanceof Traversable) {
+            $extra = ArrayUtils::iteratorToArray($extra);
+        }
 
         // HACK - get the X-Trace-Id direct from the $_SERVER global
         // if it is set
-        if (array_key_exists(TraceIdProcessor::X_TRACE_ID_HEADER_NAME, array($_SERVER))) {
+        if (array_key_exists(TraceIdProcessor::X_TRACE_ID_HEADER_NAME, $_SERVER)) {
             $extra[TraceIdProcessor::TRACE_ID_FIELD_NAME] =
                 $_SERVER[TraceIdProcessor::X_TRACE_ID_HEADER_NAME];
         }

--- a/shared/logging/module/MakeLogger/src/Logging/Logger.php
+++ b/shared/logging/module/MakeLogger/src/Logging/Logger.php
@@ -5,7 +5,6 @@ namespace MakeLogger\Logging;
 use Laminas\Log\Logger as LaminasLogger;
 use Laminas\Log\Writer\Stream as StreamWriter;
 use Laminas\Log\Formatter\Json as JsonFormatter;
-
 use MakeLogger\Logging\MvcEventProcessor;
 use MakeLogger\Logging\HeadersProcessor;
 use MakeLogger\Logging\TraceIdProcessor;
@@ -17,9 +16,7 @@ use MakeLogger\Logging\TraceIdProcessor;
  */
 class Logger extends LaminasLogger
 {
-    /**
-     * @var Logger
-     */
+    /* @var Logger */
     public function __construct(StreamWriter $writer = null)
     {
         parent::__construct();
@@ -40,15 +37,17 @@ class Logger extends LaminasLogger
      * Override the log() method to allow us to append a trace_id field into
      * the $extra argument.
      */
-    public function log($priority, $msg, $extra = [])
+    public function log($priority, $message, $extra = [])
     {
+        $extra = array($extra);
+
         // HACK - get the X-Trace-Id direct from the $_SERVER global
         // if it is set
-        if (isset($_SERVER[TraceIdProcessor::X_TRACE_ID_HEADER_NAME])) {
+        if (array_key_exists(TraceIdProcessor::X_TRACE_ID_HEADER_NAME, array($_SERVER))) {
             $extra[TraceIdProcessor::TRACE_ID_FIELD_NAME] =
                 $_SERVER[TraceIdProcessor::X_TRACE_ID_HEADER_NAME];
         }
 
-        parent::log($priority, $msg, $extra);
+        return parent::log($priority, $message, $extra);
     }
 }

--- a/shared/logging/module/MakeLogger/src/Logging/MvcEventProcessor.php
+++ b/shared/logging/module/MakeLogger/src/Logging/MvcEventProcessor.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MakeLogger\Logging;
 
 use Laminas\Mvc\MvcEvent;
@@ -23,32 +24,34 @@ class MvcEventProcessor implements ProcessorInterface
      */
     public const EVENT_FIELD_NAME = 'event';
 
-    public function process(array $logEvent): array
+    public function process(array $event): array
     {
         // early return if there's no "event" in $extra
-        if (!isset($logEvent['extra'][self::EVENT_FIELD_NAME]) ||
-        !($logEvent['extra'][self::EVENT_FIELD_NAME] instanceof MvcEvent)) {
-            return $logEvent;
+        if (
+            !isset($event['extra'][self::EVENT_FIELD_NAME]) ||
+            !($event['extra'][self::EVENT_FIELD_NAME] instanceof MvcEvent)
+        ) {
+            return $event;
         }
 
         // pick apart the log event
-        $laminasEvent = $logEvent['extra'][self::EVENT_FIELD_NAME];
+        $laminasEvent = $event['extra'][self::EVENT_FIELD_NAME];
         $req = $laminasEvent->getRequest();
 
         // raw headers
-        $logEvent['extra']['headers'] = $req->getHeaders()->toArray();
+        $event['extra']['headers'] = $req->getHeaders()->toArray();
 
         // other request data
-        $logEvent['extra']['request_uri'] = $req->getUriString();
-        $logEvent['extra']['request_method'] = $req->getMethod();
+        $event['extra']['request_uri'] = $req->getUriString();
+        $event['extra']['request_method'] = $req->getMethod();
 
         // event source controller
-        $logEvent['extra']['controller'] = $laminasEvent->getController();
+        $event['extra']['controller'] = $laminasEvent->getController();
 
         // exception (if present)
         $exception = $laminasEvent->getParam('exception');
-        if ($exception != NULL) {
-            $logEvent['extra']['exception'] = [
+        if ($exception != null) {
+            $event['extra']['exception'] = [
                 'message' => $exception->getMessage(),
                 'file' => $exception->getFile(),
                 'line' => $exception->getLine(),
@@ -58,12 +61,12 @@ class MvcEventProcessor implements ProcessorInterface
 
         // error (if present)
         if ($laminasEvent->isError()) {
-            $logEvent['extra']['errorMessage'] = $laminasEvent->getError();
+            $event['extra']['errorMessage'] = $laminasEvent->getError();
         }
 
         // remove the event we've now decomposed
-        unset($logEvent['extra'][self::EVENT_FIELD_NAME]);
+        unset($event['extra'][self::EVENT_FIELD_NAME]);
 
-        return $logEvent;
+        return $event;
     }
 }

--- a/shared/logging/module/MakeLogger/src/Logging/TraceIdProcessor.php
+++ b/shared/logging/module/MakeLogger/src/Logging/TraceIdProcessor.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MakeLogger\Logging;
 
 use Laminas\Log\Processor\ProcessorInterface;
@@ -20,21 +21,21 @@ class TraceIdProcessor implements ProcessorInterface
      */
     public const TRACE_ID_FIELD_NAME = 'trace_id';
 
-    public function process(array $logEvent): array
+    public function process(array $event): array
     {
         // early return if there's no "trace_id" in $extra
-        if (!array_key_exists(self::TRACE_ID_FIELD_NAME, $logEvent['extra'])) {
-            return $logEvent;
+        if (!array_key_exists(self::TRACE_ID_FIELD_NAME, $event['extra'])) {
+            return $event;
         }
 
-        $traceId = $logEvent['extra'][self::TRACE_ID_FIELD_NAME];
+        $traceId = $event['extra'][self::TRACE_ID_FIELD_NAME];
 
         if (!is_null($traceId)) {
-            $logEvent['trace_id'] = $traceId;
+            $event['trace_id'] = $traceId;
         }
 
-        unset($logEvent['extra'][self::TRACE_ID_FIELD_NAME]);
+        unset($event['extra'][self::TRACE_ID_FIELD_NAME]);
 
-        return $logEvent;
+        return $event;
     }
 }

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,11 +1,11 @@
-FROM composer:2.3.5 AS composer
+FROM composer:2.3 AS composer
 
 COPY tests/composer.json /app/composer.json
 COPY tests/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:8.1.2-cli
+FROM php:8.0-cli-alpine3.15
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=linux
@@ -22,7 +22,6 @@ RUN apt-get update && \
 
 RUN docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
   docker-php-ext-install -j$(nproc) imap
-
 
 # The bitbucket location gives occasional "403 Forbidden" errors, breaking the build, so we're using our own source instead
 #ADD https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 /tmp/phantomjs.tar.bz2

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,7 +5,7 @@ COPY tests/composer.lock /app/composer.lock
 
 RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM php:8.0-cli-alpine3.15
+FROM php:8.0-cli
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=linux


### PR DESCRIPTION
## Purpose

Fixes [LPAL-447](https://opgtransform.atlassian.net/browse/LPAL-447)

## Approach

I decided it made sense to lint service-api using PHP 8.1, so that's what I did.

This PR covers both service-api linting with psalm (to level 4) and upgrading it to PHP 8.1.

I also made sure that our other components were all on PHP 8.0 and composer 2.3, so we have a consistent base to start from for subsequent linting and upgrades.

This also entailed some code changes in opg-lpa-datamodels, made in that repo.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [x] The product team have tested these changes
