### PR TITLE
LPAL-859 Add default_tags block in TF AWS provider

### DIFF
--- a/terraform/email/credentials.tf
+++ b/terraform/email/credentials.tf
@@ -15,7 +15,7 @@ variable "default_role" {
 
 provider "aws" {
   region = "eu-west-1"
-  default_tags = {
+  default_tags {
     tags = local.default_tags
   }
   assume_role {
@@ -27,7 +27,7 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "management"
-  default_tags = {
+  default_tags {
     tags = local.default_tags
   }
   assume_role {

--- a/terraform/email/credentials.tf
+++ b/terraform/email/credentials.tf
@@ -15,6 +15,9 @@ variable "default_role" {
 
 provider "aws" {
   region = "eu-west-1"
+  default_tags = {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
@@ -24,6 +27,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "management"
+  default_tags = {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.default_role}"
     session_name = "terraform-session"

--- a/terraform/email/email.tf
+++ b/terraform/email/email.tf
@@ -38,7 +38,6 @@ resource "aws_route53_record" "casper_amazonses_mx" {
 resource "aws_s3_bucket" "mailbox" {
   bucket = "opg-lpa-casper-mailbox"
   acl    = "private"
-  tags   = local.default_tags
   lifecycle_rule {
     id      = "expiremessages"
     enabled = true


### PR DESCRIPTION
## Purpose

Use default_tags in email provider block

Fixes LPAL-859

## Approach

Adjust email terraform to use default_tags block

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
