### PR TITLE
LPAL-885 Reveal outline around date entry fields

### DIFF
--- a/service-front/assets/sass/extensions/elements/_forms.scss
+++ b/service-front/assets/sass/extensions/elements/_forms.scss
@@ -17,7 +17,7 @@
 
 .form-date {
     margin-bottom: 30px;
-    overflow: hidden;
+    overflow: visible;
 
     // Hide a new placement of error messages only for within popup
     .error-group-popup {
@@ -60,4 +60,3 @@
         }
     }
 }
-

--- a/service-front/assets/sass/patterns/_form-popup.scss
+++ b/service-front/assets/sass/patterns/_form-popup.scss
@@ -108,10 +108,10 @@
     }
 
     .form-date {
-        margin-bottom: 15px;
+        overflow: visible;
 
-        .form-group { 
-            margin-bottom: 0; 
+        .form-group {
+            margin-bottom: 18px;
         }
 
         .form-hint {
@@ -156,7 +156,7 @@
 
     .form-group-error {
         border-left: 0;
-        
+
         @include media(tablet) {
             position: relative;
             margin-right: 0;
@@ -246,4 +246,3 @@
         }
     }
 }
-

--- a/service-front/assets/sass/patterns/_form-popup.scss
+++ b/service-front/assets/sass/patterns/_form-popup.scss
@@ -108,8 +108,6 @@
     }
 
     .form-date {
-        overflow: visible;
-
         .form-group {
             margin-bottom: 18px;
         }


### PR DESCRIPTION
## Purpose

[LPAL-885](https://opgtransform.atlassian.net/browse/LPAL-885)

## Approach

Judicious margin adjustment and overflow change to make the outline visible around date entry inputs.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [x] The product team have tested these changes
