### PR TITLE
LPAL-816 add shield DDoS alarms

### DIFF
--- a/terraform/environment/modules/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/modules/environment/cloudwatch_alarms.tf
@@ -77,6 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "front_ddos_attack_external" {
   alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
   treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
+  tags                = merge(local.default_opg_tags, local.front_component_tag)
   dimensions = {
     ResourceArn = aws_lb.front.arn
   }
@@ -94,6 +95,7 @@ resource "aws_cloudwatch_metric_alarm" "admin_ddos_attack_external" {
   alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
   treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
+  tags                = merge(local.default_opg_tags, local.admin_component_tag)
   dimensions = {
     ResourceArn = aws_lb.admin.arn
   }

--- a/terraform/environment/modules/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/modules/environment/cloudwatch_alarms.tf
@@ -64,3 +64,37 @@ resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
   threshold           = 6
   treat_missing_data  = "notBreaching"
 }
+
+resource "aws_cloudwatch_metric_alarm" "front_ddos_attack_external" {
+  alarm_name          = "ActorDDoSDetected"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDoSProtection"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "0"
+  alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
+  dimensions = {
+    ResourceArn = aws_lb.front.arn
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "admin_ddos_attack_external" {
+  alarm_name          = "ActorDDoSDetected"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDoSProtection"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "0"
+  alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
+  dimensions = {
+    ResourceArn = aws_lb.admin.arn
+  }
+}


### PR DESCRIPTION
## Purpose

To support the shield advanced integration, add alarms for DDoS detection, which will come from this service.

Fixes LPAL-816

## Approach

Add 2 alarms, based on Use an LPA PR: https://github.com/ministryofjustice/opg-use-an-lpa/pull/1549

## Learning
N/A
## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
