### PR TITLE
LPAL-813 enable WAF in Dev

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -25,7 +25,7 @@
       "psql_parameter_group_family": "postgres10",
       "log_retention_in_days": 7,
       "account_name_short" : "dev",
-      "associate_alb_with_waf_web_acl_enabled": false,
+      "associate_alb_with_waf_web_acl_enabled": true,
       "autoscaling": {
         "front": {
           "minimum": 1,


### PR DESCRIPTION
## Purpose

to enable WAF in dev to test for issues with the Shield Advanced Integration. this sets up a `aws_wafv2_web_acl_association` with front and admin load balancers.

## Approach

Enable Waf var in terraform, which enables the association for the load balancers.

## Learning

https://docs.aws.amazon.com/waf/latest/developerguide/shield-policies.html


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
