### PR TITLE
LPAL-724: Add public access block to mail s3 bucket

### DIFF
--- a/terraform/email/email.tf
+++ b/terraform/email/email.tf
@@ -34,7 +34,7 @@ resource "aws_route53_record" "casper_amazonses_mx" {
 
 # Create S3 bucket for SES mail storage
 # this is ony used for emil testing, which will change anyway
-#tfsec:ignore:AWS017 #tfsec:ignore:AWS002 #tfsec:ignore:AWS077 #tfsec:ignore:AWS098
+#tfsec:ignore:AWS017 #tfsec:ignore:AWS002 #tfsec:ignore:AWS077
 resource "aws_s3_bucket" "mailbox" {
   bucket = "opg-lpa-casper-mailbox"
   acl    = "private"
@@ -48,6 +48,13 @@ resource "aws_s3_bucket" "mailbox" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "mailbox" {
+  bucket                  = aws_s3_bucket.mailbox.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
 
 resource "aws_s3_bucket_policy" "mailbox" {
   bucket = aws_s3_bucket.mailbox.id


### PR DESCRIPTION
## Purpose

Block / ignore public ACLs on the mail S3 bucket so that public policies cannot be accidentally added in the future.
 
Fixes LPAL-724

## Approach

Add a aws_s3_bucket_public_access_block resource to explicitly block and ignore new public ACLs.

## Learning

Learned that SES mail can be stored in S3.

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
