### PR TITLE
LPAL-875 Change wording when the donor can't sign

### DIFF
--- a/cypress/e2e/common/i_can_see.js
+++ b/cypress/e2e/common/i_can_see.js
@@ -21,7 +21,7 @@ Then('I cannot see continuation sheet reminders', () => {
 });
 
 Then('I can see fields for the donor, certificate provider, attorney, applicant', () => {
-    const expectedNames = ['Mr Dead Pool (the donor)',
+    const expectedNames = ['Mr Dead Pool (donor)',
                            'Mr Cee Pee (certificate provider)',
                            'Mr A Att (attorney)',
                            'Mr Dead Pool (applicant)']

--- a/service-front/module/Application/view/application/authenticated/lpa/date-check/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/date-check/index.twig
@@ -218,7 +218,14 @@
     <input type="hidden" name="return-route" value="{{ returnRoute }}">
 
     <div class="date-check-person person person--full">
-        <h3 class="person-name heading-small flush--ends" data-cy="person-name">{{ lpa.document.donor.name }} (the donor)</h3>
+        <h3 class="person-name heading-small flush--ends" data-cy="person-name">
+        {% if lpa.document.donor.canSign %}
+            {{ lpa.document.donor.name }} (donor)
+        {% else %}
+            A person signing on behalf of {{ lpa.document.donor.name }} (donor)
+        {% endif %}
+        </h3>
+
         {% if donorLifeSustainingElement is defined %}
             <div class="person-address flush--ends">
                 <div class="dob-element form-date {{ donorLifeSustainingElement.getMessages|length >0 ? 'form-group-error'}}">
@@ -227,7 +234,11 @@
                     {{ formElementErrorsV2(donorLifeSustainingElementYear) }}
                     {{ formElementErrorsV2(donorLifeSustainingElement) }}
 
-                    <p>This person signed section 5 of the LPA on</p>
+                    {% if lpa.document.donor.canSign %}
+                        <p>This person signed section 5 of the LPA on</p>
+                    {% else %}
+                        <p>This person signed section 5 of the LPA on behalf of the donor on</p>
+                    {% endif %}
 
                     <fieldset id="{{ donorLifeSustainingElement.getAttribute('id') }}" class="date-check-dates">
                         <legend class="visually-hidden">Check signature dates for donor who signed section 5 of the LPA</legend>
@@ -259,7 +270,12 @@
                 {{ formElementErrorsV2(donorElementYear) }}
                 {{ formElementErrorsV2(donorElement) }}
 
-                <p>This person signed section 9 of the LPA on</p>
+                {% if lpa.document.donor.canSign %}
+                    <p>This person signed continuation sheet 3 of the LPA on</p>
+                {% else %}
+                    <p>This person signed continuation sheet 3 on behalf of the donor on</p>
+                {% endif %}
+
 
                 <fieldset id="{{ donorElement.getAttribute('id') }}" class="date-check-dates">
                     <legend class="visually-hidden">Check signature dates for donor who signed section 9 of the LPA</legend>


### PR DESCRIPTION
## Purpose
This PR is a duplicate of an already approved PR. The difference is that this is being reopened against the feature branch [lpal-892-date-check-c-sheet-feature](https://github.com/ministryofjustice/opg-lpa/pull/1053), as it needs to be released alongside the other tasks in the epic [LPAL-892](https://opgtransform.atlassian.net/browse/LPAL-892).

This changes the wording in the 'Check Signatures' tool so that when the donor can't sign (this generates continuation sheet 3), it refers to 'The person signing on behalf of the donor', rather than 'The donor'.

[LPAL-875](https://opgtransform.atlassian.net/browse/LPAL-875)


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [x] The product team have tested these changes
