### PR TITLE
LPAL-978 Use bash in workspace_cleanup

### DIFF
--- a/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
+++ b/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 if [ $# -eq 0 ]
   then


### PR DESCRIPTION
## Purpose

Fix workspace cleanup cronjob

Fixes LPAL-978

## Approach

The workspace_cleanup.sh uses several bashisms but the shebang calls for sh. This replaces the shebang to use bash instead.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
