### PR TITLE
LPAL-886 Restyle "View LPA" button to improve contrast

### DIFF
--- a/service-front/module/Application/view/application/authenticated/dashboard/macros.twig
+++ b/service-front/module/Application/view/application/authenticated/dashboard/macros.twig
@@ -48,7 +48,7 @@
                 </div>
 
                 <div class="list-item_cta">
-                    <a class="button button-secondary" data-cy="view-or-continue-lpa-{{ lpa.id }}" role="button" href="/lpa/{{ lpa.id }}">
+                    <a class="button" data-cy="view-or-continue-lpa-{{ lpa.id }}" role="button" href="/lpa/{{ lpa.id }}">
                         {% if lpa.progress in ['Started', 'Created'] %}Continue<span class="visually-hidden"> LPA A{{ lpa.id }}</span>{% else %}View LPA<span class="visually-hidden"> A{{ lpa.id }}</span>{% endif %}
                     </a>
                     <ul class="list-item_secondary_actions">


### PR DESCRIPTION
## Purpose

[LPAL-886](https://opgtransform.atlassian.net/browse/LPAL-886)

## Approach

Use the same styling as main action buttons (white text on green) for the View LPA buttons in the dashboard.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [x] The product team have tested these changes
