### PR TITLE
LPAL-765 Add the AWSManagedRulesCommonRuleSet to our WAF config

### DIFF
--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -28,6 +28,7 @@ resource "aws_wafv2_web_acl" "main" {
       sampled_requests_enabled   = true
     }
   }
+
   rule {
     name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
     priority = 1
@@ -46,6 +47,32 @@ resource "aws_wafv2_web_acl" "main" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        excluded_rule {
+          name = "NoUserAgent_HEADER"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesCommonRuleSet"
       sampled_requests_enabled   = true
     }
   }


### PR DESCRIPTION
## Purpose

This is to bring us in line with other teams and webops CoP
recommendations.

This ruleset blocks requests which match a variety of common
attack patterns, such as requesting potentially vulnerable
file paths, sending cross-site scripting payloads in request bodies
and similar.

Fixes [LPAL-765](https://opgtransform.atlassian.net/browse/LPAL-765)

## Approach

Terraform update

## Learning

WAF rulesets

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
