### PR TITLE
LPAL-933: Remove count override for CommonRuleSet

### DIFF
--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -56,7 +56,7 @@ resource "aws_wafv2_web_acl" "main" {
     priority = 2
 
     override_action {
-      count {}
+      none {}
     }
 
     statement {


### PR DESCRIPTION
## Purpose

Block illegitimate requests to Make an LPA web service.

Fixes LPAL-933

## Approach

Change the AWS managed CommonRuleSet from Counting bad requests to blocking bad requests. `NoUserAgent_HEADER` is intentionally still allowed as there are a lot of seemingly legitimate requests with no user agent header set.

## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
