### PR TITLE
LPAL-724 Add descriptions to aws_security_group_rule Terraform resources

### DIFF
--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -91,9 +91,6 @@ resource "aws_security_group" "api_ecs_service" {
   tags        = merge(local.default_opg_tags, local.api_component_tag)
 }
 
-//----------------------------------
-// 80 in from front ECS service
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "api_ecs_service_front_ingress" {
   type                     = "ingress"
   from_port                = 80
@@ -101,11 +98,9 @@ resource "aws_security_group_rule" "api_ecs_service_front_ingress" {
   protocol                 = "tcp"
   security_group_id        = aws_security_group.api_ecs_service.id
   source_security_group_id = aws_security_group.front_ecs_service.id
+  description              = "Frontend ECS to API ECS - HTTP"
 }
 
-//----------------------------------
-// 80 in from Admin ECS service
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "api_ecs_service_admin_ingress" {
   type                     = "ingress"
   from_port                = 80
@@ -113,11 +108,9 @@ resource "aws_security_group_rule" "api_ecs_service_admin_ingress" {
   protocol                 = "tcp"
   security_group_id        = aws_security_group.api_ecs_service.id
   source_security_group_id = aws_security_group.admin_ecs_service.id
+  description              = "Admin ECS to API ECS - HTTP"
 }
 
-//----------------------------------
-// Anything out
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "api_ecs_service_egress" {
   type      = "egress"
   from_port = 0
@@ -126,6 +119,7 @@ resource "aws_security_group_rule" "api_ecs_service_egress" {
   #tfsec:ignore:AWS007 - anything out
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.api_ecs_service.id
+  description       = "API ECS to Anywhere - All Traffic"
 }
 
 //--------------------------------------

--- a/terraform/environment/modules/environment/ecs_feedbackdb.tf
+++ b/terraform/environment/modules/environment/ecs_feedbackdb.tf
@@ -7,9 +7,6 @@ resource "aws_security_group" "feedbackdb_ecs_service" {
   tags        = merge(local.default_opg_tags, local.feedbackdb_component_tag)
 }
 
-//----------------------------------
-// Anything out except production
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "feedbackdb_ecs_service_egress" {
   type      = "egress"
   from_port = 0
@@ -18,6 +15,7 @@ resource "aws_security_group_rule" "feedbackdb_ecs_service_egress" {
   #tfsec:ignore:AWS007 - anything out
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.feedbackdb_ecs_service.id
+  description       = "Non-production FeedbackDB ECS to anything - All traffic"
 }
 
 //--------------------------------------

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -49,7 +49,6 @@ resource "aws_security_group_rule" "front_ecs_service_ingress" {
 
 resource "aws_security_group_rule" "front_ecs_service_elasticache_region_ingress" {
   type                     = "ingress"
-  description              = "allows service front access to elasticache"
   from_port                = 0
   to_port                  = 6379
   protocol                 = "tcp"

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -37,8 +37,6 @@ resource "aws_security_group" "front_ecs_service" {
 
 }
 
-// 80 in from the ELB
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "front_ecs_service_ingress" {
   type                     = "ingress"
   from_port                = 80
@@ -46,9 +44,9 @@ resource "aws_security_group_rule" "front_ecs_service_ingress" {
   protocol                 = "tcp"
   security_group_id        = aws_security_group.front_ecs_service.id
   source_security_group_id = aws_security_group.front_loadbalancer.id
+  description              = "Front ELB to Front ECS - HTTP"
 }
 
-// from front to Elasticache (new regional one)
 resource "aws_security_group_rule" "front_ecs_service_elasticache_region_ingress" {
   type                     = "ingress"
   description              = "allows service front access to elasticache"
@@ -57,10 +55,9 @@ resource "aws_security_group_rule" "front_ecs_service_elasticache_region_ingress
   protocol                 = "tcp"
   security_group_id        = data.aws_security_group.front_cache_region.id
   source_security_group_id = aws_security_group.front_ecs_service.id
+  description              = "Front ECS to regional Elasticache - Redis"
 }
 
-// Anything out
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "front_ecs_service_egress" {
   type      = "egress"
   from_port = 0
@@ -69,6 +66,7 @@ resource "aws_security_group_rule" "front_ecs_service_egress" {
   #tfsec:ignore:AWS007 - anything out
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.front_ecs_service.id
+  description       = "Front ECS to Anywhere - All traffic"
 }
 
 //--------------------------------------

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -31,9 +31,6 @@ resource "aws_security_group" "pdf_ecs_service" {
   tags        = merge(local.default_opg_tags, local.pdf_component_tag)
 }
 
-//----------------------------------
-// Anything out
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "pdf_ecs_service_egress" {
   type      = "egress"
   from_port = 0
@@ -42,6 +39,7 @@ resource "aws_security_group_rule" "pdf_ecs_service_egress" {
   #tfsec:ignore:AWS007 - anything out
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.pdf_ecs_service.id
+  description       = "PDF ECS to Anywhere - All Traffic"
 }
 
 //--------------------------------------

--- a/terraform/environment/modules/environment/ecs_seeding.tf
+++ b/terraform/environment/modules/environment/ecs_seeding.tf
@@ -7,9 +7,6 @@ resource "aws_security_group" "seeding_ecs_service" {
   tags        = merge(local.default_opg_tags, local.seeding_component_tag)
 }
 
-//----------------------------------
-// Anything out except production
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "seeding_ecs_service_egress" {
   count     = var.environment_name == "production" ? 0 : 1
   type      = "egress"
@@ -19,6 +16,7 @@ resource "aws_security_group_rule" "seeding_ecs_service_egress" {
   #tfsec:ignore:AWS007 - anything out
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.seeding_ecs_service.id
+  description       = "Non-production Seeding ECS to Anywhere - All Traffic"
 }
 
 //--------------------------------------

--- a/terraform/environment/modules/environment/load_balancer_admin.tf
+++ b/terraform/environment/modules/environment/load_balancer_admin.tf
@@ -58,7 +58,6 @@ resource "aws_security_group" "admin_loadbalancer" {
   tags        = merge(local.default_opg_tags, local.admin_component_tag)
 }
 
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "admin_loadbalancer_ingress" {
   type              = "ingress"
   from_port         = 443
@@ -66,9 +65,9 @@ resource "aws_security_group_rule" "admin_loadbalancer_ingress" {
   protocol          = "tcp"
   cidr_blocks       = module.allowed_ip_list.moj_sites
   security_group_id = aws_security_group.admin_loadbalancer.id
+  description       = "MoJ Sites to Admin ELB - HTTPS"
 }
 
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "admin_loadbalancer_ingress_production" {
   count     = var.environment_name == "production" ? 1 : 0
   type      = "ingress"
@@ -78,9 +77,9 @@ resource "aws_security_group_rule" "admin_loadbalancer_ingress_production" {
   #tfsec:ignore:AWS006 - public facing inbound rule
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.admin_loadbalancer.id
+  description       = "Anywhere to Production Admin ELB - HTTPS"
 }
 
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "admin_loadbalancer_egress" {
   type      = "egress"
   from_port = 0
@@ -89,4 +88,5 @@ resource "aws_security_group_rule" "admin_loadbalancer_egress" {
   #tfsec:ignore:AWS007 - public facing load balancer
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.admin_loadbalancer.id
+  description       = "Admin Loadbalancer to Anywhere - All Traffic"
 }

--- a/terraform/environment/modules/environment/load_balancer_front.tf
+++ b/terraform/environment/modules/environment/load_balancer_front.tf
@@ -60,7 +60,6 @@ resource "aws_security_group" "front_loadbalancer" {
 
 }
 
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "front_loadbalancer_ingress" {
   type              = "ingress"
   from_port         = 443
@@ -68,6 +67,7 @@ resource "aws_security_group_rule" "front_loadbalancer_ingress" {
   protocol          = "tcp"
   cidr_blocks       = module.allowed_ip_list.moj_sites
   security_group_id = aws_security_group.front_loadbalancer.id
+  description       = "MoJ sites to Front ELB - HTTPS"
 }
 
 #tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
@@ -80,10 +80,9 @@ resource "aws_security_group_rule" "front_loadbalancer_ingress_production" {
   #tfsec:ignore:AWS006 - public facing inbound rule
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.front_loadbalancer.id
+  description       = "Anywhere to Production Front ELB - HTTPS"
 }
 
-// Allow http traffic in to be redirected to https
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "front_loadbalancer_ingress_http" {
   type      = "ingress"
   from_port = 80
@@ -92,10 +91,9 @@ resource "aws_security_group_rule" "front_loadbalancer_ingress_http" {
   #tfsec:ignore:AWS006 - public facing inbound rule
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.front_loadbalancer.id
+  description       = "Anywhere to Front ELB - HTTP (redirects to HTTPS)"
 }
 
-//Anything out
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "front_loadbalancer_egress" {
   type      = "egress"
   from_port = 0
@@ -104,6 +102,7 @@ resource "aws_security_group_rule" "front_loadbalancer_egress" {
   #tfsec:ignore:AWS007 - public facing load balancer
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.front_loadbalancer.id
+  description       = "Front ELB to Anywhere - All Traffic"
 }
 
 resource "aws_lb_listener_certificate" "front_loadbalancer_live_service_certificate" {

--- a/terraform/environment/modules/environment/rds.tf
+++ b/terraform/environment/modules/environment/rds.tf
@@ -152,7 +152,6 @@ resource "aws_security_group" "rds-api" {
   }
 }
 
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "rds-api" {
   type                     = "ingress"
   from_port                = 5432
@@ -160,5 +159,6 @@ resource "aws_security_group_rule" "rds-api" {
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.rds-client.id
   security_group_id        = aws_security_group.rds-api.id
+  description              = "RDS client to RDS - Postgres"
 }
 


### PR DESCRIPTION
## Purpose

Add descriptions to Security Group Rules 

Fixes LPAL-724

## Approach

Add a description attribute to every aws_security_group_rule resource

## Learning

aws_security_group's description attribute is immutable and requires destroy / create but the aws_security_group_rule description does not.

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
