### PR TITLE
LPAL-809 Use lower-level Cypress.dom methods for visibility tests

### DIFF
--- a/cypress/integration/InstructionsPreferencesHW.feature
+++ b/cypress/integration/InstructionsPreferencesHW.feature
@@ -14,8 +14,8 @@ Feature: Specify Instructions and Preferences for a Health and Welfare LPA
         # ** CUT Above Here ** This comment line needed for stitching feature files. Please do not remove
 
         Then I am taken to the instructions page
-        #Then I can find "instruction" but it is not visible
-        #And I can find "preferences" but it is not visible
+        Then I can find "instruction" but it is not visible
+        And I can find "preferences" but it is not visible
         When I click "add-extra-preferences"
         Then I can find "instruction" and it is visible
         And I can find "preferences" and it is visible
@@ -37,4 +37,3 @@ Feature: Specify Instructions and Preferences for a Health and Welfare LPA
         When I click "save"
         Then I am taken to the applicant page
         When I visit link containing "preview the LPA"
-

--- a/cypress/integration/InstructionsPreferencesPF.feature
+++ b/cypress/integration/InstructionsPreferencesPF.feature
@@ -13,8 +13,8 @@ Feature: Specify Instructions and Preferences for a Property and Finance LPA
         And I visit the instructions page for the test fixture lpa
         # ** CUT Above Here ** This comment line needed for stitching feature files. Please do not remove
 
-        #Then I can find "instruction" but it is not visible
-        #And I can find "preferences" but it is not visible
+        Then I can find "instruction" but it is not visible
+        And I can find "preferences" but it is not visible
         When I click "add-extra-preferences"
         Then I can find "instruction" and it is visible
         And I can find "preferences" and it is visible
@@ -30,4 +30,3 @@ Feature: Specify Instructions and Preferences for a Property and Finance LPA
         When I click "save"
         Then I am taken to the applicant page
         When I visit link containing "preview the LPA"
-

--- a/cypress/integration/common/i_can_find.js
+++ b/cypress/integration/common/i_can_find.js
@@ -1,5 +1,5 @@
 import { Then } from "cypress-cucumber-preprocessor/steps";
- 
+
 Then(`I can find {string}`, (object) => {
   cy.get("[data-cy=" + object + "]");
 })
@@ -23,11 +23,11 @@ Then(`I can find hidden {string}`, (object) => {
 })
 
 Then(`I can find {string} but it is not visible`, (object) => {
-  cy.get("[data-cy=" + object + "]").should('not.be.visible');
+  cy.get("[data-cy=" + object + "]").then(Cypress.dom.isHidden);
 })
 
 Then(`I can find {string} and it is visible`, (object) => {
-  cy.get("[data-cy=" + object + "]").should('be.visible');
+  cy.get("[data-cy=" + object + "]").then(Cypress.dom.isVisible);
 })
 
 Then(`I can find {string} wrapped with error highlighting`, (object) => {
@@ -42,7 +42,7 @@ Then(`I can find link pointing to {string}`, (linkAddr) => {
 })
 
 Then(`I can find draft download link`, () => {
-    cy.get('@lpaId').then((lpaId) => { 
+    cy.get('@lpaId').then((lpaId) => {
         let searchStr = 'a[href*="/lpa/' + lpaId + '/download/lp1/draft' + '"]'
         cy.get(searchStr)
     });
@@ -56,9 +56,8 @@ Then(`I can find {string} with {int} options`, (object, count) => {
 Then(`I can find {string} with options`, (object, dataTable) => {
   cy.get("[data-cy=" + object + "]").children().should($foundObject => {
     var rawTable = dataTable.rawTable;
-    rawTable.forEach(row => { 
+    rawTable.forEach(row => {
         expect($foundObject).to.contain(row[0]);
         });
     })
 })
-


### PR DESCRIPTION
## Purpose

[LPAL-809](https://opgtransform.atlassian.net/browse/LPAL-809)

## Approach

See issue for context. Main problem is that Chrome and Electron treat visibility of elements within a `<details>` element differently.

Instead of .should('not.be.visible')/should('be.visible'),
use Cypress.dom.isHidden()/Cypress.dom.isVisible()
to test visibility or not of DOM elements.

This does a more precise job of checking whether an element is
really visible, beyond just looking at its CSS or DOM properties.

## Learning

More about DOM visibility and how to test in cypress.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
