### PR TITLE
LPAL-919 Allow feedback ci flask secret access

### DIFF
--- a/terraform/region/secrets.tf
+++ b/terraform/region/secrets.tf
@@ -188,7 +188,7 @@ data "aws_iam_policy_document" "opg_feedback_secrets" {
 
     resources = [
       data.aws_secretsmanager_secret.opg_flask_api_token.arn,
-      ]
+    ]
 
     actions = [
       "secretsmanager:GetSecretValue"
@@ -196,7 +196,7 @@ data "aws_iam_policy_document" "opg_feedback_secrets" {
 
     principals {
       identifiers = ["arn:aws:iam::631181914621:user/feedback-actions-ci"]
-      type = "AWS"
+      type        = "AWS"
     }
 
   }

--- a/terraform/region/secrets.tf
+++ b/terraform/region/secrets.tf
@@ -186,17 +186,16 @@ data "aws_iam_policy_document" "opg_feedback_secrets" {
     sid    = "AllowFeedbackCIReadFlaskSecret"
     effect = "Allow"
 
-    resources = [data.aws_secretsmanager_secret.opg_flask_api_token.arn]
+    resources = [
+      data.aws_secretsmanager_secret.opg_flask_api_token.arn,
+      ]
 
     actions = [
       "secretsmanager:GetSecretValue"
     ]
 
     principals {
-      identifiers = [
-        "arn:aws:iam::631181914621:feedback-actions-ci"
-      ]
-
+      identifiers = ["arn:aws:iam::631181914621:user/feedback-actions-ci"]
       type = "AWS"
     }
 

--- a/terraform/region/secrets.tf
+++ b/terraform/region/secrets.tf
@@ -174,3 +174,37 @@ resource "aws_secretsmanager_secret" "performance_platform_db_password" {
     kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
   }
 }
+
+# IAM to allow Feedback CI to read Flask Secret key
+data "aws_secretsmanager_secret" "opg_flask_api_token" {
+  name = "opg-flask-api-token"
+}
+
+data "aws_iam_policy_document" "opg_feedback_secrets" {
+
+  statement {
+    sid    = "AllowFeedbackCIReadFlaskSecret"
+    effect = "Allow"
+
+    resources = [data.aws_secretsmanager_secret.opg_flask_api_token.arn]
+
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+
+    principals {
+      identifiers = [
+        "arn:aws:iam::631181914621:feedback-actions-ci"
+      ]
+
+      type = "AWS"
+    }
+
+  }
+}
+
+resource "aws_secretsmanager_secret_policy" "secret_policy" {
+  count      = local.account.is_production ? 0 : 1
+  secret_arn = data.aws_secretsmanager_secret.opg_flask_api_token.arn
+  policy     = data.aws_iam_policy_document.opg_feedback_secrets.json
+}

--- a/terraform/region/secrets.tf
+++ b/terraform/region/secrets.tf
@@ -3,7 +3,7 @@
 # common
 resource "aws_secretsmanager_secret" "opg_lpa_common_admin_accounts" {
   name                           = "${local.account_name}/opg_lpa_common_admin_accounts"
-  tags                           = merge(local.default_opg_tags, local.admin_component_tag)
+  tags                           = local.admin_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -15,7 +15,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_common_admin_accounts" {
 
 resource "aws_secretsmanager_secret" "opg_lpa_common_account_cleanup_notification_recipients" {
   name                           = "${local.account_name}/opg_lpa_common_account_cleanup_notification_recipients"
-  tags                           = merge(local.default_opg_tags, local.admin_component_tag)
+  tags                           = local.admin_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -28,7 +28,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_common_account_cleanup_notificatio
 # api secrets
 resource "aws_secretsmanager_secret" "opg_lpa_front_csrf_salt" {
   name                           = "${local.account_name}/opg_lpa_front_csrf_salt"
-  tags                           = merge(local.default_opg_tags, local.api_component_tag)
+  tags                           = local.api_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -40,7 +40,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_front_csrf_salt" {
 
 resource "aws_secretsmanager_secret" "opg_lpa_api_notify_api_key" {
   name                           = "${local.account_name}/opg_lpa_api_notify_api_key"
-  tags                           = merge(local.default_opg_tags, local.api_component_tag)
+  tags                           = local.api_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -53,7 +53,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_api_notify_api_key" {
 # admin secrets
 resource "aws_secretsmanager_secret" "opg_lpa_admin_jwt_secret" {
   name                           = "${local.account_name}/opg_lpa_admin_jwt_secret"
-  tags                           = merge(local.default_opg_tags, local.admin_component_tag)
+  tags                           = local.admin_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -66,7 +66,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_admin_jwt_secret" {
 # front secrets
 resource "aws_secretsmanager_secret" "opg_lpa_front_email_sendgrid_webhook_token" {
   name                           = "${local.account_name}/opg_lpa_front_email_sendgrid_webhook_token"
-  tags                           = merge(local.default_opg_tags, local.front_component_tag)
+  tags                           = local.front_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -78,7 +78,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_front_email_sendgrid_webhook_token
 
 resource "aws_secretsmanager_secret" "opg_lpa_front_email_sendgrid_api_key" {
   name                           = "${local.account_name}/opg_lpa_front_email_sendgrid_api_key"
-  tags                           = merge(local.default_opg_tags, local.front_component_tag)
+  tags                           = local.front_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -90,7 +90,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_front_email_sendgrid_api_key" {
 
 resource "aws_secretsmanager_secret" "opg_lpa_front_gov_pay_key" {
   name                           = "${local.account_name}/opg_lpa_front_gov_pay_key"
-  tags                           = merge(local.default_opg_tags, local.front_component_tag)
+  tags                           = local.front_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -102,7 +102,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_front_gov_pay_key" {
 
 resource "aws_secretsmanager_secret" "opg_lpa_front_os_places_hub_license_key" {
   name                           = "${local.account_name}/opg_lpa_front_os_places_hub_license_key"
-  tags                           = merge(local.default_opg_tags, local.front_component_tag)
+  tags                           = local.front_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -115,7 +115,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_front_os_places_hub_license_key" {
 # pdf secrets
 resource "aws_secretsmanager_secret" "opg_lpa_pdf_owner_password" {
   name                           = "${local.account_name}/opg_lpa_pdf_owner_password"
-  tags                           = merge(local.default_opg_tags, local.pdf_component_tag)
+  tags                           = local.pdf_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -128,7 +128,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_pdf_owner_password" {
 # db secrets
 resource "aws_secretsmanager_secret" "api_rds_username" {
   name                           = "${local.account_name}/api_rds_username"
-  tags                           = merge(local.default_opg_tags, local.db_component_tag)
+  tags                           = local.db_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -140,7 +140,7 @@ resource "aws_secretsmanager_secret" "api_rds_username" {
 
 resource "aws_secretsmanager_secret" "api_rds_password" {
   name                           = "${local.account_name}/api_rds_password"
-  tags                           = merge(local.default_opg_tags, local.db_component_tag)
+  tags                           = local.db_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -153,7 +153,7 @@ resource "aws_secretsmanager_secret" "api_rds_password" {
 #performance platform db secrets - test
 resource "aws_secretsmanager_secret" "performance_platform_db_username" {
   name                           = "${local.account_name}/performance_platform_db_username"
-  tags                           = merge(local.default_opg_tags, local.performance_platform_component_tag)
+  tags                           = local.performance_platform_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 
@@ -165,7 +165,7 @@ resource "aws_secretsmanager_secret" "performance_platform_db_username" {
 
 resource "aws_secretsmanager_secret" "performance_platform_db_password" {
   name                           = "${local.account_name}/performance_platform_db_password"
-  tags                           = merge(local.default_opg_tags, local.performance_platform_component_tag)
+  tags                           = local.performance_platform_component_tag
   kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
   force_overwrite_replica_secret = true
 


### PR DESCRIPTION
## Purpose

Allow the Feedback CI user to read the Feedback Secret
Fixes LPAL-919

## Approach

As the Secret currently is manually created, the code performs a data lookup for the `opg-flask-api-token`. A `aws_secretsmanager_secret_policy` is then created referencing the ARN of the Secret.

## Learning
n/a
## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
