### PR TITLE
LPAL-550 LPA deletion status

### DIFF
--- a/cypress/integration/Statuses.feature
+++ b/cypress/integration/Statuses.feature
@@ -46,6 +46,18 @@ Feature: Status display for LPAs
         # status date and Return - unpaid status on Sirius
         And the LPA with ID "15527329531" should display with status "Processed"
 
+        # Deleted from Sirius, status returns to waiting
+        And the LPA with ID "97998888883" should display with status "Waiting"
+
+    @focus
+    Scenario: An LPA which has been deleted from sirius will display as "Waiting" on its status page (LPAL-550)
+        Given I log in as appropriate test user
+        When I am taken to the dashboard page
+        And I click on the View "waiting" message link for LPA with ID "97998888883"
+        Then I am taken to the detail page for LPA with ID "97998888883"
+        And I see "A979 9888 8883" in the page text
+        And the LPA status is shown as "Waiting"
+
     @focus
     Scenario: The status message page for an LPA has the title "Status message" (LPAL-432)
         Given I log in as appropriate test user

--- a/cypress/integration/Statuses.feature
+++ b/cypress/integration/Statuses.feature
@@ -46,6 +46,9 @@ Feature: Status display for LPAs
         # status date and Return - unpaid status on Sirius
         And the LPA with ID "15527329531" should display with status "Processed"
 
+        # *no* status date and Return - unpaid status on Sirius
+        And the LPA with ID "13316443118" should display with status "Processed"
+
         # Deleted from Sirius, status returns to waiting
         And the LPA with ID "97998888883" should display with status "Waiting"
 
@@ -161,7 +164,7 @@ Feature: Status display for LPAs
         And the LPA status is shown as "Received"
 
     @focus
-    Scenario: An LPA which is received and is Payment Pending displays as "Processed" on its status page (LPAL-549)
+    Scenario: An LPA which is received and is Return - unpaid displays as "Processed" on its status page (LPAL-549)
         Given I log in as appropriate test user
         When I am taken to the dashboard page
         And I click on the View "processed" message link for LPA with ID "15527329531"
@@ -170,5 +173,18 @@ Feature: Status display for LPAs
         And the LPA status is shown as "Processed"
         And I do not see "donor and all attorneys on the LPA will get a letter" in the page text
 
-        # Return unpaid status was set on statusDate which becomes dispatch date of 27/02/20
+        # Return unpaid status was set on statusDate, which becomes dispatch date of 27/02/20
         And the date by which the LPA should be received is shown as "19/03/20"
+
+    @focus
+    Scenario: An LPA which is received and is Return - unpaid but has no status date displays as "Processed" on its status page (LPAL-550)
+        Given I log in as appropriate test user
+        When I am taken to the dashboard page
+        And I click on the View "processed" message link for LPA with ID "13316443118"
+        Then I am taken to the detail page for LPA with ID "13316443118"
+        And I see "A133 1644 3118" in the page text
+        And the LPA status is shown as "Processed"
+        And I do not see "donor and all attorneys on the LPA will get a letter" in the page text
+
+        # Return unpaid status was set but there's no statusDate
+        And the date by which the LPA should be received is shown as "15 working days"

