### PR TITLE
Add step-by-step instructions on removing dev state lock

### DIFF
--- a/docs/runbooks/terraform_state_locks.md
+++ b/docs/runbooks/terraform_state_locks.md
@@ -26,7 +26,7 @@ If you are unsure which version you need to use, look for a variable named `requ
 
 ### Terraform workspace
 
-Within the local `.envrc` file there will be a commented out variable called `TF_Workspace`, this defaults to `development`, but if you are looking at a state lock for non-dev environments, you will need to change this accordingly. 
+Within the local `.envrc` file there will be a commented out variable called `TF_Workspace`, this defaults to `development`, but if you are looking at a state lock for non-dev environments, you will need to change this accordingly.
 
 You can check which is in use within the pipeline or by using terraform itself (`terraform workspace list`).
 
@@ -58,7 +58,63 @@ The command will then ask you to confirm by typing `yes` and when complete will 
 
 ```Terraform state has been successfully unlocked```
 
+### Step-by-step instructions for unblocking builds
 
+The above steps adapt to multiple scenarios where you may want to remove a lock. However, for most purposes, we only do this when builds are blocked due to `pr_build` CircleCI pipeline runs which fail because they can't get a terraform state lock.
 
+This happens in the `dev_region_apply_terraform` step, giving us an error like this in the logs:
 
+```
+Acquiring state lock. This may take a few moments...
+╷
+│ Error: Error acquiring the state lock
+│
+│ Error message: ConditionalCheckFailedException: The conditional request failed
+│ Lock Info:
+│   ID:        ef61c6bd-4030-3098-25d3-28f971e18376
+│   Path:      opg.terraform.state/env:/development/moj-lasting-power-of-attorney-region/terraform.tfstate
+│   Operation: OperationTypeApply
+│   Who:       root@6dbbe46abe12
+│   Version:   1.1.2
+│   Created:   2022-05-11 10:09:38.706622546 +0000 UTC
+│   Info:
+│
+│
+│ Terraform acquires a state lock to protect the state from being written
+│ by multiple users at the same time. Please resolve the issue above and try
+│ again. For most commands, you can disable locking with the "-lock=false"
+│ flag, but this is not recommended.
+```
 
+The build fails as terraform (running in the pipeline) can't get a state lock (see above) to enable it to deploy the new dev infrastructure.
+
+The state lock can be removed via your local opg-lpa checkout as follows:
+
+1. Make sure there are no other running builds in CircleCI; if there are, wait for them to fail or finish.
+2. `cd opg-lpa/terraform/region`
+3. `source .envrc` (you're supposed to be able to use direnv to do this, but I can't get it to work properly; source works just as well)
+4. `aws-vault exec identity -- terraform init`; this downloads plugins/dependencies needed to run terraform
+5. Get the lock ID from the error message in CircleCI; in the above log example, it is `ef61c6bd-4030-3098-25d3-28f971e18376`
+6. `aws-vault exec identity -- terraform force-unlock <lock ID>`, where `<lock ID>` is the lock ID derived in step 4
+
+If this works, you should see something like this:
+
+```
+Do you really want to force-unlock?
+  Terraform will remove the lock on the remote state.
+  This will allow local Terraform commands to modify this state, even though it
+  may be still be in use. Only 'yes' will be accepted to confirm.
+
+  Enter a value: yes
+```
+
+When prompted to "Enter a value", type `yes` and press *Return*.
+
+If this is successful, you should see:
+
+```
+Terraform state has been successfully unlocked!
+
+The state has been unlocked, and Terraform commands should now be able to
+obtain a new lock on the remote state.
+```


### PR DESCRIPTION
## Purpose

To provide easy-to-follow instructions on removing the dev state lock which keeps blocking our builds.

## Approach

Update the docs.

## Learning

Some terraform stuff

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
