### PR TITLE
LPAL-859: Use provider-level default tags for account

### DIFF
--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -4,7 +4,6 @@ resource "aws_cloudwatch_log_group" "online-lpa" {
   retention_in_days = local.account.retention_in_days
 
   tags = merge(
-    local.default_tags,
     local.shared_component_tag,
     {
       "Name" = "online-lpa"
@@ -44,7 +43,7 @@ resource "aws_cloudwatch_metric_alarm" "account_breakglass_login_alarm" {
   evaluation_periods  = 1
   datapoints_to_alarm = 1
   statistic           = "Sum"
-  tags                = merge(local.default_tags, local.shared_component_tag)
+  tags                = local.shared_component_tag
   threshold           = 1
   treat_missing_data  = "notBreaching"
 }

--- a/terraform/account/iam.tf
+++ b/terraform/account/iam.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role" "rds_enhanced_monitoring" {
   name               = "rds-enhanced-monitoring"
   assume_role_policy = data.aws_iam_policy_document.rds_enhanced_monitoring.json
-  tags               = merge(local.default_tags, local.db_component_tag)
+  tags               = local.db_component_tag
 }
 
 resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "rds_enhanced_monitoring" {
 resource "aws_iam_role" "vpc_flow_logs" {
   name               = "vpc_flow_logs"
   assume_role_policy = data.aws_iam_policy_document.vpc_flow_logs_role_assume_role_policy.json
-  tags               = merge(local.default_tags, local.shared_component_tag)
+  tags               = local.shared_component_tag
 }
 
 data "aws_iam_policy_document" "vpc_flow_logs_role_assume_role_policy" {

--- a/terraform/account/s3.tf
+++ b/terraform/account/s3.tf
@@ -51,7 +51,6 @@ data "aws_iam_policy_document" "loadbalancer_logging" {
 resource "aws_s3_bucket" "access_log" {
   bucket = "online-lpa-${terraform.workspace}-lb-access-logs"
   acl    = "private"
-  tags   = local.default_tags
 
   server_side_encryption_configuration {
     rule {

--- a/terraform/account/sns.tf
+++ b/terraform/account/sns.tf
@@ -1,16 +1,16 @@
 #tfsec:ignore:AWS016 fix for now, to be followed with a CMK KMS
 resource "aws_sns_topic" "cloudwatch_to_slack_breakglass_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-Breakglass-alert"
-  tags = merge(local.default_tags, local.shared_component_tag)
+  tags = local.shared_component_tag
 }
 #tfsec:ignore:AWS016 unsupported for this type of alert
 resource "aws_sns_topic" "cloudwatch_to_slack_elasticache_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-elasticache-alert"
-  tags = merge(local.default_tags, local.front_component_tag)
+  tags = local.front_component_tag
 }
 
 #tfsec:ignore:AWS016 unsupported for this type of alert
 resource "aws_sns_topic" "cloudwatch_to_account_ops_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-account-ops-alert"
-  tags = merge(local.default_tags, local.shared_component_tag)
+  tags = local.shared_component_tag
 }

--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -22,6 +22,9 @@ terraform {
 
 provider "aws" {
   region = "eu-west-1"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
@@ -31,6 +34,9 @@ provider "aws" {
 provider "aws" {
   alias  = "eu-west-1"
   region = "eu-west-1"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
@@ -49,6 +55,9 @@ provider "aws" {
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
@@ -58,6 +67,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "management"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.default_role}"
     session_name = "terraform-session"
@@ -67,6 +79,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "legacy-lpa"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::550790013665:role/${var.default_role}"
     session_name = "terraform-session"

--- a/terraform/account/workspace_cleanup.tf
+++ b/terraform/account/workspace_cleanup.tf
@@ -15,7 +15,7 @@ resource "aws_dynamodb_table" "workspace_cleanup_table" {
     enabled        = true
   }
 
-  tags = merge(local.default_tags, local.shared_component_tag)
+  tags = local.shared_component_tag
 
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
## Purpose

Add provider-level default tags for account Terraform

Fixes LPAL-859

## Approach

Move default tags to provider block and remove merge function usage where no longer necessary. Limited to accounts terraform directory.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