--- a/cypress/integration/common/statuses.js
+++ b/cypress/integration/common/statuses.js
@@ -35,7 +35,7 @@ Then('the LPA status is shown as {string}', (expectedStatus) => {
 })
 
 Then('the date by which the LPA should be received is shown as {string}', (expectedDate) => {
-    cy.get('[data-cy=lpa-should-receive-by-date]').then((elt) => {
+    cy.get('[data-cy=lpa-should-receive]').then((elt) => {
         expect(elt.text()).to.eql(expectedDate);
     })
 })

--- a/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
+++ b/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
@@ -264,7 +264,13 @@ class Service extends AbstractService
 
             // We set a returnUnpaid as this is required to differentiate from returned
             if ($responseBody['status'] === 'Return - unpaid') {
-                $return['dispatchDate'] = $responseBody['statusDate'];
+                // statusDate should always be set, but put a guard on it so we can
+                // always have a dispatchDate set to null for the worst case
+                $return['dispatchDate'] = null;
+                if (isset($responseBody['statusDate'])) {
+                    $return['dispatchDate'] = $responseBody['statusDate'];
+                }
+
                 $return['returnUnpaid'] = true;
             }
 

--- a/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
+++ b/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
@@ -79,6 +79,8 @@ class Service extends AbstractService
         $requests = [];
         $siriusResponseArray = [];
 
+        $debugInfo = [];
+
         foreach ($ids as $id) {
             $prefixedId = $id;
 
@@ -87,6 +89,10 @@ class Service extends AbstractService
             }
 
             $url = new Uri($this->processingStatusServiceUri . $prefixedId);
+
+            $debugInfo[$id] = [];
+            $debugInfo[$id]['url'] = '' . $url;
+
             $requests[$id] = new Request('GET', $url, $this->buildHeaders());
             $requests[$id] = $this->awsSignature->signRequest($requests[$id], $this->credentials);
         } //end of request loop
@@ -102,7 +108,6 @@ class Service extends AbstractService
             'fulfilled' => function ($response, $id) use (&$results) {
                 // Each successful response
                 $this->getLogger()->debug('We have a result for:' . $id);
-
                 $results[$id] = $response;
             },
             'rejected' => function ($reason, $id) {
@@ -154,7 +159,19 @@ class Service extends AbstractService
                     );
                     break;
             } //end switch
+
+            if (isset($siriusResponseArray[$lpaId])) {
+                $debugInfo[$lpaId]['response'] = $siriusResponseArray[$lpaId];
+            } else {
+                $debugInfo[$lpaId]['response'] = 'BAD RESPONSE';
+            }
         } //end for
+
+        $this->getLogger()->debug(
+            "++++++++++++++++ JSON LPA STATUS RESPONSES: " .
+            json_encode($debugInfo)
+        );
+
         return $siriusResponseArray;
     }
 

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/StatusControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/StatusControllerTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace ApplicationTest\Controller\Version2\Lpa;
 
 use Application\Controller\StatusController;
@@ -45,8 +44,12 @@ class StatusControllerTest extends AbstractControllerTest
         $this->processingStatusService = Mockery::mock(ProcessingStatusService::class);
         $this->config = ['track-from-date' => '2019-01-01'];
 
-        $this->statusController = new StatusController($this->authorizationService,
-            $this->applicationsService, $this->processingStatusService, $this->config);
+        $this->statusController = new StatusController(
+            $this->authorizationService,
+            $this->applicationsService,
+            $this->processingStatusService,
+            $this->config
+        );
     }
 
     public function testGetWithFirstUpdateOnValidCase()
@@ -67,7 +70,11 @@ class StatusControllerTest extends AbstractControllerTest
             ->andReturn([
                 '98765' => [
                     'deleted'   => false,
-                    'response'  => ['status' => 'Processed' , 'rejectedDate' => new DateTime('2019-02-11'), 'returnUnpaid' => null]
+                    'response'  => [
+                        'status' => 'Processed',
+                        'rejectedDate' => new DateTime('2019-02-11'),
+                        'returnUnpaid' => null
+                    ]
                 ]
             ]);
 
@@ -118,7 +125,11 @@ class StatusControllerTest extends AbstractControllerTest
             ->andReturn([
                 '98765' => [
                     'deleted'   => false,
-                    'response'  => ['status' => 'Checking' , 'receiptDate' => new DateTime('2019-02-11'), 'returnUnpaid' => null]
+                    'response'  => [
+                        'status' => 'Checking',
+                        'receiptDate' => new DateTime('2019-02-11'),
+                        'returnUnpaid' => null
+                    ]
                 ]
             ]);
 
