### PR TITLE
LPAL-859 remove CMK - seems new envs can't work with it.

### DIFF
--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -58,8 +58,7 @@ resource "aws_s3_bucket" "access_log" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm     = "aws:kms"
-        kms_master_key_id = data.aws_kms_key.access_log_key.arn
+        sse_algorithm = "aws:kms"
       }
     }
   }


### PR DESCRIPTION
## Purpose

For some reason dev ephemerals were hitting 400 error when creating load balancers with this key in place. 

Fixes LPAL-859 in dev

## Approach

remove CMK for sse encryption.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
