### PR TITLE
LPAL-890 and LPAL-891 donor cant sign related messaging

### DIFF
--- a/cypress/e2e/DateCheck.feature
+++ b/cypress/e2e/DateCheck.feature
@@ -26,3 +26,15 @@ Feature: Check signature dates
     # primaryAttorney is a trust corporation (4)
     And I can see a reminder to sign continuation sheet 4
     And I can see that the donor cannot sign
+
+  Scenario: Displays the correct references to donor in errors when they cannot sign
+    Given I visit the dashboard
+    When I click "check-signing-dates" for LPA ID 26997335999
+    And I click element marked "Check dates"
+    Then I can see validation errors do not refer to the donor
+
+  Scenario: Displays the correct references to donor in errors when they can sign
+    Given I visit the dashboard
+    When I click "check-signing-dates" for LPA ID 91155453023
+    And I click element marked "Check dates"
+    Then I can see validation errors refer to the donor

--- a/cypress/e2e/DateCheck.feature
+++ b/cypress/e2e/DateCheck.feature
@@ -14,14 +14,15 @@ Feature: Check signature dates
     And there are "four" ".date-check-person" elements on the page
     And I can see fields for the donor, certificate provider, attorney, applicant
     And I cannot see continuation sheet reminders
+    And I cannot see that the donor cannot sign
 
   Scenario: Displays relevant information on signing continuation sheets
     Given I visit the dashboard
     When I visit the dashboard
     And I click "check-signing-dates" for LPA ID 26997335999
     Then I am taken to "/lpa/26997335999/date-check"
-    # Donor cannot sign or make mark
-    # Additional attorneys and additional preferences
-    And I can see a reminder to sign continuation sheet 1 and 2
-    # primaryAttorney is a trust corporation
+    # Additional attorneys (cs1), additional preferences (2), donor cannot sign or make mark (3)
+    And I can see a reminder to sign continuation sheet 1, 2 and 3
+    # primaryAttorney is a trust corporation (4)
     And I can see a reminder to sign continuation sheet 4
+    And I can see that the donor cannot sign

--- a/cypress/e2e/DateCheck.feature
+++ b/cypress/e2e/DateCheck.feature
@@ -33,8 +33,8 @@ Feature: Check signature dates
     And I click element marked "Check dates"
     Then I can see validation errors do not refer to the donor
 
-  Scenario: Displays the correct references to donor in errors when they can sign
+  Scenario: Displays the correct references to applicant in errors when they can sign
     Given I visit the dashboard
     When I click "check-signing-dates" for LPA ID 91155453023
     And I click element marked "Check dates"
-    Then I can see validation errors refer to the donor
+    Then I can see validation errors refer to the donor and applicant

--- a/cypress/e2e/common/i_can_see.js
+++ b/cypress/e2e/common/i_can_see.js
@@ -31,7 +31,7 @@ Then('I can see fields for the donor, certificate provider, attorney, applicant'
     })
 })
 
