### PR TITLE
LPAL-956 Move Cleanup PR workspaces cron to Github Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,18 +452,6 @@ path_to_live: &path_to_live
         requires: [test_healthcheck_prod]
 
 workflows:
-  workspace_cleanup:
-    triggers:
-      - schedule:
-          cron: "0 6,18 * * 0-6" # 6am and 6pm
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - workspace_cleanup:
-          name: workspace_cleanup
-
   pr_build:
     <<: *pr_build
 
@@ -1406,24 +1394,3 @@ jobs:
                                            --branch $CIRCLE_BRANCH \
                                            --slack_channel $BUILD_SLACK_CHANNEL \
                                            --slack_token $SLACK_ACCESS_TOKEN
-  workspace_cleanup:
-    docker:
-      - image: hashicorp/terraform:1.1.2
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_ACCESS_TOKEN
-    resource_class: small
-    steps:
-      - checkout
-      - infrastructure_and_deployment/install_workspace_manager
-      - run:
-          name: Cleanup Workspaces
-          command: |
-            cd terraform/environment
-            terraform init
-            export TF_PROTECTED_WORKSPACES=$(~/project/terraform-workspace-manager \
-             -protected-workspaces=true \
-             -aws-account-id=050256574573 \
-             -aws-iam-role=opg-lpa-ci) >> $BASH_ENV
-             echo $TF_PROTECTED_WORKSPACES
-             ~/project/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh ${TF_PROTECTED_WORKSPACES}

--- a/.github/workflows/workflow_terraform_environment_cleanup.yml
+++ b/.github/workflows/workflow_terraform_environment_cleanup.yml
@@ -1,0 +1,57 @@
+name: "[Workflow] Cleanup PR Workspaces"
+
+on:
+  schedule:
+    # 6am and 6pm every day except Sundays
+    - cron: '0 6,18 * * 0-6'
+
+permissions:
+  contents: read
+  security-events: none
+  pull-requests: none
+  actions: none
+  checks: none
+  deployments: none
+  issues: none
+  packages: none
+  repository-projects: none
+  statuses: none
+
+jobs:
+  terraform_environment_cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+      - uses: unfor19/install-aws-cli-action@35a9630be0168293ad2afccbe06e8e9f47678d2c # pin@v1.0.3
+      - uses: hashicorp/setup-terraform@17d4c9b8043b238f6f35641cdd8433da1e6f3867 # pin@v2
+        with:
+          terraform_version: 1.2.6
+          terraform_wrapper: false
+
+      - name: Configure AWS Credentials For Terraform
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # pin@v1.7.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+          aws-region: eu-west-1
+          role-duration-seconds: 3600
+          role-session-name: OPGLPATerraformGithubAction
+  
+      - uses: webfactory/ssh-agent@fc49353b67b2b7c1e0e6a600572d01a69f2672dd # pin@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Install Terraform Workspace Manager
+        run: |
+          wget https://github.com/TomTucka/terraform-workspace-manager/releases/download/v0.3.0/terraform-workspace-manager_Linux_x86_64.tar.gz -O $HOME/terraform-workspace-manager.tar.gz
+          sudo tar -xvf $HOME/terraform-workspace-manager.tar.gz -C /usr/local/bin
+          sudo chmod +x /usr/local/bin/terraform-workspace-manager
+
+      - name: Terraform Init
+        run: terraform init -input=false
+        working-directory: ./terraform/environment
+
+      - name: Destroy PR Terraform Workspaces
+        working-directory: ./terraform/environment
+        run: |
+          ../../scripts/pipeline/workspace_cleanup/workspace_cleanup.sh $(terraform-workspace-manager -protected-workspaces=true -aws-account-id=050256574573 -aws-iam-role=opg-lpa-ci)


### PR DESCRIPTION
## Purpose

Move Cleanup PR workspace cron job to Github Actions

Fixes LPAL-956

## Approach

Remove Cleanup PR workspace cronjob from circle CI and add equivalent commands to Github Actions

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
