### PR TITLE
fix image names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,6 @@ services:
 
   feedback-app:
     container_name: lpa-feedback-app
-    image: lpa-feedback-app
     image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/opg-feedback/front-app
     ports:
       - 9005:8005
@@ -427,7 +426,6 @@ services:
   # Create feedback table and db user for PerfPlat
   feedbackdb:
     container_name: lpa-feedbackdb
-    image: feedbackdb
     image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/opg-feedback/feedbackdb
     depends_on:
       - localstack


### PR DESCRIPTION
## Purpose

_image names for feedbackdb and feedbackapp were duplicated. Possibly a bad merge happened. This fixes it_

## Approach

_fix docker-compose file_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
