### PR TITLE
LPAL 724: add CMK KMS for LB access logs

### DIFF
--- a/terraform/account/kms.tf
+++ b/terraform/account/kms.tf
@@ -1,0 +1,24 @@
+resource "aws_kms_key" "multi_region_access_logs_lb_encryption_key" {
+  enable_key_rotation = true
+  multi_region        = true
+  provider            = aws.eu-west-1
+}
+
+resource "aws_kms_alias" "multi_region_access_logs_lb_encryption_alias" {
+  name          = "alias/mrk_access_logs_lb_encryption_key-${local.account_name}"
+  target_key_id = aws_kms_key.multi_region_access_logs_lb_encryption_key.key_id
+  provider      = aws.eu-west-1
+}
+
+resource "aws_kms_replica_key" "multi_region_access_logs_lb_encryption_key_replica" {
+  description             = "Loadbalancer access log encryption replica key"
+  deletion_window_in_days = 7
+  primary_key_arn         = aws_kms_key.multi_region_access_logs_lb_encryption_key.arn
+  provider                = aws.eu-west-2
+}
+
+resource "aws_kms_alias" "multi_region_access_logs_lb_encryption_alias_replica" {
+  name          = "alias/mrk_access_logs_lb_encryption_key-${local.account_name}"
+  target_key_id = aws_kms_replica_key.multi_region_access_logs_lb_encryption_key_replica.key_id
+  provider      = aws.eu-west-2
+}

--- a/terraform/account/s3.tf
+++ b/terraform/account/s3.tf
@@ -1,3 +1,7 @@
+data "aws_kms_key" "access_log_key" {
+  key_id = "alias/mrk_access_logs_lb_encryption_key-${local.account_name}"
+}
+
 data "aws_elb_service_account" "main" {
   region = "eu-west-1"
 }
@@ -56,7 +60,8 @@ resource "aws_s3_bucket" "access_log" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm = "aws:kms"
+        kms_master_key_id = data.aws_kms_key.access_log_key.id
+        sse_algorithm     = "aws:kms"
       }
     }
   }


### PR DESCRIPTION
## Purpose

Add a CMK KMS key to encrypt loadbalancer access logs in S3 using CMK

Fixes LPAL-724

## Approach

Adds an account-level KMS key in each account and uses the key to encrypt the access logs.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
