### PR TITLE
LPAL-825 Revert "Lpal 824 Workaround for PagerDuty API error (#967)"

### DIFF
--- a/terraform/account/pagerduty.tf
+++ b/terraform/account/pagerduty.tf
@@ -1,18 +1,10 @@
-locals {
-  db_alerts_service_id = (
-    local.account_name == "production" ?
-    "PXWUISC" :
-  "PB5FJ52")
-  ops_service_id = "PP0UDI9"
-}
-
-/*data "pagerduty_service" "pagerduty" {
+data "pagerduty_service" "pagerduty" {
   name = local.pager_duty_ops_service_name
 }
 
 data "pagerduty_service" "pagerduty_db_alerts" {
   name = local.pager_duty_db_service_name
-}*/
+}
 
 data "pagerduty_vendor" "cloudwatch" {
   name = "Cloudwatch"
@@ -23,16 +15,14 @@ data "pagerduty_vendor" "custom_events" {
 }
 
 resource "pagerduty_service_integration" "cloudwatch_integration" {
-  name = "${data.pagerduty_vendor.cloudwatch.name} ${local.account_name} Account Ops"
-  #service = data.pagerduty_service.pagerduty.id
-  service = local.ops_service_id
+  name    = "${data.pagerduty_vendor.cloudwatch.name} ${local.account_name} Account Ops"
+  service = data.pagerduty_service.pagerduty.id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 
 resource "pagerduty_service_integration" "db_alerts_integration" {
-  name = "${local.account_name} Account DB Alerts"
-  #service = data.pagerduty_service.pagerduty_db_alerts.id
-  service = local.db_alerts_service_id
+  name    = "${local.account_name} Account DB Alerts"
+  service = data.pagerduty_service.pagerduty_db_alerts.id
   vendor  = data.pagerduty_vendor.custom_events.id
 }
 

--- a/terraform/environment/modules/environment/pagerduty.tf
+++ b/terraform/environment/modules/environment/pagerduty.tf
@@ -1,15 +1,3 @@
-#temporary fix due to https://github.com/PagerDuty/terraform-provider-pagerduty/issues/523
-
-locals {
-  ops_service_id = "PP0UDI9"
-  cloudwatch_service_id = (
-    var.account_name == "production" ?
-    "PVIXHGS" :
-    "PS99H42"
-  )
-}
-
-/*
 data "pagerduty_service" "pagerduty" {
   name = var.account.pagerduty_service_name
 }
@@ -17,23 +5,19 @@ data "pagerduty_service" "pagerduty" {
 data "pagerduty_service" "pagerduty_ops" {
   name = local.pager_duty_ops_service_name
 }
-*/
 
 data "pagerduty_vendor" "cloudwatch" {
   name = "Cloudwatch"
 }
 
-
 resource "pagerduty_service_integration" "cloudwatch_integration" {
-  name = "${data.pagerduty_vendor.cloudwatch.name} ${var.environment_name} Environment"
-  #service = data.pagerduty_service.pagerduty.id
-  service = local.cloudwatch_service_id
+  name    = "${data.pagerduty_vendor.cloudwatch.name} ${var.environment_name} Environment"
+  service = data.pagerduty_service.pagerduty.id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 
 resource "pagerduty_service_integration" "cloudwatch_integration_ops" {
-  name = "${data.pagerduty_vendor.cloudwatch.name} ${var.environment_name} Environment Ops"
-  #service = data.pagerduty_service.pagerduty_ops.id
-  service = local.ops_service_id
+  name    = "${data.pagerduty_vendor.cloudwatch.name} ${var.environment_name} Environment Ops"
+  service = data.pagerduty_service.pagerduty_ops.id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }

--- a/terraform/region/modules/region/pagerduty.tf
+++ b/terraform/region/modules/region/pagerduty.tf
@@ -1,15 +1,3 @@
-#temporary fix due to https://github.com/PagerDuty/terraform-provider-pagerduty/issues/523
-locals {
-  db_alerts_service_id = (
-    var.account_name == "production" ?
-    "PXWUISC" :
-    "PB5FJ52"
-  )
-  ops_service_id = "PP0UDI9"
-}
-
-
-/*
 data "pagerduty_service" "pagerduty_ops" {
   name = local.pager_duty_ops_service_name
 }
@@ -17,7 +5,7 @@ data "pagerduty_service" "pagerduty_ops" {
 data "pagerduty_service" "pagerduty_db_alerts" {
   name = local.pager_duty_db_service_name
 }
-*/
+
 data "pagerduty_vendor" "cloudwatch" {
   name = "Cloudwatch"
 }
@@ -27,16 +15,14 @@ data "pagerduty_vendor" "custom_events" {
 }
 
 resource "pagerduty_service_integration" "cloudwatch_integration" {
-  name = "${data.pagerduty_vendor.cloudwatch.name} ${local.region_name} Region Ops"
-  #service = data.pagerduty_service.pagerduty_ops.id
-  service = local.ops_service_id
+  name    = "${data.pagerduty_vendor.cloudwatch.name} ${local.region_name} Region Ops"
+  service = data.pagerduty_service.pagerduty_ops.id
   vendor  = data.pagerduty_vendor.cloudwatch.id
 }
 
 resource "pagerduty_service_integration" "db_alerts_integration" {
-  name = "${local.account_name} ${local.region_name} Region DB Alerts"
-  #service = data.pagerduty_service.pagerduty_db_alerts.id
-  service = local.db_alerts_service_id
+  name    = "${local.account_name} ${local.region_name} Region DB Alerts"
+  service = data.pagerduty_service.pagerduty_db_alerts.id
   vendor  = data.pagerduty_vendor.custom_events.id
 }
 


### PR DESCRIPTION
This reverts commit dc371a0064637f04bf473220d49d58f992284958.

## Purpose

Revert previous Workaround  for pagerduty

Fixes LPAL-825

## Approach

Revert merged commit to restore to correct approach.

## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
