### PR TITLE
LPAL-901 Fix breaking tests folder composer update

### DIFF
--- a/.github/workflows/dependabot-update.yml
+++ b/.github/workflows/dependabot-update.yml
@@ -8,7 +8,7 @@ name: Dependabot updates
 
 on:
 # In case we need to change, uncomment out and change name to branch you are fixing on.
-# Commits will make action trigger. 
+# Commits will make action trigger.
 # Remember to comment out after work done.
 # push:
 #     branches:
@@ -40,9 +40,7 @@ jobs:
       - name: Update outdated dependencies - composer
         run: |
           echo "running composer updates..."
-          cd tests
-          composer update --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
-          cd ../service-front
+          cd service-front
           composer update --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
           cd ../service-api
           composer update --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs


### PR DESCRIPTION
## Purpose

The dependabot job is failing because tests folder no longer has composer based updates (Casper was removed)
This fixes that to allow the update to continue.

Fixes LPAL-901

## Approach

Remove tests folder composer run from the dependabot-update.yml

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
