### PR TITLE
LPAL-921 Update CS guidance when donor can't sign

### DIFF
--- a/cypress/e2e/DateCheck.feature
+++ b/cypress/e2e/DateCheck.feature
@@ -20,9 +20,8 @@ Feature: Check signature dates
     When I visit the dashboard
     And I click "check-signing-dates" for LPA ID 26997335999
     Then I am taken to "/lpa/26997335999/date-check"
+    # Donor cannot sign or make mark
     # Additional attorneys and additional preferences
     And I can see a reminder to sign continuation sheet 1 and 2
-    # Donor cannot sign or make mark
-    And I can see a reminder to sign continuation sheet 3
     # primaryAttorney is a trust corporation
     And I can see a reminder to sign continuation sheet 4

--- a/cypress/e2e/common/i_can_see.js
+++ b/cypress/e2e/common/i_can_see.js
@@ -32,12 +32,7 @@ Then('I can see fields for the donor, certificate provider, attorney, applicant'
 })
 
 Then('I can see a reminder to sign continuation sheet 1 and 2', () => {
-    const text = 'You must have signed and dated continuation sheets 1 and 2 before you signed section 9 of the LPA, or on the same day.'
-    cy.get('[data-cy=continuation-sheet-info]').should('contain.text', text);
-})
-
-Then('I can see a reminder to sign continuation sheet 3', () => {
-    const text = 'This person must have signed continuation sheet 3 before the certificate provider has signed section 10.'
+    const text = 'Continuation sheets 1 and 2 must have been signed and dated before or on the same day as they signed continuation sheet 3.'
     cy.get('[data-cy=continuation-sheet-info]').should('contain.text', text);
 })
 

--- a/service-front/module/Application/src/Controller/Authenticated/Lpa/DateCheckController.php
+++ b/service-front/module/Application/src/Controller/Authenticated/Lpa/DateCheckController.php
@@ -102,6 +102,7 @@ class DateCheckController extends AbstractLpaController
 
         $viewModel->setVariables([
             'continuationNoteKeys' => $helperResult['continuationNoteKeys'],
+            'continuationSheet' => $helperResult['continuationSheet'],
             'applicants' => $helperResult['applicants']
         ]);
 

--- a/service-front/module/Application/src/Controller/Authenticated/Lpa/DateCheckController.php
+++ b/service-front/module/Application/src/Controller/Authenticated/Lpa/DateCheckController.php
@@ -102,7 +102,7 @@ class DateCheckController extends AbstractLpaController
 
         $viewModel->setVariables([
             'continuationNoteKeys' => $helperResult['continuationNoteKeys'],
-            'continuationSheet' => $helperResult['continuationSheet'],
+            'continuationSheets' => $helperResult['continuationSheets'],
             'applicants' => $helperResult['applicants']
         ]);
 

--- a/service-front/module/Application/src/View/DateCheckViewModelHelper.php
+++ b/service-front/module/Application/src/View/DateCheckViewModelHelper.php
@@ -37,7 +37,7 @@ class DateCheckViewModelHelper
         $continuationSheets = new ContinuationSheets();
         $continuationNoteKeys = $continuationSheets->getContinuationNoteKeys($lpa);
 
-        $continuationSheet = [];
+        $continuationSheets = [];
         $cs1 = in_array('ANY_PEOPLE_OVERFLOW', $continuationNoteKeys);
         $cs2 = (
             in_array('LONG_INSTRUCTIONS_OR_PREFERENCES', $continuationNoteKeys) or
@@ -47,22 +47,22 @@ class DateCheckViewModelHelper
         $cs4 = in_array('HAS_TRUST_CORP', $continuationNoteKeys);
 
         if ($cs1) {
-            $continuationSheet[] = 1;
+            $continuationSheets[] = 1;
         }
         if ($cs2) {
-            $continuationSheet[] = 2;
+            $continuationSheets[] = 2;
         }
         if ($cs3) {
-            $continuationSheet[] = 3;
+            $continuationSheets[] = 3;
         }
         if ($cs4) {
-            $continuationSheet[] = 4;
+            $continuationSheets[] = 4;
         }
 
         return [
             'applicants' => $applicants,
             'continuationNoteKeys' => $continuationNoteKeys,
-            'continuationSheet' => $continuationSheet
+            'continuationSheets' => $continuationSheets
         ];
     }
 }

