### PR TITLE
LPAL-877 move certs to region level

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -4,6 +4,7 @@
     "preproduction": "preproduction",
     "production": "production"
   },
+
   "accounts": {
     "development": {
       "dr_enabled" : false,

--- a/terraform/region/modules/region/certificate.tf
+++ b/terraform/region/modules/region/certificate.tf
@@ -8,11 +8,6 @@ data "aws_route53_zone" "live_lastingpowerofattorney_gov_uk" {
   name     = "lastingpowerofattorney.service.gov.uk"
 }
 
-data "aws_route53_zone" "lastingpowerofattorney_service_gov_uk" {
-  provider = aws.legacy-lpa
-  name     = "lastingpowerofattorney.service.gov.uk"
-}
-
 //------------------------
 // Front Certificates
 

--- a/terraform/region/modules/region/locals.tf
+++ b/terraform/region/modules/region/locals.tf
@@ -7,6 +7,9 @@ locals {
   account_name_short          = local.account.account_name_short
   is_primary_region           = var.account.regions[data.aws_region.current.name].is_primary
   pagerduty_account_prefix    = local.account_name == "production" ? "Production" : "Non-Production"
+  cert_prefix_internal        = local.account_name == "production" ? "" : "*."
+  cert_prefix_public_facing   = local.account_name == "production" ? "www." : "*."
+  cert_prefix_development     = local.account_name == "development" ? "development." : ""
 
   mandatory_moj_tags = {
     business-unit = "OPG"


### PR DESCRIPTION
## Purpose

To Move account level cert definitions into region code, to allow region level Certificates. 

the process requires a bunch of imports and removals. Do not merge before completing approach below on preproduction and production.

Fixes LPAL-877

## Approach

the script is as follows (sensitive info redacted), each step is run individually for safety:

``` bash
#go to account level folder
cd terraform/account

#in account level init the workspace

export TF_WORKSPACE=<account name>
export TF_VAR_default_role=breakglass
aws-vault exec identity -- terraform init

#extract cert id's
aws-vault exec identity -- terraform show -json | jq '.values[].resources[] | select (.address | contains("cert")) | "aws-vault exec identity -- terraform import '"'"'module.eu-west-1." + .address + "'"'"' '"'"'"+ .values.id + "'"'"'"' | \
  awk '{print substr($0,2,length($0)-2)}'  | \
  tr -d "\\" > cert_import.sh
# extract states remove from account state
aws-vault exec identity -- terraform show -json | jq '.values[].resources[] | select (.address | contains("cert")) | "aws-vault exec identity -- terraform state rm '"'"'" + .address + "'"'"'"'  | \
  awk '{print substr($0,2,length($0)-2)}'  | \
  tr -d "\\" > state_removal.sh

#verify the contents of both files and remove the validation from the imports as these cannot be imported.

#switch to region level
cd ../region

#in region level init the workspace

export TF_WORKSPACE=<account name>
export TF_VAR_default_role=breakglass
aws-vault exec identity -- terraform init

# plan, but do not execute an apply as we need to check this
aws-vault exec identity -- terraform plan
#backup state
mkdir tfstate_backup
aws-vault exec identity -- terraform state pull > tfstate_backup/region_backup.tfstate

#check contents quickly
cat tfstate_backup/region_backup.tfstate | grep <account_name>

# if all good (changes made here) then run imports from the edited cert_import.sh file - e.g.

aws-vault exec identity -- terraform import 'module.eu-west-1.aws_acm_certificate.certificate_admin' 'arn:aws:acm:eu-west-1:<redacted>'
aws-vault exec identity -- terraform import 'module.eu-west-1.aws_acm_certificate.certificate_front' 'arn:aws:acm:eu-west-1:<redacted>'
aws-vault exec identity -- terraform import 'module.eu-west-1.aws_acm_certificate.certificate_public_facing' 'arn:aws:acm:eu-west-1:<redacted>'
aws-vault exec identity -- terraform import 'module.eu-west-1.aws_route53_record.certificate_validation_admin["*.<redacted>.admin.lpa.opg.service.justice.gov.uk"]' '<redacted>.admin.lpa.opg.service.justice.gov.uk._CNAME'
aws-vault exec identity -- terraform import 'module.eu-west-1.aws_route53_record.certificate_validation_front["*.<redacted>.front.lpa.opg.service.justice.gov.uk"]' '<redacted>.front.lpa.opg.service.justice.gov.uk._CNAME'
aws-vault exec identity -- terraform import 'module.eu-west-1.aws_route53_record.certificate_validation_public_facing["*.<redacted>.lastingpowerofattorney.service.gov.uk"]' '<redacted>.lastingpowerofattorney.service.gov.uk._CNAME'
# plan again, but do not execute an apply as we need to check this

aws-vault exec identity -- terraform plan

# go to account level and state remove the certs
cd ../account

# in account level init the workspace

export TF_WORKSPACE=<account name>
export TF_VAR_default_role=breakglass
aws-vault exec identity -- terrform init

# plan again, but do not execute an apply as we need to check this

aws-vault exec identity -- terraform plan

#backup state
mkdir tfstate_backup

aws-vault exec identity -- terraform state pull > tfstate_backup/account_backup.tfstate

#check contents quickly
cat tfstate_backup/account_backup.tfstate

#state rm the account level from the state_removal.sh file 
aws-vault exec identity -- terraform state rm 'aws_acm_certificate.certificate_admin'
aws-vault exec identity -- terraform state rm 'aws_acm_certificate.certificate_front'
aws-vault exec identity -- terraform state rm 'aws_acm_certificate.certificate_public_facing'
aws-vault exec identity -- terraform state rm 'aws_acm_certificate_validation.certificate_admin'
aws-vault exec identity -- terraform state rm 'aws_acm_certificate_validation.certificate_front'
aws-vault exec identity -- terraform state rm 'aws_acm_certificate_validation.certificate_public_facing'
aws-vault exec identity -- terraform state rm 'aws_route53_record.certificate_validation_admin["*.<redacted>.admin.lpa.opg.service.justice.gov.uk"]'
aws-vault exec identity -- terraform state rm 'aws_route53_record.certificate_validation_front["*.<redacted>.front.lpa.opg.service.justice.gov.uk"]'
aws-vault exec identity -- terraform state rm 'aws_route53_record.certificate_validation_public_facing["*.<redacted>.lastingpowerofattorney.service.gov.uk"]'


# plan again, but do not execute an apply as we need to check this

aws-vault exec identity -- terraform plan

#go to region and apply the changes
cd ../region

aws-vault exec identity -- terraform apply

# remove state backups if all ok and 
# run a bunch of checks on management account Hosted Zones and cloudwatch in the current account.

# backup plan
# IN CASE OF ERROR:
#revert changes in branch

# push account level backup state:
aws-vault exec identity -- terraform state push tfstate_backup/account_backup.tfstate

# run a a state check
aws-vault exec identity -- terraform plan

# push region state
cd ../region
aws-vault exec identity -- terraform state push tfstate_backup/account_backup.tfstate

# run a bunch of checks on management account Hosted Zones and cloudwatch in the current account.
```

## Learning

See [https://aws.amazon.com/premiumsupport/knowledge-center/acm-export-certificate/](https://aws.amazon.com/premiumsupport/knowledge-center/acm-export-certificate/#:~:text=You%20can%20create%20multiple%20ACM,see%20Requesting%20a%20public%20certificate.)


## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
