### PR TITLE
LPAL-919 Make non-prod data lookups conditional

### DIFF
--- a/terraform/region/secrets.tf
+++ b/terraform/region/secrets.tf
@@ -182,14 +182,13 @@ data "aws_secretsmanager_secret" "opg_flask_api_token" {
 }
 
 data "aws_iam_policy_document" "opg_feedback_secrets" {
-
   count = local.account.is_production ? 0 : 1
   statement {
     sid    = "AllowFeedbackCIReadFlaskSecret"
     effect = "Allow"
 
     resources = [
-      data.aws_secretsmanager_secret.opg_flask_api_token.arn,
+      data.aws_secretsmanager_secret.opg_flask_api_token[0].arn,
     ]
 
     actions = [
@@ -206,6 +205,6 @@ data "aws_iam_policy_document" "opg_feedback_secrets" {
 
 resource "aws_secretsmanager_secret_policy" "secret_policy" {
   count      = local.account.is_production ? 0 : 1
-  secret_arn = data.aws_secretsmanager_secret.opg_flask_api_token.arn
-  policy     = data.aws_iam_policy_document.opg_feedback_secrets.json
+  secret_arn = data.aws_secretsmanager_secret.opg_flask_api_token[0].arn
+  policy     = data.aws_iam_policy_document.opg_feedback_secrets[0].json
 }

--- a/terraform/region/secrets.tf
+++ b/terraform/region/secrets.tf
@@ -177,11 +177,13 @@ resource "aws_secretsmanager_secret" "performance_platform_db_password" {
 
 # IAM to allow Feedback CI to read Flask Secret key
 data "aws_secretsmanager_secret" "opg_flask_api_token" {
-  name = "opg-flask-api-token"
+  count = local.account.is_production ? 0 : 1
+  name  = "opg-flask-api-token"
 }
 
 data "aws_iam_policy_document" "opg_feedback_secrets" {
 
+  count = local.account.is_production ? 0 : 1
   statement {
     sid    = "AllowFeedbackCIReadFlaskSecret"
     effect = "Allow"


### PR DESCRIPTION
## Purpose

Fix path to live pipeline
Fixes LPAL-919

## Approach

Makes data lookups conditional on the environment not being production

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
