### PR TITLE
LPAL-859 Use default_tags block in TF provider

### DIFF
--- a/terraform/environment/modules/environment/autoscaling.tf
+++ b/terraform/environment/modules/environment/autoscaling.tf
@@ -6,7 +6,7 @@ module "front_ecs_autoscaling" {
   ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn
   ecs_task_autoscaling_minimum     = var.account.autoscaling.front.minimum
   ecs_task_autoscaling_maximum     = var.account.autoscaling.front.maximum
-  tags                             = merge(local.default_opg_tags, local.front_component_tag)
+  tags                             = local.front_component_tag
 }
 
 module "api_ecs_autoscaling" {
@@ -17,7 +17,7 @@ module "api_ecs_autoscaling" {
   ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn
   ecs_task_autoscaling_minimum     = var.account.autoscaling.api.minimum
   ecs_task_autoscaling_maximum     = var.account.autoscaling.api.maximum
-  tags                             = merge(local.default_opg_tags, local.api_component_tag)
+  tags                             = local.api_component_tag
 }
 
 module "pdf_ecs_autoscaling" {
@@ -28,7 +28,7 @@ module "pdf_ecs_autoscaling" {
   ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn
   ecs_task_autoscaling_minimum     = var.account.autoscaling.pdf.minimum
   ecs_task_autoscaling_maximum     = var.account.autoscaling.pdf.maximum
-  tags                             = merge(local.default_opg_tags, local.pdf_component_tag)
+  tags                             = local.pdf_component_tag
 }
 
 module "admin_ecs_autoscaling" {
@@ -39,5 +39,5 @@ module "admin_ecs_autoscaling" {
   ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn
   ecs_task_autoscaling_minimum     = 1
   ecs_task_autoscaling_maximum     = 1
-  tags                             = merge(local.default_opg_tags, local.pdf_component_tag)
+  tags                             = local.pdf_component_tag
 }

--- a/terraform/environment/modules/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/modules/environment/cloudwatch_alarms.tf
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "front_5xx_errors" {
   ok_actions                = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
   period                    = 60
   statistic                 = "Sum"
-  tags                      = merge(local.default_opg_tags, local.front_component_tag)
+  tags                      = local.front_component_tag
   threshold                 = 2
   treat_missing_data        = "notBreaching"
 }
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_metric_alarm" "admin_5xx_errors" {
   ok_actions                = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
   period                    = 60
   statistic                 = "Sum"
-  tags                      = merge(local.default_opg_tags, local.admin_component_tag)
+  tags                      = local.admin_component_tag
   threshold                 = 2
   treat_missing_data        = "notBreaching"
 }
@@ -60,7 +60,7 @@ resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
   evaluation_periods  = 1
   datapoints_to_alarm = 1
   statistic           = "Sum"
-  tags                = merge(local.default_opg_tags, local.pdf_component_tag)
+  tags                = local.pdf_component_tag
   threshold           = 6
   treat_missing_data  = "notBreaching"
 }
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "front_ddos_attack_external" {
   alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
   treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
-  tags                = merge(local.default_opg_tags, local.front_component_tag)
+  tags                = local.front_component_tag
   dimensions = {
     ResourceArn = aws_lb.front.arn
   }
@@ -95,7 +95,7 @@ resource "aws_cloudwatch_metric_alarm" "admin_ddos_attack_external" {
   alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
   treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
-  tags                = merge(local.default_opg_tags, local.admin_component_tag)
+  tags                = local.admin_component_tag
   dimensions = {
     ResourceArn = aws_lb.admin.arn
   }

--- a/terraform/environment/modules/environment/cloudwatch_logs.tf
+++ b/terraform/environment/modules/environment/cloudwatch_logs.tf
@@ -4,7 +4,6 @@ resource "aws_cloudwatch_log_group" "application_logs" {
   retention_in_days = var.account.log_retention_in_days
 
   tags = merge(
-    local.default_opg_tags,
     local.shared_component_tag,
     {
       "Name" = "${var.environment_name}_application_logs"

--- a/terraform/environment/modules/environment/dynamo_db.tf
+++ b/terraform/environment/modules/environment/dynamo_db.tf
@@ -9,7 +9,7 @@ resource "aws_dynamodb_table" "lpa-locks" {
     type = "S"
   }
 
-  tags = merge(local.default_opg_tags, local.dynamodb_component_tag)
+  tags = local.dynamodb_component_tag
 }
 
 #tfsec:ignore:AWS086 #tfsec:ignore:AWS092 #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption short lived dynamo table doesn't hold customer data
@@ -23,7 +23,7 @@ resource "aws_dynamodb_table" "lpa-properties" {
     type = "S"
   }
 
-  tags = merge(local.default_opg_tags, local.dynamodb_component_tag)
+  tags = local.dynamodb_component_tag
 }
 
 #tfsec:ignore:AWS086 #tfsec:ignore:AWS092 #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption To be removed soon as session table deprecated
@@ -42,5 +42,5 @@ resource "aws_dynamodb_table" "lpa-sessions" {
     enabled        = true
   }
 
-  tags = merge(local.default_opg_tags, local.dynamodb_component_tag)
+  tags = local.dynamodb_component_tag
 }

--- a/terraform/environment/modules/environment/ecs_admin.tf
+++ b/terraform/environment/modules/environment/ecs_admin.tf
@@ -23,7 +23,7 @@ resource "aws_ecs_service" "admin" {
   }
 
   depends_on = [aws_lb.admin, aws_iam_role.admin_task_role, aws_iam_role.execution_role]
-  tags       = merge(local.default_opg_tags, local.admin_component_tag)
+  tags       = local.admin_component_tag
 }
 
 //----------------------------------
@@ -33,7 +33,7 @@ resource "aws_ecs_service" "admin" {
 resource "aws_security_group" "admin_ecs_service" {
   name_prefix = "${var.environment_name}-admin-ecs-service"
   vpc_id      = data.aws_vpc.default.id
-  tags        = merge(local.default_opg_tags, local.admin_component_tag)
+  tags        = local.admin_component_tag
 }
 
 resource "aws_security_group_rule" "admin_ecs_service_ingress" {
@@ -69,7 +69,7 @@ resource "aws_ecs_task_definition" "admin" {
   container_definitions    = "[${local.admin_web}, ${local.admin_app}]"
   task_role_arn            = aws_iam_role.admin_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = merge(local.default_opg_tags, local.admin_component_tag)
+  tags                     = local.admin_component_tag
 }
 
 //----------------
@@ -78,7 +78,7 @@ resource "aws_ecs_task_definition" "admin" {
 resource "aws_iam_role" "admin_task_role" {
   name               = "${var.environment_name}-admin-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = merge(local.default_opg_tags, local.admin_component_tag)
+  tags               = local.admin_component_tag
 }
 
 resource "aws_iam_role_policy" "admin_permissions_role" {

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -22,7 +22,7 @@ resource "aws_ecs_service" "api" {
   service_registries {
     registry_arn = aws_service_discovery_service.api_canonical.arn
   }
-  tags = merge(local.default_opg_tags, local.api_component_tag)
+  tags = local.api_component_tag
 }
 
 //-----------------------------------------------
@@ -78,7 +78,7 @@ locals {
 resource "aws_security_group" "api_ecs_service" {
   name_prefix = "${terraform.workspace}-api-ecs-service"
   vpc_id      = data.aws_vpc.default.id
-  tags        = merge(local.default_opg_tags, local.api_component_tag)
+  tags        = local.api_component_tag
 }
 
 resource "aws_security_group_rule" "api_ecs_service_front_ingress" {
@@ -124,7 +124,7 @@ resource "aws_ecs_task_definition" "api" {
   container_definitions    = "[${local.api_web}, ${local.api_app}]"
   task_role_arn            = aws_iam_role.api_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = merge(local.default_opg_tags, local.api_component_tag)
+  tags                     = local.api_component_tag
 }
 
 
@@ -134,7 +134,7 @@ resource "aws_ecs_task_definition" "api" {
 resource "aws_iam_role" "api_task_role" {
   name               = "${var.environment_name}-api-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = merge(local.default_opg_tags, local.api_component_tag)
+  tags               = local.api_component_tag
 }
 
 resource "aws_iam_role_policy" "api_permissions_role" {

--- a/terraform/environment/modules/environment/ecs_api_cron.tf
+++ b/terraform/environment/modules/environment/ecs_api_cron.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "cloudwatch_events_assume_policy" {
 resource "aws_iam_role" "cloudwatch_events_ecs_role" {
   name               = "${var.environment_name}-cloudwatch_events_ecs_cron"
   assume_role_policy = data.aws_iam_policy_document.cloudwatch_events_assume_policy.json
-  tags               = merge(local.default_opg_tags, local.api_component_tag)
+  tags               = local.api_component_tag
 }
 
 //---
@@ -59,13 +59,13 @@ resource "aws_iam_role_policy" "ecs_events_run_task_with_any_role" {
 resource "aws_cloudwatch_event_rule" "middle_of_the_night" {
   name                = "${var.environment_name}-middle-of-the-night-cron"
   schedule_expression = "cron(0 3 * * ? *)" // 3am UTC, every day.
-  tags                = merge(local.default_opg_tags, local.api_component_tag)
+  tags                = local.api_component_tag
 }
 
 resource "aws_cloudwatch_event_rule" "mid_morning" {
   name                = "${var.environment_name}-mid-morning-cron"
   schedule_expression = "cron(0 10 * * ? *)" // 10am UTC, every day.
-  tags                = merge(local.default_opg_tags, local.api_component_tag)
+  tags                = local.api_component_tag
 }
 
 //------------------------------------------------
@@ -80,7 +80,7 @@ resource "aws_ecs_task_definition" "api_crons" {
   container_definitions    = "[${local.api_app}]"
   task_role_arn            = aws_iam_role.api_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = merge(local.default_opg_tags, local.api_component_tag)
+  tags                     = local.api_component_tag
 }
 
 //------------------------------------------------

--- a/terraform/environment/modules/environment/ecs_cluster.tf
+++ b/terraform/environment/modules/environment/ecs_cluster.tf
@@ -1,6 +1,6 @@
 resource "aws_ecs_cluster" "online-lpa" {
   name = "${var.environment_name}-online-lpa"
-  tags = merge(local.default_opg_tags, local.shared_component_tag)
+  tags = local.shared_component_tag
 
   setting {
     name  = "containerInsights"
@@ -10,13 +10,13 @@ resource "aws_ecs_cluster" "online-lpa" {
 
 data "aws_cloudwatch_log_group" "online-lpa" {
   name = "online-lpa"
-  tags = merge(local.default_opg_tags, local.shared_component_tag)
+  tags = local.shared_component_tag
 }
 
 resource "aws_iam_role" "execution_role" {
   name               = "${var.environment_name}-execution-role-ecs-cluster"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = merge(local.default_opg_tags, local.shared_component_tag)
+  tags               = local.shared_component_tag
 }
 
 data "aws_iam_policy_document" "ecs_assume_policy" {

--- a/terraform/environment/modules/environment/ecs_feedbackdb.tf
+++ b/terraform/environment/modules/environment/ecs_feedbackdb.tf
@@ -4,7 +4,7 @@
 resource "aws_security_group" "feedbackdb_ecs_service" {
   name_prefix = "${terraform.workspace}-feedbackdb-ecs-service"
   vpc_id      = data.aws_vpc.default.id
-  tags        = merge(local.default_opg_tags, local.feedbackdb_component_tag)
+  tags        = local.feedbackdb_component_tag
 }
 
 resource "aws_security_group_rule" "feedbackdb_ecs_service_egress" {
@@ -30,7 +30,7 @@ resource "aws_ecs_task_definition" "feedbackdb" {
   container_definitions    = "[${local.feedbackdb_app}]"
   task_role_arn            = aws_iam_role.feedbackdb_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = merge(local.default_opg_tags, local.feedbackdb_component_tag)
+  tags                     = local.feedbackdb_component_tag
 }
 
 
@@ -40,7 +40,7 @@ resource "aws_ecs_task_definition" "feedbackdb" {
 resource "aws_iam_role" "feedbackdb_task_role" {
   name               = "${var.environment_name}-feedbackdb-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = merge(local.default_opg_tags, local.feedbackdb_component_tag)
+  tags               = local.feedbackdb_component_tag
 }
 
 data "aws_ecr_repository" "lpa_feedbackdb_app" {

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -23,7 +23,7 @@ resource "aws_ecs_service" "front" {
   }
 
   depends_on = [aws_lb.front, aws_iam_role.front_task_role, aws_iam_role.execution_role]
-  tags       = merge(local.default_opg_tags, local.front_component_tag)
+  tags       = local.front_component_tag
 }
 
 //----------------------------------
@@ -33,7 +33,7 @@ resource "aws_ecs_service" "front" {
 resource "aws_security_group" "front_ecs_service" {
   name_prefix = "${var.environment_name}-front-ecs-service"
   vpc_id      = data.aws_vpc.default.id
-  tags        = merge(local.default_opg_tags, local.front_component_tag)
+  tags        = local.front_component_tag
 
 }
 
@@ -80,7 +80,7 @@ resource "aws_ecs_task_definition" "front" {
   container_definitions    = "[${local.front_web}, ${local.front_app}, ${local.front_v2_app}]"
   task_role_arn            = aws_iam_role.front_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = merge(local.default_opg_tags, local.front_component_tag)
+  tags                     = local.front_component_tag
 
 }
 
@@ -90,7 +90,7 @@ resource "aws_ecs_task_definition" "front" {
 resource "aws_iam_role" "front_task_role" {
   name               = "${var.environment_name}-front-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = merge(local.default_opg_tags, local.front_component_tag)
+  tags               = local.front_component_tag
 
 }
 

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -17,7 +17,7 @@ resource "aws_ecs_service" "pdf" {
   }
 
   depends_on = [aws_iam_role.pdf_task_role, aws_iam_role.execution_role]
-  tags       = merge(local.default_opg_tags, local.pdf_component_tag)
+  tags       = local.pdf_component_tag
 
 }
 
@@ -28,7 +28,7 @@ resource "aws_ecs_service" "pdf" {
 resource "aws_security_group" "pdf_ecs_service" {
   name_prefix = "${var.environment_name}-pdf-ecs-service"
   vpc_id      = data.aws_vpc.default.id
-  tags        = merge(local.default_opg_tags, local.pdf_component_tag)
+  tags        = local.pdf_component_tag
 }
 
 resource "aws_security_group_rule" "pdf_ecs_service_egress" {
@@ -54,7 +54,7 @@ resource "aws_ecs_task_definition" "pdf" {
   container_definitions    = "[${local.pdf_app}]"
   task_role_arn            = aws_iam_role.pdf_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = merge(local.default_opg_tags, local.pdf_component_tag)
+  tags                     = local.pdf_component_tag
 }
 
 //----------------
@@ -63,7 +63,7 @@ resource "aws_ecs_task_definition" "pdf" {
 resource "aws_iam_role" "pdf_task_role" {
   name               = "${var.environment_name}-pdf-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = merge(local.default_opg_tags, local.pdf_component_tag)
+  tags               = local.pdf_component_tag
 }
 
 resource "aws_iam_role_policy" "pdf_permissions_role" {

--- a/terraform/environment/modules/environment/ecs_seeding.tf
+++ b/terraform/environment/modules/environment/ecs_seeding.tf
@@ -4,7 +4,7 @@
 resource "aws_security_group" "seeding_ecs_service" {
   name_prefix = "${terraform.workspace}-seeding-ecs-service"
   vpc_id      = data.aws_vpc.default.id
-  tags        = merge(local.default_opg_tags, local.seeding_component_tag)
+  tags        = local.seeding_component_tag
 }
 
 resource "aws_security_group_rule" "seeding_ecs_service_egress" {
@@ -32,7 +32,7 @@ resource "aws_ecs_task_definition" "seeding" {
   container_definitions    = "[${local.seeding_app}]"
   task_role_arn            = aws_iam_role.seeding_task_role[count.index].arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = merge(local.default_opg_tags, local.seeding_component_tag)
+  tags                     = local.seeding_component_tag
 }
 
 
@@ -43,7 +43,7 @@ resource "aws_iam_role" "seeding_task_role" {
   count              = var.environment_name == "production" ? 0 : 1
   name               = "${var.environment_name}-seeding-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = merge(local.default_opg_tags, local.seeding_component_tag)
+  tags               = local.seeding_component_tag
 }
 
 data "aws_ecr_repository" "lpa_seeding_app" {

--- a/terraform/environment/modules/environment/lambda_functions.tf
+++ b/terraform/environment/modules/environment/lambda_functions.tf
@@ -20,7 +20,7 @@ module "performance_platform_worker" {
 
   ecr_arn                     = data.aws_ecr_repository.performance_platform_worker.arn
   lambda_role_policy_document = data.aws_iam_policy_document.performance_platform_worker_lambda_function_policy[0].json
-  tags                        = merge(local.default_opg_tags, local.performance_platform_component_tag)
+  tags                        = local.performance_platform_component_tag
 }
 
 data "aws_iam_policy_document" "performance_platform_worker_lambda_function_policy" {

--- a/terraform/environment/modules/environment/load_balancer_admin.tf
+++ b/terraform/environment/modules/environment/load_balancer_admin.tf
@@ -14,7 +14,7 @@ resource "aws_lb_target_group" "admin" {
     matcher             = 200
   }
   depends_on = [aws_lb.admin]
-  tags       = merge(local.default_opg_tags, local.admin_component_tag)
+  tags       = local.admin_component_tag
 }
 
 resource "aws_lb" "admin" {
@@ -23,7 +23,7 @@ resource "aws_lb" "admin" {
   internal                   = false
   load_balancer_type         = "application"
   subnets                    = data.aws_subnet_ids.public.ids
-  tags                       = merge(local.default_opg_tags, local.admin_component_tag)
+  tags                       = local.admin_component_tag
   drop_invalid_header_fields = true
   security_groups = [
     aws_security_group.admin_loadbalancer.id,
@@ -55,7 +55,7 @@ resource "aws_security_group" "admin_loadbalancer" {
   name        = "${var.environment_name}-admin-loadbalancer"
   description = "Allow inbound traffic"
   vpc_id      = data.aws_vpc.default.id
-  tags        = merge(local.default_opg_tags, local.admin_component_tag)
+  tags        = local.admin_component_tag
 }
 
 resource "aws_security_group_rule" "admin_loadbalancer_ingress" {

--- a/terraform/environment/modules/environment/load_balancer_front.tf
+++ b/terraform/environment/modules/environment/load_balancer_front.tf
@@ -14,7 +14,7 @@ resource "aws_lb_target_group" "front" {
     matcher             = 200
   }
   depends_on = [aws_lb.front]
-  tags       = merge(local.default_opg_tags, local.front_component_tag)
+  tags       = local.front_component_tag
 }
 
 resource "aws_lb" "front" {
@@ -23,7 +23,7 @@ resource "aws_lb" "front" {
   internal                   = false
   load_balancer_type         = "application"
   subnets                    = data.aws_subnet_ids.public.ids
-  tags                       = merge(local.default_opg_tags, local.front_component_tag)
+  tags                       = local.front_component_tag
   drop_invalid_header_fields = true
 
   security_groups = [
@@ -56,7 +56,7 @@ resource "aws_security_group" "front_loadbalancer" {
   name        = "${var.environment_name}-front-loadbalancer"
   description = "Allow inbound traffic"
   vpc_id      = data.aws_vpc.default.id
-  tags        = merge(local.default_opg_tags, local.front_component_tag)
+  tags        = local.front_component_tag
 
 }
 

--- a/terraform/environment/modules/environment/rds.tf
+++ b/terraform/environment/modules/environment/rds.tf
@@ -44,7 +44,7 @@ resource "aws_db_instance" "api" {
   multi_az                            = true
   backup_retention_period             = var.account.backup_retention_period
   deletion_protection                 = var.account.deletion_protection
-  tags                                = merge(local.default_opg_tags, local.db_component_tag)
+  tags                                = local.db_component_tag
   allow_major_version_upgrade         = true
   monitoring_interval                 = 30
   monitoring_role_arn                 = data.aws_iam_role.rds_enhanced_monitoring.arn
@@ -80,7 +80,7 @@ module "aws_rds_api_alarms" {
   evaluation_period                         = "10"
   db_instance_class                         = "db.m3.medium"
   prefix                                    = "${var.environment_name}-"
-  tags                                      = merge(local.default_opg_tags, local.db_component_tag)
+  tags                                      = local.db_component_tag
 }
 
 module "api_aurora" {
@@ -104,7 +104,7 @@ module "api_aurora" {
   replication_source_identifier = var.account.always_on ? aws_db_instance.api[0].arn : ""
   skip_final_snapshot           = !var.account.deletion_protection
   vpc_security_group_ids        = [aws_security_group.rds-api.id]
-  tags                          = merge(local.default_opg_tags, local.db_component_tag)
+  tags                          = local.db_component_tag
   copy_tags_to_snapshot         = true
 }
 
@@ -137,7 +137,7 @@ resource "aws_security_group" "rds-client" {
   description            = "rds access for ${var.environment_name}"
   vpc_id                 = data.aws_vpc.default.id
   revoke_rules_on_delete = true
-  tags                   = merge(local.default_opg_tags, local.db_component_tag)
+  tags                   = local.db_component_tag
 }
 
 resource "aws_security_group" "rds-api" {
@@ -145,7 +145,7 @@ resource "aws_security_group" "rds-api" {
   description            = "api rds access"
   vpc_id                 = data.aws_vpc.default.id
   revoke_rules_on_delete = true
-  tags                   = merge(local.default_opg_tags, local.db_component_tag)
+  tags                   = local.db_component_tag
 
   lifecycle {
     create_before_destroy = true

--- a/terraform/environment/modules/environment/resource_group.tf
+++ b/terraform/environment/modules/environment/resource_group.tf
@@ -1,6 +1,6 @@
 resource "aws_resourcegroups_group" "environment" {
   name = var.environment_name
-  tags = merge(local.default_opg_tags, local.shared_component_tag)
+  tags = local.shared_component_tag
   resource_query {
     query = local.environment_resource_group_query
   }

--- a/terraform/environment/modules/environment/sns.tf
+++ b/terraform/environment/modules/environment/sns.tf
@@ -1,13 +1,13 @@
 #tfsec:ignore:aws-sns-enable-topic-encryption CMK to be added
 resource "aws_sns_topic" "cloudwatch_to_pagerduty" {
   name = "CloudWatch-to-PagerDuty-${var.environment_name}"
-  tags = merge(local.default_opg_tags, local.shared_component_tag)
+  tags = local.shared_component_tag
 
 }
 #tfsec:ignore:aws-sns-enable-topic-encryption  CMK to be added
 resource "aws_sns_topic" "cloudwatch_to_pagerduty_ops" {
   name = "CloudWatch-to-PagerDuty-${var.environment_name}-Ops"
-  tags = merge(local.default_opg_tags, local.shared_component_tag)
+  tags = local.shared_component_tag
 }
 
 resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription" {

--- a/terraform/environment/modules/environment/sqs.tf
+++ b/terraform/environment/modules/environment/sqs.tf
@@ -7,7 +7,7 @@ resource "aws_sqs_queue" "pdf_fifo_queue" {
   kms_master_key_id                 = "alias/mrk_pdf_sqs_encryption_key-${var.account_name}"
   kms_data_key_reuse_period_seconds = "300"
   max_message_size                  = "262144"
-  tags                              = merge(local.default_opg_tags, local.pdf_component_tag)
+  tags                              = local.pdf_component_tag
 
   depends_on = [aws_ecs_service.api, aws_iam_role.api_task_role, aws_iam_role.pdf_task_role]
 }
@@ -58,7 +58,7 @@ resource "aws_sqs_queue" "performance_platform_worker" {
   max_message_size                  = 16384 #adjust as needed
   message_retention_seconds         = 86400
   receive_wait_time_seconds         = 10
-  tags                              = merge(local.default_opg_tags, local.performance_platform_component_tag)
+  tags                              = local.performance_platform_component_tag
   kms_master_key_id                 = "alias/mrk_perfplat_sqs_encryption_key-${var.account_name}"
   kms_data_key_reuse_period_seconds = "300"
 

--- a/terraform/environment/terraform.tf
+++ b/terraform/environment/terraform.tf
@@ -27,6 +27,9 @@ terraform {
 
 provider "aws" {
   region = "eu-west-1"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
@@ -37,6 +40,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "eu_west_1"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
@@ -47,6 +53,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-2"
   alias  = "eu_west_2"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
@@ -57,6 +66,9 @@ provider "aws" {
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
@@ -67,6 +79,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "management"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.management_role}"
     session_name = "terraform-session"


### PR DESCRIPTION
## Purpose

Use default_tags block in AWS TF Provider

Fixes LPAL-859

## Approach

Removes unnecessary merge function calls and replaces with default_tags block in the AWS provider config

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
