### PR TITLE
LPAL-917 Fix suddenly enforced engine version

### DIFF
--- a/terraform/environment/modules/environment/modules/aurora/main.tf
+++ b/terraform/environment/modules/environment/modules/aurora/main.tf
@@ -68,6 +68,7 @@ resource "aws_rds_cluster" "cluster_serverless" {
   db_subnet_group_name         = var.db_subnet_group_name
   deletion_protection          = var.deletion_protection
   engine                       = var.engine
+  engine_version               = var.engine_version
   engine_mode                  = "serverless"
   final_snapshot_identifier    = "${var.database_name}-${var.environment}-final-snapshot"
   kms_key_id                   = var.kms_key_id


### PR DESCRIPTION
## Purpose

AWS has since Friday placed an enforcement on the Aurora serverless engine version, which has stopped our dev CI in it's tracks. This change fixes that issue and by doing so means we actually specify the engine version in serverless, which was missed previously.

Fixes LPAL-917

## Approach

Add `engine_version` in. to the serverless db definition, which was assumed to be there anyway.

## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
