### PR TITLE
LPAL-955 Correct DNS firewall domain names

### DIFF
--- a/terraform/region/terraform.tfvars.json
+++ b/terraform/region/terraform.tfvars.json
@@ -54,7 +54,7 @@
         "enabled": true,
         "domains_allowed": [
           "api.notifications.service.gov.uk.",
-          "d2kjg78kcam6ku.cloudfront.net",
+          "d2kjg78kcam6ku.cloudfront.net.",
           "notify-paas-proxy-359224506.eu-west-1.elb.amazonaws.com.",
           "api.os.uk.",
           "publicapi.payments.service.gov.uk.",
@@ -83,7 +83,7 @@
         "enabled": true,
         "domains_allowed": [
           "api.notifications.service.gov.uk.",
-          "d2kjg78kcam6ku.cloudfront.net",
+          "d2kjg78kcam6ku.cloudfront.net.",
           "notify-paas-proxy-359224506.eu-west-1.elb.amazonaws.com.",
           "api.os.uk.",
           "publicapi.payments.service.gov.uk.",


### PR DESCRIPTION
## Purpose

Correct DNS firewall domain names

Fixes LPAL-955

## Approach

Add terminating dot to end of cloudfront.net DNS name in variables file.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
