### PR TITLE
LPAL-720 change internal dns in preprod

### DIFF
--- a/terraform/environment/modules/environment/dns.tf
+++ b/terraform/environment/modules/environment/dns.tf
@@ -1,6 +1,6 @@
 locals {
   dns_namespace_internal = (
-    var.account_name == "development" ?
+    var.account_name != "production" ?
     "${var.environment_name}.${var.account_name}.opg.lpa.api.ecs.internal" :
     "${var.environment_name}-internal"
   )


### PR DESCRIPTION
## Purpose

To enable the internal namespace changes from #894 

Fixes LPAL-720

## Approach
change local var to calculate dns convention to exclude `production` rather than being `development` only. There will be a follow on DNS change for `production` which will require downtime, to be scheduled. this will fire the preprod replace check as this replaces the ECS service clusters

## Learning
N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
