### PR TITLE
LPAL-949 tfsec ignore rule names instead of legacy id

### DIFF
--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -1,4 +1,4 @@
-#tfsec:ignore:AWS089
+#tfsec:ignore:aws-cloudwatch-log-group-customer-key
 resource "aws_cloudwatch_log_group" "online-lpa" {
   name              = "online-lpa"
   retention_in_days = local.account.retention_in_days

--- a/terraform/account/s3.tf
+++ b/terraform/account/s3.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "loadbalancer_logging" {
 # We will keep this in for historical purposes. we need to think how far back we need this.
 #versioning not required for a logging bucket bucket logging not needed
 #encryption of ALB access logs not supported with CMK
-#tfsec:ignore:AWS002  #tfsec:ignore:AWS077 #tfsec:ignore:aws-s3-encryption-customer-key
+#tfsec:ignore:aws-s3-enable-bucket-logging  #tfsec:ignore:aws-s3-enable-versioning #tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket" "access_log" {
   bucket = "online-lpa-${terraform.workspace}-lb-access-logs"
   acl    = "private"

--- a/terraform/account/sns.tf
+++ b/terraform/account/sns.tf
@@ -1,15 +1,15 @@
-#tfsec:ignore:AWS016 fix for now, to be followed with a CMK KMS
+#tfsec:ignore:aws-sns-enable-topic-encryption fix for now, to be followed with a CMK KMS
 resource "aws_sns_topic" "cloudwatch_to_slack_breakglass_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-Breakglass-alert"
   tags = local.shared_component_tag
 }
-#tfsec:ignore:AWS016 unsupported for this type of alert
+#tfsec:ignore:aws-sns-enable-topic-encryption unsupported for this type of alert
 resource "aws_sns_topic" "cloudwatch_to_slack_elasticache_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-elasticache-alert"
   tags = local.front_component_tag
 }
 
-#tfsec:ignore:AWS016 unsupported for this type of alert
+#tfsec:ignore:aws-sns-enable-topic-encryption unsupported for this type of alert
 resource "aws_sns_topic" "cloudwatch_to_account_ops_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-account-ops-alert"
   tags = local.shared_component_tag

