### PR TITLE
LPAL 819: Add Notify CNAMEs to DNS firewall

### DIFF
--- a/terraform/region/terraform.tfvars.json
+++ b/terraform/region/terraform.tfvars.json
@@ -25,6 +25,8 @@
         "enabled": true,
         "domains_allowed": [
           "api.notifications.service.gov.uk.",
+          "d2kjg78kcam6ku.cloudfront.net.",
+          "notify-paas-proxy-359224506.eu-west-1.elb.amazonaws.com.",
           "api.os.uk.",
           "publicapi.payments.service.gov.uk.",
           "integration.dev.lpa.api.opg.service.justice.gov.uk."
@@ -52,6 +54,8 @@
         "enabled": true,
         "domains_allowed": [
           "api.notifications.service.gov.uk.",
+          "d2kjg78kcam6ku.cloudfront.net",
+          "notify-paas-proxy-359224506.eu-west-1.elb.amazonaws.com.",
           "api.os.uk.",
           "publicapi.payments.service.gov.uk.",
           "integration.dev.lpa.api.opg.service.justice.gov.uk."
@@ -79,6 +83,8 @@
         "enabled": true,
         "domains_allowed": [
           "api.notifications.service.gov.uk.",
+          "d2kjg78kcam6ku.cloudfront.net",
+          "notify-paas-proxy-359224506.eu-west-1.elb.amazonaws.com.",
           "api.os.uk.",
           "publicapi.payments.service.gov.uk.",
           "lpa.api.opg.service.justice.gov.uk."


### PR DESCRIPTION
## Purpose

To explicitly allow DNS lookups of the Notify CNAMEs on the DNS firewall

Fixes LPAL-819

## Approach

Add the record of the AWS ELB (currently used around 5% of the time) and the new CloudFront record.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
