### PR TITLE
Change the time to 5am

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,7 +508,7 @@ workflows:
   weekly_refresh:
     triggers:
       - schedule:
-          cron: "0 3 * * 3" # 3 am (UTC) on wednesday
+          cron: "0 5 * * 3" # 5 am (UTC) on wednesday
           filters:
             branches:
               only:


### PR DESCRIPTION
We run a daily key rotation at a similar time to this used to run, so change this to avoid failures