--- a/terraform/account/workspace_cleanup.tf
+++ b/terraform/account/workspace_cleanup.tf
@@ -1,4 +1,4 @@
-#tfsec:ignore:AWS086 #tfsec:ignore:AWS092 #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption Point in time and encryption not needed for this short lived data
+#tfsec:ignore:aws-dynamodb-enable-recovery #tfsec:ignore:aws-dynamodb-table-customer-key #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption Point in time and encryption not needed for this short lived data
 resource "aws_dynamodb_table" "workspace_cleanup_table" {
   count        = local.account_name == "development" ? 1 : 0
   name         = "WorkspaceCleanup"

--- a/terraform/email/email.tf
+++ b/terraform/email/email.tf
@@ -34,7 +34,7 @@ resource "aws_route53_record" "casper_amazonses_mx" {
 
 # Create S3 bucket for SES mail storage
 # this is ony used for emil testing, which will change anyway
-#tfsec:ignore:AWS017 #tfsec:ignore:AWS002 #tfsec:ignore:AWS077 #tfsec:ignore:aws-s3-encryption-customer-key
+#tfsec:ignore:aws-s3-enable-bucket-encryption #tfsec:ignore:aws-s3-enable-bucket-logging #tfsec:ignore:aws-s3-enable-versioning #tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket" "mailbox" {
   bucket = "opg-lpa-casper-mailbox"
   acl    = "private"

--- a/terraform/environment/modules/environment/cloudwatch_logs.tf
+++ b/terraform/environment/modules/environment/cloudwatch_logs.tf
@@ -1,4 +1,4 @@
-#tfsec:ignore:AWS089 encryption of logs too expensive
+#tfsec:ignore:aws-cloudwatch-log-group-customer-key encryption of logs too expensive
 resource "aws_cloudwatch_log_group" "application_logs" {
   name              = "${var.environment_name}_application_logs"
   retention_in_days = var.account.log_retention_in_days

--- a/terraform/environment/modules/environment/dynamo_db.tf
+++ b/terraform/environment/modules/environment/dynamo_db.tf
@@ -1,4 +1,4 @@
-#tfsec:ignore:AWS086 #tfsec:ignore:AWS092 #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption short lived dynamo table doesn't hold customer data
+#tfsec:ignore:aws-dynamodb-enable-recovery #tfsec:ignore:aws-dynamodb-table-customer-key #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption short lived dynamo table doesn't hold customer data
 resource "aws_dynamodb_table" "lpa-locks" {
   name         = "lpa-locks-${var.environment_name}"
   billing_mode = "PAY_PER_REQUEST"
@@ -12,7 +12,7 @@ resource "aws_dynamodb_table" "lpa-locks" {
   tags = local.dynamodb_component_tag
 }
 
-#tfsec:ignore:AWS086 #tfsec:ignore:AWS092 #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption short lived dynamo table doesn't hold customer data
+#tfsec:ignore:aws-dynamodb-enable-recovery #tfsec:ignore:aws-dynamodb-table-customer-key #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption short lived dynamo table doesn't hold customer data
 resource "aws_dynamodb_table" "lpa-properties" {
   name         = "lpa-properties-${var.environment_name}"
   billing_mode = "PAY_PER_REQUEST"
@@ -26,7 +26,7 @@ resource "aws_dynamodb_table" "lpa-properties" {
   tags = local.dynamodb_component_tag
 }
 
-#tfsec:ignore:AWS086 #tfsec:ignore:AWS092 #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption To be removed soon as session table deprecated
+#tfsec:ignore:aws-dynamodb-enable-recovery #tfsec:ignore:aws-dynamodb-table-customer-key #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption To be removed soon as session table deprecated
 resource "aws_dynamodb_table" "lpa-sessions" {
   name         = "lpa-sessions-${var.environment_name}"
   billing_mode = "PAY_PER_REQUEST"

--- a/terraform/environment/modules/environment/ecs_admin.tf
+++ b/terraform/environment/modules/environment/ecs_admin.tf
@@ -29,7 +29,7 @@ resource "aws_ecs_service" "admin" {
 //----------------------------------
 // The service's Security Groups
 
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
+#tfsec:ignore:aws-ec2-add-description-to-security-group - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group" "admin_ecs_service" {
   name_prefix = "${var.environment_name}-admin-ecs-service"
   vpc_id      = data.aws_vpc.default.id
@@ -51,7 +51,7 @@ resource "aws_security_group_rule" "admin_ecs_service_egress" {
   from_port = 0
   to_port   = 0
   protocol  = "-1"
-  #tfsec:ignore:AWS007 - anything out
+  #tfsec:ignore:aws-ec2-no-public-egress-sgr - anything out
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.admin_ecs_service.id
   description       = "Admin ECS to Anywhere - All Traffic"

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -74,7 +74,7 @@ locals {
 
 //----------------------------------
 // The Api service's Security Groups
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
+#tfsec:ignore:aws-ec2-add-description-to-security-group - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group" "api_ecs_service" {
   name_prefix = "${terraform.workspace}-api-ecs-service"
   vpc_id      = data.aws_vpc.default.id
@@ -106,7 +106,7 @@ resource "aws_security_group_rule" "api_ecs_service_egress" {
   from_port = 0
   to_port   = 0
   protocol  = "-1"
-  #tfsec:ignore:AWS007 - anything out
+  #tfsec:ignore:aws-ec2-no-public-egress-sgr - anything out
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.api_ecs_service.id
   description       = "API ECS to Anywhere - All Traffic"

--- a/terraform/environment/modules/environment/ecs_cluster.tf
+++ b/terraform/environment/modules/environment/ecs_cluster.tf
@@ -37,6 +37,7 @@ resource "aws_iam_role_policy" "execution_role" {
   role   = aws_iam_role.execution_role.id
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards Necessary wildcards
 data "aws_iam_policy_document" "execution_role" {
   statement {
     effect    = "Allow"

--- a/terraform/environment/modules/environment/ecs_feedbackdb.tf
+++ b/terraform/environment/modules/environment/ecs_feedbackdb.tf
@@ -1,6 +1,6 @@
 //----------------------------------
 // The Api service's Security Groups
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
+#tfsec:ignore:aws-ec2-add-description-to-security-group - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group" "feedbackdb_ecs_service" {
   name_prefix = "${terraform.workspace}-feedbackdb-ecs-service"
   vpc_id      = data.aws_vpc.default.id
@@ -12,7 +12,7 @@ resource "aws_security_group_rule" "feedbackdb_ecs_service_egress" {
   from_port = 0
   to_port   = 0
   protocol  = "-1"
-  #tfsec:ignore:AWS007 - anything out
+  #tfsec:ignore:aws-ec2-no-public-egress-sgr - anything out
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.feedbackdb_ecs_service.id
   description       = "Non-production FeedbackDB ECS to anything - All traffic"

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -29,7 +29,7 @@ resource "aws_ecs_service" "front" {
 //----------------------------------
 // The service's Security Groups
 
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
+#tfsec:ignore:aws-ec2-add-description-to-security-group - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group" "front_ecs_service" {
   name_prefix = "${var.environment_name}-front-ecs-service"
   vpc_id      = data.aws_vpc.default.id
@@ -62,7 +62,7 @@ resource "aws_security_group_rule" "front_ecs_service_egress" {
   from_port = 0
   to_port   = 0
   protocol  = "-1"
-  #tfsec:ignore:AWS007 - anything out
+  #tfsec:ignore:aws-ec2-no-public-egress-sgr - anything out
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.front_ecs_service.id
   description       = "Front ECS to Anywhere - All traffic"

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -24,7 +24,7 @@ resource "aws_ecs_service" "pdf" {
 //----------------------------------
 // The service's Security Groups
 
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
+#tfsec:ignore:aws-ec2-add-description-to-security-group - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group" "pdf_ecs_service" {
   name_prefix = "${var.environment_name}-pdf-ecs-service"
   vpc_id      = data.aws_vpc.default.id
@@ -36,7 +36,7 @@ resource "aws_security_group_rule" "pdf_ecs_service_egress" {
   from_port = 0
   to_port   = 0
   protocol  = "-1"
-  #tfsec:ignore:AWS007 - anything out
+  #tfsec:ignore:aws-ec2-no-public-egress-sgr - anything out
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.pdf_ecs_service.id
   description       = "PDF ECS to Anywhere - All Traffic"

--- a/terraform/environment/modules/environment/ecs_seeding.tf
+++ b/terraform/environment/modules/environment/ecs_seeding.tf
@@ -1,6 +1,6 @@
 //----------------------------------
 // The Api service's Security Groups
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
+#tfsec:ignore:aws-ec2-add-description-to-security-group - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group" "seeding_ecs_service" {
   name_prefix = "${terraform.workspace}-seeding-ecs-service"
   vpc_id      = data.aws_vpc.default.id
@@ -13,7 +13,7 @@ resource "aws_security_group_rule" "seeding_ecs_service_egress" {
   from_port = 0
   to_port   = 0
   protocol  = "-1"
-  #tfsec:ignore:AWS007 - anything out
+  #tfsec:ignore:aws-ec2-no-public-egress-sgr - anything out
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.seeding_ecs_service.id
   description       = "Non-production Seeding ECS to Anywhere - All Traffic"

--- a/terraform/environment/modules/environment/load_balancer_admin.tf
+++ b/terraform/environment/modules/environment/load_balancer_admin.tf
@@ -19,7 +19,7 @@ resource "aws_lb_target_group" "admin" {
 
 resource "aws_lb" "admin" {
   name = "${var.environment_name}-admin"
-  #tfsec:ignore:AWS005 - public facing load balancer
+  #tfsec:ignore:aws-elb-alb-not-public - public facing load balancer
   internal                   = false
   load_balancer_type         = "application"
   subnets                    = data.aws_subnet_ids.public.ids
@@ -50,7 +50,7 @@ resource "aws_lb_listener" "admin_loadbalancer" {
   }
 }
 
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
+#tfsec:ignore:aws-ec2-add-description-to-security-group - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group" "admin_loadbalancer" {
   name        = "${var.environment_name}-admin-loadbalancer"
   description = "Allow inbound traffic"
@@ -74,7 +74,7 @@ resource "aws_security_group_rule" "admin_loadbalancer_ingress_production" {
   from_port = 443
   to_port   = 443
   protocol  = "tcp"
-  #tfsec:ignore:AWS006 - public facing inbound rule
+  #tfsec:ignore:aws-ec2-no-public-ingress-sgr - public facing inbound rule
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.admin_loadbalancer.id
   description       = "Anywhere to Production Admin ELB - HTTPS"
@@ -85,7 +85,7 @@ resource "aws_security_group_rule" "admin_loadbalancer_egress" {
   from_port = 0
   to_port   = 0
   protocol  = "-1"
-  #tfsec:ignore:AWS007 - public facing load balancer
+  #tfsec:ignore:aws-ec2-no-public-egress-sgr - public facing load balancer
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.admin_loadbalancer.id
   description       = "Admin Loadbalancer to Anywhere - All Traffic"

--- a/terraform/environment/modules/environment/load_balancer_front.tf
+++ b/terraform/environment/modules/environment/load_balancer_front.tf
@@ -19,7 +19,7 @@ resource "aws_lb_target_group" "front" {
 
 resource "aws_lb" "front" {
   name = "${var.environment_name}-front"
-  #tfsec:ignore:AWS005 - public facing load balancer
+  #tfsec:ignore:aws-elb-alb-not-public - public facing load balancer
   internal                   = false
   load_balancer_type         = "application"
   subnets                    = data.aws_subnet_ids.public.ids
@@ -51,7 +51,7 @@ resource "aws_lb_listener" "front_loadbalancer" {
   }
 }
 
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
+#tfsec:ignore:aws-ec2-add-description-to-security-group - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group" "front_loadbalancer" {
   name        = "${var.environment_name}-front-loadbalancer"
   description = "Allow inbound traffic"
@@ -70,14 +70,14 @@ resource "aws_security_group_rule" "front_loadbalancer_ingress" {
   description       = "MoJ sites to Front ELB - HTTPS"
 }
 
-#tfsec:ignore:AWS018 - Adding description is destructive change needing downtime. to be revisited
+#tfsec:ignore:aws-ec2-add-description-to-security-group - Adding description is destructive change needing downtime. to be revisited
 resource "aws_security_group_rule" "front_loadbalancer_ingress_production" {
   count     = var.environment_name == "production" ? 1 : 0
   type      = "ingress"
   from_port = 443
   to_port   = 443
   protocol  = "tcp"
-  #tfsec:ignore:AWS006 - public facing inbound rule
+  #tfsec:ignore:aws-ec2-no-public-ingress-sgr - public facing inbound rule
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.front_loadbalancer.id
   description       = "Anywhere to Production Front ELB - HTTPS"
@@ -88,7 +88,7 @@ resource "aws_security_group_rule" "front_loadbalancer_ingress_http" {
   from_port = 80
   to_port   = 80
   protocol  = "tcp"
-  #tfsec:ignore:AWS006 - public facing inbound rule
+  #tfsec:ignore:aws-ec2-no-public-ingress-sgr - public facing inbound rule
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.front_loadbalancer.id
   description       = "Anywhere to Front ELB - HTTP (redirects to HTTPS)"
@@ -99,7 +99,7 @@ resource "aws_security_group_rule" "front_loadbalancer_egress" {
   from_port = 0
   to_port   = 0
   protocol  = "-1"
-  #tfsec:ignore:AWS007 - public facing load balancer
+  #tfsec:ignore:aws-ec2-no-public-egress-sgr - public facing load balancer
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.front_loadbalancer.id
   description       = "Front ELB to Anywhere - All Traffic"

--- a/terraform/environment/modules/environment/modules/lambda_function/main.tf
+++ b/terraform/environment/modules/environment/modules/lambda_function/main.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "lambda_function" {
   tags = var.tags
 }
 
-#tfsec:ignore:AWS089 encryption of logs too expensive
+#tfsec:ignore:aws-cloudwatch-log-group-customer-key encryption of logs too expensive
 resource "aws_cloudwatch_log_group" "lambda_function" {
   name              = "/aws/lambda/${var.lambda_name}"
   tags              = var.tags

--- a/terraform/region/modules/region/elasticache.tf
+++ b/terraform/region/modules/region/elasticache.tf
@@ -1,4 +1,4 @@
-#tfsec:ignore:AWS018 - adding a description is a destructive change.
+#tfsec:ignore:aws-ec2-add-description-to-security-group - adding a description is a destructive change.
 resource "aws_security_group" "front_cache" {
   name   = "${local.account_name_short}-${local.region_name}-front-cache"
   vpc_id = aws_default_vpc.default.id

--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "loadbalancer_logging" {
 
 #versioning not required for a logging bucket bucket logging not needed. 
 #encryption of ALB access logs not supported with CMK
-#tfsec:ignore:AWS002  #tfsec:ignore:AWS077 #tfsec:ignore:aws-s3-encryption-customer-key
+#tfsec:ignore:aws-s3-enable-bucket-logging  #tfsec:ignore:aws-s3-enable-versioning #tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket" "access_log" {
   bucket = "online-lpa-${local.account_name}-${local.region_name}-lb-access-logs"
   acl    = "private"
@@ -78,7 +78,7 @@ resource "aws_s3_bucket_policy" "access_log" {
   policy = data.aws_iam_policy_document.loadbalancer_logging.json
 }
 
-#tfsec:ignore:AWS002 #tfsec:ignore:AWS077 - no logging or versioning required as a temp cache
+#tfsec:ignore:aws-s3-enable-bucket-logging #tfsec:ignore:aws-s3-enable-versioning - no logging or versioning required as a temp cache
 resource "aws_s3_bucket" "lpa_pdf_cache" {
   bucket        = lower("online-lpa-pdf-cache-${local.account_name}-${local.region_name}")
   acl           = "private"

--- a/terraform/region/modules/region/sns.tf
+++ b/terraform/region/modules/region/sns.tf
@@ -1,10 +1,10 @@
-#tfsec:ignore:AWS016 unsupported for this type of alert
+#tfsec:ignore:aws-sns-enable-topic-encryption unsupported for this type of alert
 resource "aws_sns_topic" "cloudwatch_to_slack_elasticache_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-${local.region_name}-elasticache-alert"
   tags = local.front_component_tag
 }
 
-#tfsec:ignore:AWS016 unsupported for this type of alert
+#tfsec:ignore:aws-sns-enable-topic-encryption unsupported for this type of alert
 resource "aws_sns_topic" "cloudwatch_to_account_ops_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-${local.region_name}-ops-alert"
   tags = local.shared_component_tag

--- a/terraform/region/modules/region/vpc.tf
+++ b/terraform/region/modules/region/vpc.tf
@@ -1,4 +1,4 @@
-#tfsec:ignore:AWS082 this is currently std practice. will look to change later if needed
+#tfsec:ignore:aws-ec2-no-default-vpc this is currently std practice. will look to change later if needed
 resource "aws_default_vpc" "default" {
   tags = merge(
     local.shared_component_tag,

--- a/terraform/region/modules/region/vpc_flow_logs.tf
+++ b/terraform/region/modules/region/vpc_flow_logs.tf
@@ -5,13 +5,13 @@ resource "aws_flow_log" "vpc_flow_logs" {
   vpc_id          = aws_default_vpc.default.id
 }
 
-#tfsec:ignore:AWS089 cost to encrypt is expensive. this is legacy so keep for now.
+#tfsec:ignore:aws-cloudwatch-log-group-customer-key cost to encrypt is expensive. this is legacy so keep for now.
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
   name = "vpc_flow_logs"
   tags = local.shared_component_tag
 }
 
-#tfsec:ignore:AWS089 cost to encrypt is expensive. region support needed
+#tfsec:ignore:aws-cloudwatch-log-group-customer-key cost to encrypt is expensive. region support needed
 resource "aws_cloudwatch_log_group" "vpc_flow_logs_region" {
   name = "vpc_flow_logs_${local.account_name}_${local.region_name}"
   tags = local.shared_component_tag


### PR DESCRIPTION
## Purpose

tfsec is no longer ignoring rules by their AWSXXX ID. 
Fixes LPAL-949

## Approach

Change all ignore rules to be rule names instead of legacy tfsec IDs.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