@@ -184,7 +195,11 @@ class StatusControllerTest extends AbstractControllerTest
             ->andReturn([
                 '98765' => [
                     'deleted'   => false,
-                    'response'  => ['status' => 'Received' , 'receiptDate' => new DateTime('2019-02-11'), 'returnUnpaid' => null]
+                    'response'  => [
+                        'status' => 'Received',
+                        'receiptDate' => new DateTime('2019-02-11'),
+                        'returnUnpaid' => null
+                    ]
                 ]
             ]);
 
@@ -220,7 +235,11 @@ class StatusControllerTest extends AbstractControllerTest
             ->andReturn([
                 '98765' => [
                     'deleted'   => false,
-                    'response'  => ['status' => 'Checking' , 'registrationDate' => new DateTime('2019-02-11'), 'returnUnpaid' => null]
+                    'response'  => [
+                        'status' => 'Checking',
+                        'registrationDate' => new DateTime('2019-02-11'),
+                        'returnUnpaid' => null
+                    ]
                 ]
             ]);
 
@@ -330,7 +349,11 @@ class StatusControllerTest extends AbstractControllerTest
             ->andReturn([
                 '98765' => [
                     'deleted'   => false,
-                    'response'  => ['status' => 'Checking' , 'receiptDate' => new DateTime('2019-02-11'), 'returnUnpaid' => null]
+                    'response'  => [
+                        'status' => 'Checking',
+                        'receiptDate' => new DateTime('2019-02-11'),
+                        'returnUnpaid' => null
+                    ]
                 ]
             ]);
 
@@ -600,7 +623,10 @@ class StatusControllerTest extends AbstractControllerTest
             ->andReturn([
                 '98766' => [
                     'deleted'   => false,
-                    'response'  => ['status' => 'Processed','dispatchDate' => new DateTime('2019-02-15'), 'returnUnpaid' => true]
+                    'response'  => [
+                        'status' => 'Processed', 'dispatchDate' => new DateTime('2019-02-15'),
+                        'returnUnpaid' => true
+                    ]
                 ]
             ]);
         $this->applicationsService->shouldReceive('patch')->once();
@@ -854,6 +880,23 @@ class StatusControllerTest extends AbstractControllerTest
             ->once()
             ->andReturn([$lpa]);
 
+        $this->applicationsService->shouldReceive('patch')
+            ->withArgs([
+                [
+                    'metadata' => [
+                        'sirius-processing-status' => 'Waiting',
+                        'application-registration-date' => null,
+                        'application-receipt-date' => null,
+                        'application-rejected-date' => null,
+                        'application-invalid-date' => null,
+                        'application-withdrawn-date' => null,
+                        'application-dispatch-date' => null,
+                    ]
+                ],
+                '98765',
+                '12345'
+            ])->once();
+
         $this->processingStatusService->shouldReceive('getStatuses')
             ->once()
             ->andReturn([
@@ -867,7 +910,9 @@ class StatusControllerTest extends AbstractControllerTest
 
         $this->assertEquals(new Json([
             '98765' => [
-                'found' => false,
+                'found' => true,
+                'status' => 'Waiting',
+                'returnUnpaid' => null,
             ]]), $result);
     }
 }

--- a/service-front/module/Application/src/Controller/Authenticated/Lpa/StatusController.php
+++ b/service-front/module/Application/src/Controller/Authenticated/Lpa/StatusController.php
@@ -68,7 +68,10 @@ class StatusController extends AbstractLpaController
         // The "should receive by" date is set to a number of working days after the
         // $processedDate, defined in config
         $shouldReceiveByDate = null;
