### PR TITLE
LPAL-724 Ignore tfsec warnings for access log buckets not using CMK

### DIFF
--- a/terraform/account/s3.tf
+++ b/terraform/account/s3.tf
@@ -47,7 +47,8 @@ data "aws_iam_policy_document" "loadbalancer_logging" {
 
 # We will keep this in for historical purposes. we need to think how far back we need this.
 #versioning not required for a logging bucket bucket logging not needed
-#tfsec:ignore:AWS002  #tfsec:ignore:AWS077
+#encryption of ALB access logs not supported with CMK
+#tfsec:ignore:AWS002  #tfsec:ignore:AWS077 #tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket" "access_log" {
   bucket = "online-lpa-${terraform.workspace}-lb-access-logs"
   acl    = "private"

--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -49,8 +49,9 @@ data "aws_iam_policy_document" "loadbalancer_logging" {
   }
 }
 
-#versioning not required for a logging bucket bucket logging not needed
-#tfsec:ignore:AWS002  #tfsec:ignore:AWS077
+#versioning not required for a logging bucket bucket logging not needed. 
+#encryption of ALB access logs not supported with CMK
+#tfsec:ignore:AWS002  #tfsec:ignore:AWS077 #tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket" "access_log" {
   bucket = "online-lpa-${local.account_name}-${local.region_name}-lb-access-logs"
   acl    = "private"


### PR DESCRIPTION
## Purpose

Ignore the TFSec warnings for access logs not using Customer Managed KMS keys. 

Fixes LPAL-724

## Approach

Adds comments for tfsec to ignore the config issues.

## Learning

Using a CMK for an ALB's access logs does not seem to be supported by AWS.

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
