### PR TITLE
LPAL-859 New default_tags in region

### DIFF
--- a/terraform/region/modules/region/certificate.tf
+++ b/terraform/region/modules/region/certificate.tf
@@ -36,7 +36,7 @@ resource "aws_acm_certificate_validation" "certificate_front" {
 resource "aws_acm_certificate" "certificate_front" {
   domain_name       = "${local.cert_prefix_internal}${local.cert_prefix_development}front.lpa.opg.service.justice.gov.uk"
   validation_method = "DNS"
-  tags              = merge(local.default_tags, local.shared_component_tag)
+  tags              = local.shared_component_tag
 }
 
 //------------------------
@@ -69,7 +69,7 @@ resource "aws_acm_certificate_validation" "certificate_admin" {
 resource "aws_acm_certificate" "certificate_admin" {
   domain_name       = "${local.cert_prefix_internal}${local.cert_prefix_development}admin.lpa.opg.service.justice.gov.uk"
   validation_method = "DNS"
-  tags              = merge(local.default_tags, local.shared_component_tag)
+  tags              = local.shared_component_tag
 }
 
 //---------------
@@ -103,7 +103,7 @@ resource "aws_acm_certificate" "certificate_public_facing" {
   domain_name               = "${local.cert_prefix_public_facing}${local.cert_prefix_development}${data.aws_route53_zone.live_lastingpowerofattorney_gov_uk.name}"
   validation_method         = "DNS"
   subject_alternative_names = terraform.workspace == "production" ? ["lastingpowerofattorney.service.gov.uk", "maintenance.lastingpowerofattorney.service.gov.uk"] : []
-  tags                      = merge(local.default_tags, local.shared_component_tag)
+  tags                      = local.shared_component_tag
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/region/modules/region/cloudwatch.tf
+++ b/terraform/region/modules/region/cloudwatch.tf
@@ -59,7 +59,6 @@ resource "aws_cloudwatch_event_rule" "tasks_stopped" {
     }
   })
   tags = merge(
-    local.default_tags,
     local.shared_component_tag,
     {
       "Name" = "online-lpa"

--- a/terraform/region/modules/region/dns_firewall.tf
+++ b/terraform/region/modules/region/dns_firewall.tf
@@ -4,7 +4,6 @@ resource "aws_cloudwatch_log_group" "aws_route53_resolver_query_log" {
   retention_in_days = 400
   kms_key_id        = aws_kms_key.cloudwatch_encryption.arn
   tags = merge(
-    local.default_tags,
     local.shared_component_tag, {
       "Name" = "make-an-lpa-aws-route53-resolver-query-log-config"
     },

--- a/terraform/region/modules/region/elasticache.tf
+++ b/terraform/region/modules/region/elasticache.tf
@@ -2,7 +2,7 @@
 resource "aws_security_group" "front_cache" {
   name   = "${local.account_name_short}-${local.region_name}-front-cache"
   vpc_id = aws_default_vpc.default.id
-  tags   = merge(local.default_tags, local.front_component_tag)
+  tags   = local.front_component_tag
 }
 
 resource "aws_elasticache_subnet_group" "private_subnets" {
@@ -28,7 +28,7 @@ resource "aws_elasticache_replication_group" "front_cache" {
   subnet_group_name             = aws_elasticache_subnet_group.private_subnets.name
   security_group_ids            = [aws_security_group.front_cache.id]
 
-  tags = merge(local.default_tags, local.front_component_tag)
+  tags = local.front_component_tag
 }
 
 

--- a/terraform/region/modules/region/kms.tf
+++ b/terraform/region/modules/region/kms.tf
@@ -11,7 +11,7 @@ resource "aws_kms_alias" "secrets_encryption_alias" {
 resource "aws_kms_key" "lpa_pdf_cache" {
   description             = "S3 bucket encryption key for lpa_pdf_cache"
   deletion_window_in_days = 7
-  tags                    = merge(local.default_tags, local.pdf_component_tag)
+  tags                    = local.pdf_component_tag
   enable_key_rotation     = true
 }
 
@@ -25,7 +25,7 @@ resource "aws_kms_alias" "lpa_pdf_cache" {
 resource "aws_kms_key" "cloudwatch_encryption" {
   description             = "encryption key for cloudwatch"
   deletion_window_in_days = 7
-  tags                    = merge(local.default_tags, local.pdf_component_tag)
+  tags                    = local.pdf_component_tag
   enable_key_rotation     = true
   policy                  = data.aws_iam_policy_document.cloudwatch_encryption_kms.json
 

--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -50,7 +50,6 @@ data "aws_iam_policy_document" "loadbalancer_logging" {
 resource "aws_s3_bucket" "access_log" {
   bucket = "online-lpa-${local.account_name}-${local.region_name}-lb-access-logs"
   acl    = "private"
-  tags   = local.default_tags
 
   server_side_encryption_configuration {
     rule {
@@ -97,7 +96,6 @@ resource "aws_s3_bucket" "lpa_pdf_cache" {
     }
   }
 
-  tags = local.default_tags
 }
 
 resource "aws_s3_bucket_policy" "lpa_pdf_cache" {

--- a/terraform/region/modules/region/sns.tf
+++ b/terraform/region/modules/region/sns.tf
@@ -1,18 +1,18 @@
 #tfsec:ignore:AWS016 unsupported for this type of alert
 resource "aws_sns_topic" "cloudwatch_to_slack_elasticache_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-${local.region_name}-elasticache-alert"
-  tags = merge(local.default_tags, local.front_component_tag)
+  tags = local.front_component_tag
 }
 
 #tfsec:ignore:AWS016 unsupported for this type of alert
 resource "aws_sns_topic" "cloudwatch_to_account_ops_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-${local.region_name}-ops-alert"
-  tags = merge(local.default_tags, local.shared_component_tag)
+  tags = local.shared_component_tag
 }
 
 resource "aws_sns_topic" "rds_events" {
   name = "${local.account_name}-${local.region_name}-rds-events"
-  tags = merge(local.default_tags, local.db_component_tag)
+  tags = local.db_component_tag
 }
 
 resource "aws_db_event_subscription" "rds_events" {

--- a/terraform/region/modules/region/subnet.tf
+++ b/terraform/region/modules/region/subnet.tf
@@ -14,11 +14,10 @@ resource "aws_default_subnet" "public" {
   availability_zone       = element(data.aws_availability_zones.default.names, count.index)
   map_public_ip_on_launch = false
   tags = merge(
-    local.default_tags,
     local.shared_component_tag,
-    tomap({
+    {
       "Name" = "public"
-    })
+    },
   )
 }
 
@@ -30,11 +29,10 @@ resource "aws_subnet" "private" {
   availability_zone = element(data.aws_availability_zones.default.names, count.index)
 
   tags = merge(
-    local.default_tags,
     local.shared_component_tag,
-    tomap({
+    {
       "Name" = "private"
-    })
+    },
   )
 }
 

--- a/terraform/region/modules/region/vpc.tf
+++ b/terraform/region/modules/region/vpc.tf
@@ -1,11 +1,10 @@
 #tfsec:ignore:AWS082 this is currently std practice. will look to change later if needed
 resource "aws_default_vpc" "default" {
   tags = merge(
-    local.default_tags,
     local.shared_component_tag,
-    tomap({
+    {
       "Name" = "default"
-    })
+    },
   )
 }
 
@@ -14,11 +13,10 @@ resource "aws_eip" "nat" {
   count = 3
 
   tags = merge(
-    local.default_tags,
     local.shared_component_tag,
-    tomap({
+    {
       "Name" = "nat"
-    })
+    },
   )
 }
 
@@ -41,11 +39,10 @@ resource "aws_nat_gateway" "nat" {
   subnet_id     = element(aws_default_subnet.public.*.id, count.index)
 
   tags = merge(
-    local.default_tags,
     local.shared_component_tag,
-    tomap({
+    {
       "Name" = "nat"
-    })
+    },
   )
 }
 
@@ -53,11 +50,10 @@ resource "aws_default_route_table" "default" {
   default_route_table_id = aws_default_vpc.default.default_route_table_id
 
   tags = merge(
-    local.default_tags,
     local.shared_component_tag,
-    tomap({
+    {
       "Name" = "default"
-    })
+    },
   )
 }
 
@@ -66,11 +62,10 @@ resource "aws_route_table" "private" {
   vpc_id = aws_default_vpc.default.id
 
   tags = merge(
-    local.default_tags,
     local.shared_component_tag,
-    tomap({
+    {
       "Name" = "private"
-    })
+    },
   )
 }
 

--- a/terraform/region/modules/region/vpc_flow_logs.tf
+++ b/terraform/region/modules/region/vpc_flow_logs.tf
@@ -3,19 +3,18 @@ resource "aws_flow_log" "vpc_flow_logs" {
   log_destination = aws_cloudwatch_log_group.vpc_flow_logs_region.arn
   traffic_type    = "ALL"
   vpc_id          = aws_default_vpc.default.id
-  tags            = local.default_tags
 }
 
 #tfsec:ignore:AWS089 cost to encrypt is expensive. this is legacy so keep for now.
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
   name = "vpc_flow_logs"
-  tags = merge(local.default_tags, local.shared_component_tag)
+  tags = local.shared_component_tag
 }
 
 #tfsec:ignore:AWS089 cost to encrypt is expensive. region support needed
 resource "aws_cloudwatch_log_group" "vpc_flow_logs_region" {
   name = "vpc_flow_logs_${local.account_name}_${local.region_name}"
-  tags = merge(local.default_tags, local.shared_component_tag)
+  tags = local.shared_component_tag
 }
 
 

--- a/terraform/region/terraform.tf
+++ b/terraform/region/terraform.tf
@@ -24,7 +24,7 @@ terraform {
 provider "aws" {
   region = "eu-west-1"
   default_tags {
-    tags = local.default_tags
+    tags = local.default_opg_tags
   }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
@@ -36,7 +36,7 @@ provider "aws" {
   alias  = "eu-west-1"
   region = "eu-west-1"
   default_tags {
-    tags = local.default_tags
+    tags = local.default_opg_tags
   }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
@@ -48,7 +48,7 @@ provider "aws" {
   region = "eu-west-2"
   alias  = "eu-west-2"
   default_tags {
-    tags = local.default_tags
+    tags = local.default_opg_tags
   }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
@@ -59,6 +59,9 @@ provider "aws" {
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
+  default_tags {
+    tags = local.default_opg_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
@@ -69,7 +72,7 @@ provider "aws" {
   region = "eu-west-1"
   alias  = "management"
   default_tags {
-    tags = local.default_tags
+    tags = local.default_opg_tags
   }
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.default_role}"

--- a/terraform/region/terraform.tf
+++ b/terraform/region/terraform.tf
@@ -23,6 +23,9 @@ terraform {
 
 provider "aws" {
   region = "eu-west-1"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
@@ -32,6 +35,9 @@ provider "aws" {
 provider "aws" {
   alias  = "eu-west-1"
   region = "eu-west-1"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
@@ -41,6 +47,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-2"
   alias  = "eu-west-2"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
@@ -59,6 +68,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "management"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.default_role}"
     session_name = "terraform-session"


### PR DESCRIPTION
## Purpose

Use provider-level `default_tags` block instead instead of duplicating merging default_tags on each resource. Region level only.

Fixes LPAL-859

## Approach

Removes unnecessary merge function calls and use default_tags in the provider block.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
