### PR TITLE
converted to jsonencode

### DIFF
--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -197,7 +197,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
     #tfsec:ignore:aws-iam-no-policy-wildcards - Wildcard required for PutObject
     resources = [
-      "${data.aws_s3_bucket.lpa_pdf_cache.arn}*", 
+      "${data.aws_s3_bucket.lpa_pdf_cache.arn}*",
     ]
   }
   statement {

--- a/terraform/environment/modules/environment/ecs_api_cron.tf
+++ b/terraform/environment/modules/environment/ecs_api_cron.tf
@@ -111,16 +111,16 @@ resource "aws_cloudwatch_event_target" "api_ecs_cron_event_account_cleanup" {
     }
   }
 
-  input = <<DOC
-{
-  "containerOverrides": [
+  input = jsonencode(
     {
-      "name": "app",
-      "command": ["php", "/app/vendor/bin/laminas", "service-api:account-cleanup"]
-    }
-  ]
-}
-DOC
+      "containerOverrides" : [
+        {
+          "name" : "app",
+          "command" : ["php", "/app/vendor/bin/laminas", "service-api:account-cleanup"]
+        }
+      ]
+  })
+
 }
 
 //------------------------------------------------
@@ -148,14 +148,13 @@ resource "aws_cloudwatch_event_target" "api_ecs_cron_event_generate_stats" {
     }
   }
 
-  input = <<DOC
-{
-  "containerOverrides": [
+  input = jsonencode(
     {
-      "name": "app",
-      "command": ["php", "/app/vendor/bin/laminas", "service-api:generate-stats"]
-    }
-  ]
-}
-DOC
+      "containerOverrides" : [
+        {
+          "name" : "app",
+          "command" : ["php", "/app/vendor/bin/laminas", "service-api:generate-stats"]
+        }
+      ]
+  })
 }