-Then('I can see a reminder to sign continuation sheet 1 and 2', () => {
+Then('I can see a reminder to sign continuation sheet 1, 2 and 3', () => {
     const text = 'Continuation sheets 1 and 2 must have been signed and dated before or on the same day as they signed continuation sheet 3.'
     cy.get('[data-cy=continuation-sheet-info]').should('contain.text', text);
 })
@@ -39,4 +39,28 @@ Then('I can see a reminder to sign continuation sheet 1 and 2', () => {
 Then('I can see a reminder to sign continuation sheet 4', () => {
     const text = 'They must have signed continuation sheet 4 after the \'certificate provider\' has signed section 10 of the LPA form.'
     cy.get('[data-cy=primary-attorney]').find('[data-cy=continuation-sheet-info]').should('contain.text', text);
+})
+
+Then('I can see that the donor cannot sign', () => {
+    const donorName = 'A person signing on behalf of Mr Christopher Robin (donor)'
+    const donorText = 'This person signed continuation sheet 3 on behalf of the donor on'
+    cy.get('[data-cy=date-check-donor]').find('h3').should('contain.text', donorName);
+    cy.get('[data-cy=date-check-donor]').find('p').should('contain.text', donorText);
+
+    const applicantName = 'A person signing on behalf of Mr Christopher Robin (applicant)'
+    const applicantText = 'This person signed section 15 of the LPA on behalf of the donor on'
+    cy.get('[data-cy=date-check-applicant]').find('h3').should('contain.text', applicantName);
+    cy.get('[data-cy=date-check-applicant]').find('p').should('contain.text', applicantText);
+})
+
+Then('I cannot see that the donor cannot sign', () => {
+    const donorName = 'Mr Dead Pool (donor)'
+    const donorText = 'This person signed section 9 of the LPA on'
+    cy.get('[data-cy=date-check-donor]').find('h3').should('contain.text', donorName);
+    cy.get('[data-cy=date-check-donor]').find('p').should('contain.text', donorText);
+
+    const applicantName = 'Mr Dead Pool (applicant)'
+    const applicantText = 'This person signed section 15'
+    cy.get('[data-cy=date-check-applicant]').find('h3').should('contain.text', applicantName);
+    cy.get('[data-cy=date-check-applicant]').find('p').should('contain.text', applicantText);
 })

--- a/cypress/e2e/common/i_can_see.js
+++ b/cypress/e2e/common/i_can_see.js
@@ -64,3 +64,15 @@ Then('I cannot see that the donor cannot sign', () => {
     cy.get('[data-cy=date-check-applicant]').find('h3').should('contain.text', applicantName);
     cy.get('[data-cy=date-check-applicant]').find('p').should('contain.text', applicantText);
 })
+
+Then('I can see validation errors do not refer to the donor', () => {
+    const text = 'Enter the person signing on behalf of the donor\'s signature date'
+    cy.get('[data-cy=date-check-donor]').find('.error-message').should('contain.text', text);
+    cy.get('[data-cy=date-check-applicant]').find('.error-message').should('contain.text', text);
+})
+
+Then('I can see validation errors refer to the donor', () => {
+    const text = 'Enter the donor\'s signature date'
+    cy.get('[data-cy=date-check-donor]').find('.error-message').should('contain.text', text);
+    cy.get('[data-cy=date-check-applicant]').find('.error-message').should('contain.text', text);
+})

--- a/cypress/e2e/common/i_can_see.js
+++ b/cypress/e2e/common/i_can_see.js
@@ -71,8 +71,10 @@ Then('I can see validation errors do not refer to the donor', () => {
     cy.get('[data-cy=date-check-applicant]').find('.error-message').should('contain.text', text);
 })
 
-Then('I can see validation errors refer to the donor', () => {
-    const text = 'Enter the donor\'s signature date'
-    cy.get('[data-cy=date-check-donor]').find('.error-message').should('contain.text', text);
-    cy.get('[data-cy=date-check-applicant]').find('.error-message').should('contain.text', text);
+Then('I can see validation errors refer to the donor and applicant', () => {
+    const donorText = 'Enter the donor\'s signature date'
+    cy.get('[data-cy=date-check-donor]').find('.error-message').should('contain.text', donorText);
+
+    const applicantText = 'Enter the applicant\'s signature date'
+    cy.get('[data-cy=date-check-applicant]').find('.error-message').should('contain.text', applicantText );
 })

--- a/service-front/module/Application/src/View/DateCheckViewModelHelper.php
+++ b/service-front/module/Application/src/View/DateCheckViewModelHelper.php
@@ -16,6 +16,7 @@ class DateCheckViewModelHelper
             if ($lpa->document->whoIsRegistering === 'donor') {
                 $applicants[0] = [
                     'name' => $lpa->document->donor->name,
+                    'isDonor' => true,
                     'isHuman' => true,
                 ];
             } elseif (is_array($lpa->document->whoIsRegistering)) {

--- a/service-front/module/Application/view/application/authenticated/lpa/date-check/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/date-check/index.twig
@@ -194,7 +194,7 @@
 
     <input type="hidden" name="return-route" value="{{ returnRoute }}">
 
-    <div class="date-check-person person person--full">
+    <div class="date-check-person person person--full" data-cy="date-check-donor">
         <h3 class="person-name heading-small flush--ends" data-cy="person-name">
         {% if lpa.document.donor.canSign %}
             {{ lpa.document.donor.name }} (donor)
@@ -211,11 +211,13 @@
                     {{ formElementErrorsV2(donorLifeSustainingElementYear) }}
                     {{ formElementErrorsV2(donorLifeSustainingElement) }}
 
+                    <p>
                     {% if lpa.document.donor.canSign %}
-                        <p>This person signed section 5 of the LPA on</p>
+                        This person signed section 5 of the LPA on
                     {% else %}
-                        <p>This person signed section 5 of the LPA on behalf of the donor on</p>
+                        This person signed section 5 of the LPA on behalf of the donor on
                     {% endif %}
+                    </p>
 
                     <fieldset id="{{ donorLifeSustainingElement.getAttribute('id') }}" class="date-check-dates">
                         <legend class="visually-hidden">Check signature dates for donor who signed section 5 of the LPA</legend>
@@ -247,12 +249,13 @@
                 {{ formElementErrorsV2(donorElementYear) }}
                 {{ formElementErrorsV2(donorElement) }}
 
+                <p>
                 {% if lpa.document.donor.canSign %}
-                    <p>This person signed continuation sheet 3 of the LPA on</p>
+                    This person signed section 9 of the LPA on
                 {% else %}
-                    <p>This person signed continuation sheet 3 on behalf of the donor on</p>
+                    This person signed continuation sheet 3 on behalf of the donor on
                 {% endif %}
-
+                </p>
 
                 <fieldset id="{{ donorElement.getAttribute('id') }}" class="date-check-dates">
                     <legend class="visually-hidden">Check signature dates for donor who signed section 9 of the LPA</legend>
@@ -556,8 +559,14 @@
             id: elementYearId
         }) ? '' }}
 
-        <div class="date-check-person person person--full">
-            <h3 class="person-name heading-small flush--ends" data-cy="person-name">{{ applicant['name'] }} (applicant)</h3>
+        <div class="date-check-person person person--full" data-cy="date-check-applicant">
+            <h3 class="person-name heading-small flush--ends" data-cy="person-name">
+            {% if applicant['isDonor'] and not lpa.document.donor.canSign %}
+                A person signing on behalf of {{ applicant['name'] }} (applicant)
+            {% else %}
+                {{ applicant['name'] }} (applicant)
+            {% endif %}
+            </h3>
             <div class="person-address flush--ends">
                 <div class="dob-element form-date {{ element.getMessages|length >0 ? 'form-group-error'}}">
                     {{ formElementErrorsV2(elementDay) }}
@@ -566,11 +575,13 @@
                     {{ formElementErrorsV2(element) }}
 
                     <p>
-                        {% if applicant['isHuman'] %}
-                            This person signed section 15 of the LPA on
-                        {% else %}
-                            This corporation signed section 15 of the LPA on
-                        {% endif %}
+                    {% if applicant['isHuman'] and applicant['isDonor'] and not lpa.document.donor.canSign %}
+                        This person signed section 15 of the LPA on behalf of the donor on
+                    {% elseif applicant['isHuman'] %}
+                        This person signed section 15 of the LPA on
+                    {% else %}
+                        This corporation signed section 15 of the LPA on
+                    {% endif %}
                     </p>
 
                     <fieldset id="{{ element.getAttribute('id') }}" class="date-check-dates">

--- a/service-front/module/Application/view/application/authenticated/lpa/date-check/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/date-check/index.twig
@@ -4,14 +4,16 @@
 
 {%- set pageTitle = 'Check signature dates' -%}
 
+{% set personSigningForDonor = lpa.document.donor.canSign ? 'donor' : 'person signing on behalf of the donor' %}
+
 {% set errorMappings = {
     'sign-date-donor-life-sustaining': {
-        'Enter all the date fields': 'Enter the donor\'s signature date',
-        'The input does not appear to be a valid date': 'The donor\'s signature date does not appear to be a valid date'
+        'Enter all the date fields': 'Enter the ' ~ (personSigningForDonor) ~ '\'s signature date',
+        'The input does not appear to be a valid date': 'The ' ~ (personSigningForDonor) ~ '\'s signature date does not appear to be a valid date'
     },
     'sign-date-donor': {
-        'Enter all the date fields': 'Enter the donor\'s signature date',
-        'The input does not appear to be a valid date': 'The donor\'s signature date does not appear to be a valid date'
+        'Enter all the date fields': 'Enter the ' ~ (personSigningForDonor) ~ '\'s signature date',
+        'The input does not appear to be a valid date': 'The ' ~ (personSigningForDonor) ~ '\'s signature date does not appear to be a valid date'
     },
     'sign-date-certificate-provider': {
         'Enter all the date fields': 'Enter the certificate provider\'s signature date',
@@ -45,10 +47,16 @@
 {% for idx, applicant in applicants %}
     {% set messageKey = 'sign-date-applicant-' ~ idx %}
 
+    {% if applicant['isHuman'] and applicant['isDonor'] and not lpa.document.donor.canSign %}
+        {% set personSigningForApplicant = 'person signing on behalf of the donor' %}
+    {% else %}
+        {% set personSigningForApplicant = 'applicant' %}
+    {% endif %}
+
     {% set errorMappings = errorMappings|merge({
         (messageKey) : {
-            'Enter all the date fields': 'Enter the applicant\'s signature date',
-            'The input does not appear to be a valid date': 'The applicant\'s signature date does not appear to be a valid date'
+            'Enter all the date fields': 'Enter the ' ~ (personSigningForApplicant) ~ '\'s signature date',
+            'The input does not appear to be a valid date': 'The ' ~ (personSigningForApplicant) ~ '\'s signature date does not appear to be a valid date'
         }
     }) %}
 {% endfor %}


### PR DESCRIPTION
## Purpose

[LPAL-890](https://opgtransform.atlassian.net/browse/LPAL-890)
Change heading and text of applicant in the 'Check signatures' tool when the applicant is the donor and the donor cannot sign to say 'The person signing on behalf of the donor'.

[LPAL-891](https://opgtransform.atlassian.net/browse/LPAL-891)
Change validation error messages when the donor cannot sign, and also when the applicant is the donor and the donor cannot sign.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
