### PR TITLE
LPAL-720 service discovery dns rework, better fix.

### DIFF
--- a/terraform/environment/modules/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/modules/environment/cloudwatch_alarms.tf
@@ -66,7 +66,7 @@ resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "front_ddos_attack_external" {
-  alarm_name          = "FrontDDoSDetected"
+  alarm_name          = "${var.environment_name}-FrontDDoSDetected"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
   metric_name         = "DDoSDetected"
@@ -84,7 +84,7 @@ resource "aws_cloudwatch_metric_alarm" "front_ddos_attack_external" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "admin_ddos_attack_external" {
-  alarm_name          = "AdminDDoSDetected"
+  alarm_name          = "${var.environment_name}-AdminDDoSDetected"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
   metric_name         = "DDoSDetected"

--- a/terraform/environment/modules/environment/dns.tf
+++ b/terraform/environment/modules/environment/dns.tf
@@ -1,7 +1,7 @@
 locals {
   dns_namespace_internal = (
-    var.account_name == "development" ?
-    "${var.environment_name}.${var.account_name}.opg.lpa.api.ecs.internal" :
+    #var.account_name == "development" ?
+    #"${var.environment_name}.${var.account_name}.opg.lpa.api.ecs.internal" :
     "${var.environment_name}-internal"
   )
 }

--- a/terraform/environment/modules/environment/dns.tf
+++ b/terraform/environment/modules/environment/dns.tf
@@ -1,12 +1,21 @@
 locals {
-  dns_namespace_internal = (
-    #var.account_name == "development" ?
-    #"${var.environment_name}.${var.account_name}.opg.lpa.api.ecs.internal" :
-    "${var.environment_name}-internal"
+  dns_namespace_internal_original = (
+     "${var.environment_name}-internal"
   )
+  dns_namespace_internal_canonical = (
+    var.account_name == "development" ?
+    "${var.environment_name}.${var.account_name}.opg.lpa.api.ecs.internal" :
+    "${var.account_name}.opg.lpa.api.ecs.internal"
+  )
+
 }
 
 resource "aws_service_discovery_private_dns_namespace" "internal" {
-  name = local.dns_namespace_internal
+  name = local.dns_namespace_internal_original
+  vpc  = data.aws_vpc.default.id
+}
+
+resource "aws_service_discovery_private_dns_namespace" "internal_canonical" {
+  name = local.dns_namespace_internal_canonical
   vpc  = data.aws_vpc.default.id
 }

--- a/terraform/environment/modules/environment/dns.tf
+++ b/terraform/environment/modules/environment/dns.tf
@@ -1,6 +1,6 @@
 locals {
   dns_namespace_internal_original = (
-     "${var.environment_name}-internal"
+    "${var.environment_name}-internal"
   )
   dns_namespace_internal_canonical = (
     var.account_name == "development" ?

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -20,9 +20,20 @@ resource "aws_ecs_service" "api" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.api.arn
+    registry_arn = local.registry_arn_selection
   }
+
   tags = merge(local.default_opg_tags, local.api_component_tag)
+}
+
+
+# this is needed until we move the new dns into production.
+locals{
+  registry_arn_selection  = (
+    var.account_name == "production" ?
+    aws_service_discovery_service.api.arn :
+    aws_service_discovery_service.api_canonical.arn
+  )
 }
 
 //-----------------------------------------------
@@ -47,9 +58,30 @@ resource "aws_service_discovery_service" "api" {
   }
 }
 
+
+resource "aws_service_discovery_service" "api_canonical" {
+  name = "api"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.internal_canonical.id
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+
 //
 locals {
-  api_service_fqdn = "${aws_service_discovery_service.api.name}.${aws_service_discovery_private_dns_namespace.internal.name}"
+  api_service_fqdn = "${aws_service_discovery_service.api.name}.${aws_service_discovery_private_dns_namespace.internal_canonical.name}"
 }
 
 //----------------------------------

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -27,14 +27,6 @@ resource "aws_ecs_service" "api" {
 }
 
 
-# this is needed until we move the new dns into production.
-locals{
-  registry_arn_selection  = (
-    var.account_name == "production" ?
-    aws_service_discovery_service.api.arn :
-    aws_service_discovery_service.api_canonical.arn
-  )
-}
 
 //-----------------------------------------------
 // Api service discovery
@@ -79,9 +71,20 @@ resource "aws_service_discovery_service" "api_canonical" {
 }
 
 
-//
+# this switching is needed until we move the new dns convention into production.
 locals {
-  api_service_fqdn = "${aws_service_discovery_service.api.name}.${aws_service_discovery_private_dns_namespace.internal_canonical.name}"
+
+  registry_arn_selection = (
+    var.account_name == "production" ?
+    aws_service_discovery_service.api.arn :
+    aws_service_discovery_service.api_canonical.arn
+  )
+
+  api_service_fqdn = (
+    var.account_name == "production" ?
+    "${aws_service_discovery_service.api.name}.${aws_service_discovery_private_dns_namespace.internal.name}" :
+    "${aws_service_discovery_service.api_canonical.name}.${aws_service_discovery_private_dns_namespace.internal_canonical.name}"
+  )
 }
 
 //----------------------------------

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -22,11 +22,8 @@ resource "aws_ecs_service" "api" {
   service_registries {
     registry_arn = local.registry_arn_selection
   }
-
   tags = merge(local.default_opg_tags, local.api_component_tag)
 }
-
-
 
 //-----------------------------------------------
 // Api service discovery
@@ -50,7 +47,6 @@ resource "aws_service_discovery_service" "api" {
   }
 }
 
-
 resource "aws_service_discovery_service" "api_canonical" {
   name = "api"
 
@@ -69,7 +65,6 @@ resource "aws_service_discovery_service" "api_canonical" {
     failure_threshold = 1
   }
 }
-
 
 # this switching is needed until we move the new dns convention into production.
 locals {

--- a/terraform/environment/modules/rds_cross_region_backup/main.tf
+++ b/terraform/environment/modules/rds_cross_region_backup/main.tf
@@ -9,7 +9,7 @@ resource "aws_db_instance_automated_backups_replication" "instance" {
 
 
 data "aws_kms_key" "destination_rds_snapshot_key" {
-    provider  = aws.destination
-    key_id = "arn:aws:kms:${var.destination_region_name}:${data.aws_caller_identity.current.account_id}:alias/${var.key_alias}"
+  provider = aws.destination
+  key_id   = "arn:aws:kms:${var.destination_region_name}:${data.aws_caller_identity.current.account_id}:alias/${var.key_alias}"
 }
 


### PR DESCRIPTION
## Purpose

Create a new Service Discovery Namespace and Service for the Service API to use instead, which uses the new canonical naming convention as agreed in ADR 0008 on this repo. This will be implemented on environments in dev and preproduction first before being rolled out in a maintenance slot for production.

Fixes LPAL-720

## Approach

- create new service discovery namespace, using the agreed format
- keep existing for production use
- create new service discovery service using that namespace
- attach correct service discovery service arn to the api ECS Service, using a local selection based on environment

We will remove the older namespace and service later on, once implemented in production.

Note - i've update further the DDoS Alarms to be environment specific.

## Learning

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html 

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
