### PR TITLE
LPAL-872 Add tfsec commenter to Github Actions

### DIFF
--- a/.github/workflows/tfsec-pr-commenter.yml
+++ b/.github/workflows/tfsec-pr-commenter.yml
@@ -1,0 +1,38 @@
+name: "[Analysis] TFSec PR feedback"
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "**.tf"
+
+permissions:
+  actions: read
+  checks: read
+  contents: none
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: write
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  tfsec:
+    name: TFSec Static analysis
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        terraform_path: ['terraform/account', 'terraform/region' ,'terraform/environment']
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: tfsec with pr comments
+        uses: tfsec/tfsec-pr-commenter-action@v1.2.0
+        with:
+          working_directory: ${{ matrix.terraform_path }}
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          soft_fail_commenter: true


### PR DESCRIPTION
## Purpose

Re-add the TFSEC Commenter to the repo. the idea is that it will create comments for TFSec violations on terraform.

Fixes LPAL-872

## Approach

Add a github action 

## Learning

https://github.com/aquasecurity/tfsec-pr-commenter-action 

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