-        if (!is_null($processedDate) && isset($this->config()['processing-status']['expected-working-days-before-receipt'])) {
+        if (
+            !is_null($processedDate) &&
+            isset($this->config()['processing-status']['expected-working-days-before-receipt'])
+        ) {
             $days = intval($this->config()['processing-status']['expected-working-days-before-receipt']);
             $shouldReceiveByDate = new DateTime($processedDate);
             $interval = new DateInterval('P1D');

--- a/service-front/module/Application/src/Model/Service/Lpa/Application.php
+++ b/service-front/module/Application/src/Model/Service/Lpa/Application.php
@@ -60,11 +60,11 @@ class Application extends AbstractService implements ApiClientAwareInterface
             $result = $this->apiClient->httpGet($target);
         } catch (ApiException $ex) {
             $this->getLogger()->err($ex->getMessage());
-
             $result = null;
         }
 
-        // if an ApiException is returned, we set result to null and return found false for the id's
+        // if an ApiException is returned, we set result to null and
+        // return found => false for the ids
         if ($result == null) {
             $result = [];
 

--- a/service-front/module/Application/view/application/authenticated/dashboard/index.twig
+++ b/service-front/module/Application/view/application/authenticated/dashboard/index.twig
@@ -127,7 +127,7 @@
             // Get an array of the LPA IDs to check for a status update
             var ids = $('li[data-refresh-id]').map(function () { return this.getAttribute('data-refresh-id'); }).get();
 
-            if(ids.length > 0) {
+            if (ids.length > 0) {
                 $.ajax({
                     url: "/user/dashboard/statuses/" + ids.join(),
                     dataType: "json",

--- a/service-front/module/Application/view/application/authenticated/lpa/status/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/status/index.twig
@@ -90,7 +90,13 @@
                     <p>The donor and all attorneys on the LPA will get a letter telling them the outcome.</p>
                 {% endif %}
 
-                <p>The letter and LPA were sent by second class post. If they have not arrived by <span data-cy="lpa-should-receive-by-date">{{ shouldReceiveByDate|date('d/m/y') }}</span>, please call 0300 456 0300.</p>
+                <p>The letter and LPA were sent by second class post. If they have not arrived
+                {% if shouldReceiveByDate != null %}
+                    by <span data-cy="lpa-should-receive">{{ shouldReceiveByDate|date('d/m/y') }}</span>,
+                {% else %}
+                    after <span data-cy="lpa-should-receive">15 working days</span>,
+                {% endif %}
+                please call 0300 456 0300.</p>
 
                 <p>Opening times: Monday, Tuesday, Thursday, Friday 9.30am to 5pm. Wednesday 10am to 5pm.</p>
             </div>

--- a/service-gateway-mock/README.md
+++ b/service-gateway-mock/README.md
@@ -46,6 +46,9 @@ curl -i -H "Authorization: sigv4 x" -k http://localhost:7010/lpa-online-tool/lpa
 # Withdrawn
 curl -i -H "Authorization: sigv4 x" -k http://localhost:7010/lpa-online-tool/lpas/A43476377885
 
+# Deleted 410 response returned which sets LPA as Waiting
+curl -i -H "Authorization: sigv4 x" -k http://localhost:7010/lpa-online-tool/lpas/A97998888883
+
 # Waiting (returns a 404 which Make front-end interprets as Waiting status, i.e.
 # the LPA application has not yet been recorded on Sirius)
 curl -i -H "Authorization: sigv4 x" -k http://localhost:7010/lpa-online-tool/lpas/A91155453023
@@ -68,4 +71,3 @@ pip install -r requirements.txt
 ```
 
 You should now be able to work on the scripts in the `scripts/` directory.
-

--- a/service-gateway-mock/nginx.conf
+++ b/service-gateway-mock/nginx.conf
@@ -12,8 +12,9 @@ map $request_uri $swagger_example {
     "~A32004638272" 'code=200,example=returned_registered_and_dispatched';
     "~A48218451245" 'code=200,example=received_payment_pending';
     "~A15527329531" 'code=200,example=received_payment_unpaid';
+    "~A13316443118" 'code=200,example=received_payment_unpaid_no_statusdate';
 
-    # 410 deleted from siruis example
+    # 410 deleted from sirius example
     "~A97998888883" 'code=410,example=deleted';
 
     # 404 - results in a "waiting" status in Make

--- a/service-gateway-mock/nginx.conf
+++ b/service-gateway-mock/nginx.conf
@@ -3,24 +3,24 @@
 # but use different response fields to derive the date
 map $request_uri $swagger_example {
     # 200 examples
-    "~A91155453023" 'received';
-    "~A54171193342" 'checking';
-    "~A68582508781" 'returned_registered';
-    "~A88668805824" 'returned_rejected';
-    "~A93348314693" 'returned_invalid';
-    "~A43476377885" 'returned_withdrawn';
-    "~A32004638272" 'returned_registered_and_dispatched';
-    "~A48218451245" 'received_payment_pending';
-    "~A15527329531" 'received_payment_unpaid';
+    "~A91155453023" 'code=200,example=received';
+    "~A54171193342" 'code=200,example=checking';
+    "~A68582508781" 'code=200,example=returned_registered';
+    "~A88668805824" 'code=200,example=returned_rejected';
+    "~A93348314693" 'code=200,example=returned_invalid';
+    "~A43476377885" 'code=200,example=returned_withdrawn';
+    "~A32004638272" 'code=200,example=returned_registered_and_dispatched';
+    "~A48218451245" 'code=200,example=received_payment_pending';
+    "~A15527329531" 'code=200,example=received_payment_unpaid';
 
     # 410 deleted from siruis example
-    "~A97998888883" 'deleted';
+    "~A97998888883" 'code=410,example=deleted';
 
     # 404 - results in a "waiting" status in Make
     # NB there doesn't seem to be a way to supply an example for a non-200
     # response so we just request an example which doesn't exist, which
     # gives us a 404 response (albeit not a Sirius-style 404 response)
-    default         'NOTFOUND';
+    default         'example=NOTFOUND';
 }
 
 server {
@@ -28,7 +28,7 @@ server {
     listen 5000 default_server;
 
     location / {
-        proxy_set_header Prefer example=$swagger_example;
+        proxy_set_header Prefer $swagger_example;
         proxy_pass http://mocksirius:5000;
     }
 }

--- a/service-gateway-mock/swagger-examples.yaml
+++ b/service-gateway-mock/swagger-examples.yaml
@@ -115,6 +115,18 @@ paths:
                     withdrawnDate: null
                     statusDate: '2020-02-27'
                     status: Return - unpaid
+                received_payment_unpaid_no_statusdate:
+                  value:
+                    onlineLpaId: A13316443118
+                    receiptDate: '2022-05-11'
+                    rejectedDate: null
+                    dispatchDate: null
+                    registrationDate: null
+                    registrationDate: null
+                    cancellationDate: null
+                    invalidDate: null
+                    withdrawnDate: null
+                    status: Return - unpaid
         '410':
           content:
             application/json:


### PR DESCRIPTION
## Purpose

[LPAL-550](https://opgtransform.atlassian.net/browse/LPAL-550)

## Approach

* Add additional logging to track down issue (then remove it again).
* Fix logic which was preventing correct status being shown.
 
This was difficult to find as the error only triggers when the status is first viewed at a point when the LPA is in a non-waiting status, then is viewed again after the LPA application has been removed from Sirius (giving us a 410 response). 

The problem arose because the initial valid response was cached into our db. Then, when the 410 response was later fetched, our logic prevented it from overriding the cached response (as 400 codes were not allowed to override the cache, being treated as `found=>false`).

Also found another bug in opg-data-lpa where statusDate was not set on some responses when it should be. Added a guard to our code to deal with that, and also arranged for a fix to go into opg-data-lpa (https://github.com/ministryofjustice/opg-data-lpa/commit/8599c9cd498e47ebd496055f9339b70a1416a77a).

## Learning

Learned more about how to read the AWS logs for our clusters.

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [X] The product team have tested these changes
