### PR TITLE
LPAL-720 Revert "LPAL-720 change internal dns in preprod (#957)"

### DIFF
--- a/terraform/environment/modules/environment/dns.tf
+++ b/terraform/environment/modules/environment/dns.tf
@@ -1,6 +1,6 @@
 locals {
   dns_namespace_internal = (
-    var.account_name != "production" ?
+    var.account_name == "development" ?
     "${var.environment_name}.${var.account_name}.opg.lpa.api.ecs.internal" :
     "${var.environment_name}-internal"
   )


### PR DESCRIPTION
This reverts commit ecd0d92d84e02ab4e68ca352201d7ff9a079e1e5.

## Purpose

So service discovery namespaces are not destroying properly on an existing environment.
 This needs further work on it, so i am reverting to unblock the Path to Live.


Fixes LPAL-720

## Approach

revert commit

## Learning

We hit a snag which is listed in this issue.

https://github.com/hashicorp/terraform-provider-aws/issues/4853

seems to have regressed in V4 of the aws provider. So will investigate what to do next.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
