### PR TITLE
LPAL-749 hibernation extended to midnight bst

### DIFF
--- a/terraform/environment/modules/environment/ecs_hibernation.tf
+++ b/terraform/environment/modules/environment/ecs_hibernation.tf
@@ -3,7 +3,7 @@ module "dev_weekdays" {
   source           = "./modules/ecs_scheduled_scaling"
   name             = "daytime"
   ecs_cluster_name = aws_ecs_cluster.online-lpa.name
-  scale_down_time  = "cron(00 19 ? * MON-FRI *)"
+  scale_down_time  = "cron(00 23 ? * MON-FRI *)"
   scale_up_time    = "cron(30 06 ? * MON-FRI *)"
   service_config = {
     tostring(aws_ecs_service.admin.name) = {


### PR DESCRIPTION
## Purpose

As per amy's request, dev environment scaling set to scale down much later. this is a temporary move.

Fixes LPAL-749

## Approach

update cron settings for autoscaling module.

## Learning

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