--- a/service-front/module/Application/src/View/DateCheckViewModelHelper.php
+++ b/service-front/module/Application/src/View/DateCheckViewModelHelper.php
@@ -37,9 +37,32 @@ class DateCheckViewModelHelper
         $continuationSheets = new ContinuationSheets();
         $continuationNoteKeys = $continuationSheets->getContinuationNoteKeys($lpa);
 
+        $continuationSheet = [];
+        $cs1 = in_array('ANY_PEOPLE_OVERFLOW', $continuationNoteKeys);
+        $cs2 = (
+            in_array('LONG_INSTRUCTIONS_OR_PREFERENCES', $continuationNoteKeys) or
+            in_array('HAS_ATTORNEY_DECISIONS', $continuationNoteKeys)
+        );
+        $cs3 = in_array('CANT_SIGN', $continuationNoteKeys);
+        $cs4 = in_array('HAS_TRUST_CORP', $continuationNoteKeys);
+
+        if ($cs1) {
+            $continuationSheet[] = 1;
+        }
+        if ($cs2) {
+            $continuationSheet[] = 2;
+        }
+        if ($cs3) {
+            $continuationSheet[] = 3;
+        }
+        if ($cs4) {
+            $continuationSheet[] = 4;
+        }
+
         return [
             'applicants' => $applicants,
-            'continuationNoteKeys' => $continuationNoteKeys
+            'continuationNoteKeys' => $continuationNoteKeys,
+            'continuationSheet' => $continuationSheet
         ];
     }
 }

--- a/service-front/module/Application/tests/View/DateCheckViewModelHelperTest.php
+++ b/service-front/module/Application/tests/View/DateCheckViewModelHelperTest.php
@@ -261,6 +261,80 @@ class DateCheckViewModelHelperTest extends MockeryTestCase
                                     'same day as they signed continuation sheet 3.'],
             'expectedAttorneyText' => []
         ],
