### PR TITLE
LPAL 724 Correct ignores on dynamodb encryption

### DIFF
--- a/terraform/account/workspace_cleanup.tf
+++ b/terraform/account/workspace_cleanup.tf
@@ -1,4 +1,4 @@
-#tfsec:ignore:AWS086 #tfsec:ignore:AWS092 Point in time and encryption not needed for this short lived data
+#tfsec:ignore:AWS086 #tfsec:ignore:AWS092 #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption Point in time and encryption not needed for this short lived data
 resource "aws_dynamodb_table" "workspace_cleanup_table" {
   count        = local.account_name == "development" ? 1 : 0
   name         = "WorkspaceCleanup"

--- a/terraform/environment/modules/environment/dynamo_db.tf
+++ b/terraform/environment/modules/environment/dynamo_db.tf
@@ -1,4 +1,4 @@
-#tfsec:ignore:AWS086 #tfsec:ignore:AWS092 short lived dynamo table doesn't hold customer data
+#tfsec:ignore:AWS086 #tfsec:ignore:AWS092 #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption short lived dynamo table doesn't hold customer data
 resource "aws_dynamodb_table" "lpa-locks" {
   name         = "lpa-locks-${var.environment_name}"
   billing_mode = "PAY_PER_REQUEST"
@@ -12,7 +12,7 @@ resource "aws_dynamodb_table" "lpa-locks" {
   tags = merge(local.default_opg_tags, local.dynamodb_component_tag)
 }
 
-#tfsec:ignore:AWS086 #tfsec:ignore:AWS092 short lived dynamo table doesn't hold customer data
+#tfsec:ignore:AWS086 #tfsec:ignore:AWS092 #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption short lived dynamo table doesn't hold customer data
 resource "aws_dynamodb_table" "lpa-properties" {
   name         = "lpa-properties-${var.environment_name}"
   billing_mode = "PAY_PER_REQUEST"
@@ -26,7 +26,7 @@ resource "aws_dynamodb_table" "lpa-properties" {
   tags = merge(local.default_opg_tags, local.dynamodb_component_tag)
 }
 
-#tfsec:ignore:AWS086 #tfsec:ignore:AWS092 To be removed soon as session table deprecated
+#tfsec:ignore:AWS086 #tfsec:ignore:AWS092 #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption To be removed soon as session table deprecated
 resource "aws_dynamodb_table" "lpa-sessions" {
   name         = "lpa-sessions-${var.environment_name}"
   billing_mode = "PAY_PER_REQUEST"


### PR DESCRIPTION
## Purpose

Add extra ignore for DynamoDB encryption

Fixes LPAL-724

## Approach

Add additional tfsec ignore for DynamoDB tables not requiring encryption.

## Learning

n/a 
## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
