### PR TITLE
LPAL-666 add lambda log retention control

### DIFF
--- a/.github/workflows/tfsec-pr-commenter.yml
+++ b/.github/workflows/tfsec-pr-commenter.yml
@@ -1,0 +1,38 @@
+name: "[Analysis] TFSec PR feedback"
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "**.tf"
+
+permissions:
+  actions: read
+  checks: read
+  contents: none
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: write
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  tfsec:
+    name: TFSec Static analysis
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        terraform_path: ['terraform/account', 'terraform/region' ,'terraform/environment']
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: tfsec with pr comments
+        uses: tfsec/tfsec-pr-commenter-action@v1.2.0
+        with:
+          working_directory: ${{ matrix.terraform_path }}
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          soft_fail_commenter: true

--- a/terraform/environment/modules/environment/lambda_functions.tf
+++ b/terraform/environment/modules/environment/lambda_functions.tf
@@ -21,7 +21,7 @@ module "performance_platform_worker" {
   ecr_arn                     = data.aws_ecr_repository.performance_platform_worker.arn
   lambda_role_policy_document = data.aws_iam_policy_document.performance_platform_worker_lambda_function_policy[0].json
   tags                        = merge(local.default_opg_tags, local.performance_platform_component_tag)
-  log_retention_in_days       = var.log_retention_in_days
+  log_retention_in_days       = var.account.log_retention_in_days
 }
 
 data "aws_iam_policy_document" "performance_platform_worker_lambda_function_policy" {

--- a/terraform/environment/modules/environment/lambda_functions.tf
+++ b/terraform/environment/modules/environment/lambda_functions.tf
@@ -21,6 +21,7 @@ module "performance_platform_worker" {
   ecr_arn                     = data.aws_ecr_repository.performance_platform_worker.arn
   lambda_role_policy_document = data.aws_iam_policy_document.performance_platform_worker_lambda_function_policy[0].json
   tags                        = merge(local.default_opg_tags, local.performance_platform_component_tag)
+  log_retention_in_days       = var.log_retention_in_days
 }
 
 data "aws_iam_policy_document" "performance_platform_worker_lambda_function_policy" {

--- a/terraform/environment/modules/environment/modules/lambda_function/main.tf
+++ b/terraform/environment/modules/environment/modules/lambda_function/main.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "lambda_function" {
 
 #tfsec:ignore:AWS089 encryption of logs too expensive
 resource "aws_cloudwatch_log_group" "lambda_function" {
-  name = "/aws/lambda/${var.lambda_name}"
-  tags = var.tags
-
+  name              = "/aws/lambda/${var.lambda_name}"
+  tags              = var.tags
+  retention_in_days = var.log_retention_in_days
 }

--- a/terraform/environment/modules/environment/modules/lambda_function/variables.tf
+++ b/terraform/environment/modules/environment/modules/lambda_function/variables.tf
@@ -74,7 +74,7 @@ variable "log_retention_in_days" {
   default     = 400
 
   validation {
-    condition     = contains([0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653], var.log_retention_period)
-    error_message = "log retention in days is invalid, allowed values are 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0"
+    condition     = contains([0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653], var.log_retention_in_days)
+    error_message = "Log retention in days is invalid, allowed values are 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0."
   }
 }

--- a/terraform/environment/modules/environment/modules/lambda_function/variables.tf
+++ b/terraform/environment/modules/environment/modules/lambda_function/variables.tf
@@ -67,3 +67,14 @@ variable "working_directory" {
   type        = string
   default     = null
 }
+
+variable "log_retention_in_days" {
+  description = "log retention period on cloudwatch. defaults to 400 to meet minimum moj security requirements"
+  type        = number
+  default     = 400
+
+  validation {
+    condition     = contains([0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653], var.log_retention_period)
+    error_message = "log retention in days is invalid, allowed values are 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0"
+  }
+}


### PR DESCRIPTION
## Purpose

Add log retention control to Lambda module
Fixes LPAL-666

## Approach

- update module to take `log_retention_in_days` setting from the `terraform.tfvars.json` file.
## Learning

Still cannot make the setting of other insight logs variable. 

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
