### PR TITLE
LPAL-724 Ignore (for now) remaining alerts

### DIFF
--- a/terraform/email/email.tf
+++ b/terraform/email/email.tf
@@ -34,7 +34,7 @@ resource "aws_route53_record" "casper_amazonses_mx" {
 
 # Create S3 bucket for SES mail storage
 # this is ony used for emil testing, which will change anyway
-#tfsec:ignore:AWS017 #tfsec:ignore:AWS002 #tfsec:ignore:AWS077
+#tfsec:ignore:AWS017 #tfsec:ignore:AWS002 #tfsec:ignore:AWS077 #tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket" "mailbox" {
   bucket = "opg-lpa-casper-mailbox"
   acl    = "private"

--- a/terraform/environment/modules/environment/modules/lambda_function/main.tf
+++ b/terraform/environment/modules/environment/modules/lambda_function/main.tf
@@ -1,3 +1,4 @@
+#tfsec:ignore:aws-lambda-enable-tracing - To be enabled along with apps
 resource "aws_lambda_function" "lambda_function" {
   function_name = var.lambda_name
   image_uri     = var.image_uri

--- a/terraform/region/modules/region/sns.tf
+++ b/terraform/region/modules/region/sns.tf
@@ -10,11 +10,13 @@ resource "aws_sns_topic" "cloudwatch_to_account_ops_alerts" {
   tags = local.shared_component_tag
 }
 
+#tfsec:ignore:aws-sns-enable-topic-encryption - review if changed to Aurora
 resource "aws_sns_topic" "rds_events" {
   name = "${local.account_name}-${local.region_name}-rds-events"
   tags = local.db_component_tag
 }
 
+#tfsec:ignore:aws-sns-enable-topic-encryption - - review if changed to Aurora
 resource "aws_db_event_subscription" "rds_events" {
   name      = "${local.account_name}-${local.region_name}-rds-event-sub"
   sns_topic = aws_sns_topic.rds_events.arn


### PR DESCRIPTION
## Purpose

Ignore the remaining security alerts which can't yet be fixed.

Fixes LPAL-724

## Approach

Add ignore comments for tfsec.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
