### PR TITLE
LPAL-976 Upgrade local docker stack to use postgresql 13.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   postgres:
     container_name: lpa-postgres
-    image: postgres:10.13
+    image: postgres:13.6
     ports:
       - 5432:5432
     environment:

--- a/terraform/environment/modules/environment/rds.tf
+++ b/terraform/environment/modules/environment/rds.tf
@@ -37,7 +37,7 @@ resource "aws_db_instance" "api" {
   kms_key_id                          = local.is_primary_region ? data.aws_kms_key.rds.arn : data.aws_kms_key.multi_region_db_snapshot_key.arn
   username                            = data.aws_secretsmanager_secret_version.api_rds_username.secret_string
   password                            = data.aws_secretsmanager_secret_version.api_rds_password.secret_string
-  parameter_group_name                = aws_db_parameter_group.postgres-db-params.name
+  parameter_group_name                = var.account.use_postgres13 == true ? aws_db_parameter_group.postgres13-db-params.name : aws_db_parameter_group.postgres-db-params.name
   vpc_security_group_ids              = [aws_security_group.rds-api.id]
   auto_minor_version_upgrade          = true
   maintenance_window                  = "wed:05:00-wed:09:00"

--- a/terraform/environment/modules/environment/variables.tf
+++ b/terraform/environment/modules/environment/variables.tf
@@ -17,6 +17,7 @@ variable "lambda_container_version" {
 variable "account" {
   type = object({
     dr_enabled                             = bool
+    use_postgres13                         = bool
     performance_platform_enabled           = bool
     pagerduty_service_name                 = string
     account_id                             = string

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -8,7 +8,7 @@
   "accounts": {
     "development": {
       "dr_enabled" : false,
-      "use_postgres13" : false,
+      "use_postgres13" : true,
       "performance_platform_enabled" : true,
       "deletion_protection" :false,
       "aurora_enabled" :  false,
@@ -23,7 +23,7 @@
       "auth_token_ttl_secs": 4500,
       "backup_retention_period": 1,
       "skip_final_snapshot" : true,
-      "psql_engine_version": "10.18",
+      "psql_engine_version": "13.6",
       "psql_parameter_group_family": "postgres10",
       "psql13_parameter_group_family": "postgres13",
       "log_retention_in_days": 7,

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -8,6 +8,7 @@
   "accounts": {
     "development": {
       "dr_enabled" : false,
+      "use_postgres13" : false,
       "performance_platform_enabled" : true,
       "deletion_protection" :false,
       "aurora_enabled" :  false,
@@ -60,6 +61,7 @@
     },
     "preproduction": {
       "dr_enabled" : false,
+      "use_postgres13" : true,
       "performance_platform_enabled" : false,
       "deletion_protection" :false,
       "aurora_enabled" : false,
@@ -74,7 +76,7 @@
       "auth_token_ttl_secs": 4500,
       "backup_retention_period": 2,
       "skip_final_snapshot" : true,
-      "psql_engine_version": "10.18",
+      "psql_engine_version": "13.6",
       "psql_parameter_group_family": "postgres10",
       "psql13_parameter_group_family": "postgres13",
       "log_retention_in_days": 7,
@@ -112,6 +114,7 @@
     },
     "production": {
       "dr_enabled" : false,
+      "use_postgres13" : false,
       "performance_platform_enabled" : false,
       "deletion_protection" :true,
       "aurora_enabled" : false,

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -23,6 +23,7 @@ variable "accounts" {
   type = map(
     object({
       dr_enabled                             = bool
+      use_postgres13                         = bool
       performance_platform_enabled           = bool
       pagerduty_service_name                 = string
       account_id                             = string


### PR DESCRIPTION
## Purpose

[LPAL-976](https://opgtransform.atlassian.net/browse/LPAL-976)

## Approach

* Upgrade docker-compose.yml to use postgresql v13.6.
* Clean out local volumes relating to postgres and existing postgres images.
* Run `make cypress-local` to run the main user journeys.
* Run `make cypress-open` and run other UI tests manually.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