--- a/terraform/environment/modules/environment/ecs_feedbackdb.tf
+++ b/terraform/environment/modules/environment/ecs_feedbackdb.tf
@@ -52,41 +52,40 @@ data "aws_ecr_repository" "lpa_feedbackdb_app" {
 // feedbackdb ECS Service Task Container level config
 
 locals {
-  feedbackdb_app = <<EOF
-  {
-    "cpu": 1,
-    "essential": true,
-    "image": "${data.aws_ecr_repository.lpa_feedbackdb_app.repository_url}:${var.container_version}",
-    "mountPoints": [],
-    "name": "app",
-    "portMappings": [
+  feedbackdb_app = jsonencode(
+    {
+      "cpu" : 1,
+      "essential" : true,
+      "image" : "${data.aws_ecr_repository.lpa_feedbackdb_app.repository_url}:${var.container_version}",
+      "mountPoints" : [],
+      "name" : "app",
+      "portMappings" : [
         {
-            "containerPort": 9000,
-            "hostPort": 9000,
-            "protocol": "tcp"
+          "containerPort" : 9000,
+          "hostPort" : 9000,
+          "protocol" : "tcp"
         }
-    ],
-    "volumesFrom": [],
-    "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-            "awslogs-group": "${aws_cloudwatch_log_group.application_logs.name}",
-            "awslogs-region": "${var.region_name}",
-            "awslogs-stream-prefix": "${var.environment_name}.feedbackdb.online-lpa"
+      ],
+      "volumesFrom" : [],
+      "logConfiguration" : {
+        "logDriver" : "awslogs",
+        "options" : {
+          "awslogs-group" : "${aws_cloudwatch_log_group.application_logs.name}",
+          "awslogs-region" : "${var.region_name}",
+          "awslogs-stream-prefix" : "${var.environment_name}.feedbackdb.online-lpa"
         }
-    },
-    "secrets": [
-      { "name": "OPG_LPA_POSTGRES_USERNAME", "valueFrom": "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.api_rds_username.name}" },
-      { "name": "OPG_LPA_POSTGRES_PASSWORD", "valueFrom": "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.api_rds_password.name}" },
-      { "name": "OPG_LPA_POSTGRES_FEEDBACK_USERNAME", "valueFrom": "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.performance_platform_db_username.name}" },
-      { "name": "OPG_LPA_POSTGRES_FEEDBACK_PASSWORD", "valueFrom": "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.performance_platform_db_password.name}" }
-    ],
-    "environment": [
-      { "name": "OPG_LPA_POSTGRES_NAME", "value": "${local.db.name}"},
-      { "name": "OPG_LPA_POSTGRES_HOSTNAME", "value": "${local.db.endpoint}"},
-      { "name": "OPG_LPA_POSTGRES_PORT", "value": "${local.db.port}"},
-      { "name": "OPG_LPA_STACK_ENVIRONMENT", "value" : "${var.account_name}"}
+      },
+      "secrets" : [
+        { "name" : "OPG_LPA_POSTGRES_USERNAME", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.api_rds_username.name}" },
+        { "name" : "OPG_LPA_POSTGRES_PASSWORD", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.api_rds_password.name}" },
+        { "name" : "OPG_LPA_POSTGRES_FEEDBACK_USERNAME", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.performance_platform_db_username.name}" },
+        { "name" : "OPG_LPA_POSTGRES_FEEDBACK_PASSWORD", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.performance_platform_db_password.name}" }
+      ],
+      "environment" : [
+        { "name" : "OPG_LPA_POSTGRES_NAME", "value" : "${local.db.name}" },
+        { "name" : "OPG_LPA_POSTGRES_HOSTNAME", "value" : "${local.db.endpoint}" },
+        { "name" : "OPG_LPA_POSTGRES_PORT", "value" : "${local.db.port}" },
+        { "name" : "OPG_LPA_STACK_ENVIRONMENT", "value" : "${var.account_name}" }
       ]
-    }
-  EOF
+  })
 }

--- a/terraform/environment/modules/environment/ecs_seeding.tf
+++ b/terraform/environment/modules/environment/ecs_seeding.tf
@@ -55,39 +55,38 @@ data "aws_ecr_repository" "lpa_seeding_app" {
 // seeding ECS Service Task Container level config
 
 locals {
-  seeding_app = <<EOF
-  {
-    "cpu": 1,
-    "essential": true,
-    "image": "${data.aws_ecr_repository.lpa_seeding_app.repository_url}:${var.container_version}",
-    "mountPoints": [],
-    "name": "app",
-    "portMappings": [
+  seeding_app = jsonencode(
+    {
+      "cpu" : 1,
+      "essential" : true,
+      "image" : "${data.aws_ecr_repository.lpa_seeding_app.repository_url}:${var.container_version}",
+      "mountPoints" : [],
+      "name" : "app",
+      "portMappings" : [
         {
-            "containerPort": 9000,
-            "hostPort": 9000,
-            "protocol": "tcp"
+          "containerPort" : 9000,
+          "hostPort" : 9000,
+          "protocol" : "tcp"
         }
-    ],
-    "volumesFrom": [],
-    "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-            "awslogs-group": "${aws_cloudwatch_log_group.application_logs.name}",
-            "awslogs-region": "${var.region_name}",
-            "awslogs-stream-prefix": "${var.environment_name}.seeding.online-lpa"
+      ],
+      "volumesFrom" : [],
+      "logConfiguration" : {
+        "logDriver" : "awslogs",
+        "options" : {
+          "awslogs-group" : "${aws_cloudwatch_log_group.application_logs.name}",
+          "awslogs-region" : "${var.region_name}",
+          "awslogs-stream-prefix" : "${var.environment_name}.seeding.online-lpa"
         }
-    },
-    "secrets": [
-      { "name": "OPG_LPA_POSTGRES_USERNAME", "valueFrom": "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.api_rds_username.name}" },
-      { "name": "OPG_LPA_POSTGRES_PASSWORD", "valueFrom": "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.api_rds_password.name}" }
-    ],
-    "environment": [
-      { "name": "OPG_LPA_POSTGRES_NAME", "value": "${local.db.name}"},
-      { "name": "OPG_LPA_POSTGRES_HOSTNAME", "value": "${local.db.endpoint}"},
-      { "name": "OPG_LPA_POSTGRES_PORT", "value": "${local.db.port}"},
-      { "name": "OPG_LPA_STACK_ENVIRONMENT", "value" : "${var.account_name}"}
+      },
+      "secrets" : [
+        { "name" : "OPG_LPA_POSTGRES_USERNAME", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.api_rds_username.name}" },
+        { "name" : "OPG_LPA_POSTGRES_PASSWORD", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.api_rds_password.name}" }
+      ],
+      "environment" : [
+        { "name" : "OPG_LPA_POSTGRES_NAME", "value" : "${local.db.name}" },
+        { "name" : "OPG_LPA_POSTGRES_HOSTNAME", "value" : "${local.db.endpoint}" },
+        { "name" : "OPG_LPA_POSTGRES_PORT", "value" : "${local.db.port}" },
+        { "name" : "OPG_LPA_STACK_ENVIRONMENT", "value" : "${var.account_name}" }
       ]
-    }
-  EOF
+  })
 }


### PR DESCRIPTION
## Purpose

to use `jsonencode` instead of HEREDOC notation as this is better to work with, and preferred for task definitions. These ones were missed on the previous pass.

Fixes LPAL-860

## Approach

remove HEREDOC usage where appropriate and wrap contents in a `jsonencode` function block

## Learning


## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