+        // CS3 & CS1 HW LPA - donor cannot sign or make a mark, >4 people to notify
+        [
+            'lpa' => [
+                'document' => [
+                    'type' => 'health-and-welfare',
+                    'peopleToNotify' => [[], [], [], [], []],
+                    'donor' => [
+                        'canSign' => false
+                    ]
+                ]
+            ],
+            'expectedDonorText' => ['Continuation sheet 1 must have been signed and dated before or on the ' .
+                                    'same day as they signed section 5.',
+                                    'Section 5 must have been signed and ' .
+                                    'dated before or on the same day as they signed continuation sheet 3.'],
+            'expectedAttorneyText' => []
+        ],
+        // CS3 & CS2 HW LPA - donor cannot sign or make a mark, additional info on how attorneys make decisions
+        [
+            'lpa' => [
+                'document' => [
+                    'type' => 'health-and-welfare',
+                    'replacementAttorneyDecisions' => [
+                        'howDetails' => 'Replacement attorneys should only step in when I say so.'
+                    ],
+                    'donor' => [
+                        'canSign' => false
+                    ]
+                ]
+            ],
+            'expectedDonorText' => ['Continuation sheet 2 must have been signed and dated before or on the ' .
+                                    'same day as they signed section 5.',
+                                    'Section 5 must have been signed and ' .
+                                    'dated before or on the same day as they signed continuation sheet 3.'],
+            'expectedAttorneyText' => []
+        ],
+        // CS3 & CS2 HW LPA - donor cannot sign or make a mark, >4 people to notify
+        [
+            'lpa' => [
+                'document' => [
+                    'type' => 'health-and-welfare',
+                    'peopleToNotify' => [[], [], [], [], []],
+                    'donor' => [
+                        'canSign' => false
+                    ]
+                ]
+            ],
+            'expectedDonorText' => ['Continuation sheet 1 must have been signed and dated before or on the ' .
+                                    'same day as they signed section 5.',
+                                    'Section 5 must have been signed and ' .
+                                    'dated before or on the same day as they signed continuation sheet 3.'],
+            'expectedAttorneyText' => []
+        ],
+        // CS3 & CS2 & CS1 HW LPA - donor cannot sign or make a mark,
+        // additional info on how attorneys make decisions, >4 people to notify
+        [
+            'lpa' => [
+                'document' => [
+                    'type' => 'health-and-welfare',
+                    'peopleToNotify' => [[], [], [], [], []],
+                    'replacementAttorneyDecisions' => [
+                        'howDetails' => 'Replacement attorneys should only step in when I say so.'
+                    ],
+                    'donor' => [
+                        'canSign' => false
+                    ]
+                ]
+            ],
+            'expectedDonorText' => ['Continuation sheets 1 and 2 must have been signed and dated before or on the ' .
+                                    'same day as they signed section 5.',
+                                    'Section 5 must have been signed and ' .
+                                    'dated before or on the same day as they signed continuation sheet 3.'],
+            'expectedAttorneyText' => []
+        ],
     ];
 
     /* This returns an arbitrary string to imitate a class constant needed when adding twig functions to the
@@ -296,7 +370,7 @@ class DateCheckViewModelHelperTest extends MockeryTestCase
         // set vars on ViewModel as it is done in controller
         $viewModel->setVariables([
             'continuationNoteKeys' => $helperResult['continuationNoteKeys'],
-            'continuationSheet' => $helperResult['continuationSheet'],
+            'continuationSheets' => $helperResult['continuationSheets'],
             'applicants' => []
         ]);
 

--- a/service-front/module/Application/tests/View/DateCheckViewModelHelperTest.php
+++ b/service-front/module/Application/tests/View/DateCheckViewModelHelperTest.php
@@ -164,7 +164,7 @@ class DateCheckViewModelHelperTest extends MockeryTestCase
             'expectedAttorneyText' => []
         ],
         // Continuation sheet 3
-        // Health & welfare LPA - donor cannot sign or make a mark
+        // Health & welfare (HW) LPA - donor cannot sign or make a mark
         [
             'lpa' => [
                 'document' => [
@@ -176,10 +176,11 @@ class DateCheckViewModelHelperTest extends MockeryTestCase
             ],
             'expectedDonorText' => [
                 'This person must have signed continuation sheet 3 on the same day as they sign ' .
-                'section 5 and before the certificate provider signs section 10.'],
+                'section 5 and before the certificate provider signs section 10.'
+            ],
             'expectedAttorneyText' => []
         ],
-        // Property & finance LPA - donor cannot sign or make a mark
+        // Property & finance (PF) LPA - donor cannot sign or make a mark
         [
             'lpa' => [
                 'document' => [
@@ -207,6 +208,58 @@ class DateCheckViewModelHelperTest extends MockeryTestCase
             'expectedDonorText' => [],
             'expectedAttorneyText' => ['They must have signed continuation sheet 4 after the ' .
                                        '\'certificate provider\' has signed section 10 of the LPA form.']
+        ],
+        // Combined continuation sheet scenarios
+        // CS3 & CS1 PF LPA - donor cannot sign or make a mark, >4 people to notify
+        [
+            'lpa' => [
+                'document' => [
+                    'type' => 'property-and-financial',
+                    'peopleToNotify' => [[], [], [], [], []],
+                    'donor' => [
+                        'canSign' => false
+                    ]
+                ]
+            ],
+            'expectedDonorText' => ['Continuation sheet 1 must have been signed and dated before or on the ' .
+                                    'same day as they signed continuation sheet 3.'],
+            'expectedAttorneyText' => []
+        ],
+        // CS3 & CS2 PF LPA - donor cannot sign or make a mark, additional info on how attorneys make decisions
+        [
+            'lpa' => [
+                'document' => [
+                    'type' => 'property-and-financial',
+                    'replacementAttorneyDecisions' => [
+                        'howDetails' => 'Replacement attorneys should only step in when I say so.'
+                    ],
+                    'donor' => [
+                        'canSign' => false
+                    ]
+                ]
+            ],
+            'expectedDonorText' => ['Continuation sheet 2 must have been signed and dated before or on the ' .
+                                    'same day as they signed continuation sheet 3.'],
+            'expectedAttorneyText' => []
+        ],
+        // CS3 & CS2 & CS1 PF LPA - donor cannot sign or make a mark,
+        // additional info on how attorneys make decisions, >4 people to notify
+        [
+            'lpa' => [
+                'document' => [
+                    'type' => 'property-and-financial',
+                    'peopleToNotify' => [[], [], [], [], []],
+                    'replacementAttorneyDecisions' => [
+                        'howDetails' => 'Replacement attorneys should only step in when I say so.'
+                    ],
+                    'donor' => [
+                        'canSign' => false
+                    ]
+                ]
+            ],
+            'expectedDonorText' => ['Continuation sheets 1 and 2 must have been signed and dated before or on the ' .
+                                    'same day as they signed continuation sheet 3.'],
+            'expectedAttorneyText' => []
         ],
     ];
 
@@ -243,6 +296,7 @@ class DateCheckViewModelHelperTest extends MockeryTestCase
         // set vars on ViewModel as it is done in controller
         $viewModel->setVariables([
             'continuationNoteKeys' => $helperResult['continuationNoteKeys'],
+            'continuationSheet' => $helperResult['continuationSheet'],
             'applicants' => []
         ]);
 
@@ -302,8 +356,8 @@ class DateCheckViewModelHelperTest extends MockeryTestCase
             echo "Running tests for donor DateCheckViewModelHelper test case $index\n";
 
             $this->assertEquals(
-                $matchesArray,
-                $expectedText
+                $expectedText,
+                $matchesArray
             );
         }
     }
@@ -331,8 +385,8 @@ class DateCheckViewModelHelperTest extends MockeryTestCase
             echo "Running tests for attorney DateCheckViewModelHelper test case $index\n";
 
             $this->assertEquals(
-                $matchesArray,
-                $expectedText
+                $expectedText,
+                $matchesArray
             );
         }
     }

--- a/service-front/module/Application/view/application/authenticated/lpa/date-check/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/date-check/index.twig
@@ -278,15 +278,26 @@
         {% block donorGuidance %}
             {% if continuationNoteKeys is not empty %}
             <div class="panel panel-border-wide text">
-                {% if 'ANY_PEOPLE_OVERFLOW' in continuationNoteKeys and ('LONG_INSTRUCTIONS_OR_PREFERENCES' in continuationNoteKeys or 'HAS_ATTORNEY_DECISIONS' in continuationNoteKeys) %}
+                {# cs1 cs2 cs3#}
+                {% if 1 in continuationSheet and 2 in continuationSheet and 3 in continuationSheet %}
+                    <p data-cy="continuation-sheet-info">Continuation sheets 1 and 2 must have been signed and dated before or on the same day as they signed continuation sheet 3.</p>
+                {# cs1 cs2 #}
+                {% elseif 1 in continuationSheet and 2 in continuationSheet %}
                     <p data-cy="continuation-sheet-info">You must have signed and dated continuation sheets 1 and 2 before you signed section 9 of the LPA, or on the same day.</p>
-                {% elseif 'LONG_INSTRUCTIONS_OR_PREFERENCES' in continuationNoteKeys or 'HAS_ATTORNEY_DECISIONS' in continuationNoteKeys %}
-                    <p data-cy="continuation-sheet-info">You must have signed and dated continuation sheet/s 2 before you signed section 9 of the LPA, or on the same day.</p>
-                {% elseif 'ANY_PEOPLE_OVERFLOW' in continuationNoteKeys %}
+                {# cs1 cs3 #}
+                {% elseif 1 in continuationSheet and 3 in continuationSheet %}
+                    <p data-cy="continuation-sheet-info">Continuation sheet 1 must have been signed and dated before or on the same day as they signed continuation sheet 3.</p>
+                {# cs2 cs3 #}
+                {% elseif 2 in continuationSheet and 3 in continuationSheet %}
+                    <p data-cy="continuation-sheet-info">Continuation sheet 2 must have been signed and dated before or on the same day as they signed continuation sheet 3.</p>
+                {# cs1 #}
+                {% elseif 1 in continuationSheet %}
                     <p data-cy="continuation-sheet-info">You must have signed and dated continuation sheet/s 1 before you signed section 9 of the LPA, or on the same day.</p>
-                {% endif %}
-
-                {% if 'CANT_SIGN' in continuationNoteKeys%}
+                {# cs2 #}
+                {% elseif 2 in continuationSheet %}
+                    <p data-cy="continuation-sheet-info">You must have signed and dated continuation sheet/s 2 before you signed section 9 of the LPA, or on the same day.</p>
+                {# cs3 #}
+                {% elseif 3 in continuationSheet %}
                     {% if lpa.document.type == 'property-and-financial' %}
                         <p data-cy="continuation-sheet-info">This person must have signed continuation sheet 3 before the certificate provider has signed section 10.</p>
                     {% elseif lpa.document.type == 'health-and-welfare' %}

--- a/service-front/module/Application/view/application/authenticated/lpa/date-check/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/date-check/index.twig
@@ -276,33 +276,53 @@
         </div>
 
         {% block donorGuidance %}
-            {% if continuationNoteKeys is not empty %}
+            {% if continuationSheets is not empty %}
             <div class="panel panel-border-wide text">
-                {# cs1 cs2 cs3#}
-                {% if 1 in continuationSheet and 2 in continuationSheet and 3 in continuationSheet %}
-                    <p data-cy="continuation-sheet-info">Continuation sheets 1 and 2 must have been signed and dated before or on the same day as they signed continuation sheet 3.</p>
+                {# cs1 cs2 cs3 #}
+                {% if 1 in continuationSheets and 2 in continuationSheets and 3 in continuationSheets %}
+                    {% if lpa.document.type == 'property-and-financial' %}
+                        <p data-cy="continuation-sheet-info">Continuation sheets 1 and 2 must have been signed and dated before or on the same day as they signed continuation sheet 3.</p>
+                    {% elseif lpa.document.type == 'health-and-welfare' %}
+                        <p data-cy="continuation-sheet-info">Continuation sheets 1 and 2 must have been signed and dated before or on the same day as they signed section 5.</p>
+                    {% endif %}
+
                 {# cs1 cs2 #}
-                {% elseif 1 in continuationSheet and 2 in continuationSheet %}
+                {% elseif 1 in continuationSheets and 2 in continuationSheets %}
                     <p data-cy="continuation-sheet-info">You must have signed and dated continuation sheets 1 and 2 before you signed section 9 of the LPA, or on the same day.</p>
+
                 {# cs1 cs3 #}
-                {% elseif 1 in continuationSheet and 3 in continuationSheet %}
-                    <p data-cy="continuation-sheet-info">Continuation sheet 1 must have been signed and dated before or on the same day as they signed continuation sheet 3.</p>
+                {% elseif 1 in continuationSheets and 3 in continuationSheets %}
+                    {% if lpa.document.type == 'property-and-financial' %}
+                        <p data-cy="continuation-sheet-info">Continuation sheet 1 must have been signed and dated before or on the same day as they signed continuation sheet 3.</p>
+                    {% elseif lpa.document.type == 'health-and-welfare' %}
+                        <p data-cy="continuation-sheet-info">Continuation sheet 1 must have been signed and dated before or on the same day as they signed section 5.</p>
+                    {% endif %}
+
                 {# cs2 cs3 #}
-                {% elseif 2 in continuationSheet and 3 in continuationSheet %}
-                    <p data-cy="continuation-sheet-info">Continuation sheet 2 must have been signed and dated before or on the same day as they signed continuation sheet 3.</p>
+                {% elseif 2 in continuationSheets and 3 in continuationSheets %}
+                    {% if lpa.document.type == 'property-and-financial' %}
+                        <p data-cy="continuation-sheet-info">Continuation sheet 2 must have been signed and dated before or on the same day as they signed continuation sheet 3.</p>
+                    {% elseif lpa.document.type == 'health-and-welfare' %}
+                        <p data-cy="continuation-sheet-info">Continuation sheet 2 must have been signed and dated before or on the same day as they signed section 5.</p>
+                    {% endif %}
+
                 {# cs1 #}
-                {% elseif 1 in continuationSheet %}
+                {% elseif 1 in continuationSheets %}
                     <p data-cy="continuation-sheet-info">You must have signed and dated continuation sheet/s 1 before you signed section 9 of the LPA, or on the same day.</p>
                 {# cs2 #}
-                {% elseif 2 in continuationSheet %}
+                {% elseif 2 in continuationSheets %}
                     <p data-cy="continuation-sheet-info">You must have signed and dated continuation sheet/s 2 before you signed section 9 of the LPA, or on the same day.</p>
                 {# cs3 #}
-                {% elseif 3 in continuationSheet %}
+                {% elseif 3 in continuationSheets %}
                     {% if lpa.document.type == 'property-and-financial' %}
                         <p data-cy="continuation-sheet-info">This person must have signed continuation sheet 3 before the certificate provider has signed section 10.</p>
                     {% elseif lpa.document.type == 'health-and-welfare' %}
                         <p data-cy="continuation-sheet-info">This person must have signed continuation sheet 3 on the same day as they sign section 5 and before the certificate provider signs section 10.</p>
                     {% endif %}
+                {% endif %}
+
+                {% if (1 in continuationSheets or 2 in continuationSheets) and 3 in continuationSheets and lpa.document.type == 'health-and-welfare' %}
+                    <p data-cy="continuation-sheet-info">Section 5 must have been signed and dated before or on the same day as they signed continuation sheet 3.</p>
                 {% endif %}
             </div>
             {% endif %}


### PR DESCRIPTION
## Purpose

[LPAL-921](https://opgtransform.atlassian.net/browse/LPAL-921)

Amend guidance in Check Signatures tool when continuation sheet 3 applies to reflect that it is not the donor themselves who would be signing, but the person who would sign on their behalf.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
