### PR TITLE
LPAL-854 Upgrade production to Postgres 13

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -129,7 +129,7 @@
       "auth_token_ttl_secs": 4500,
       "backup_retention_period": 30,
       "skip_final_snapshot" : false,
-      "psql_engine_version": "13.8",
+      "psql_engine_version": "13.6",
       "psql_parameter_group_family": "postgres10",
       "psql13_parameter_group_family": "postgres13",
       "log_retention_in_days": 120,

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -114,7 +114,7 @@
     },
     "production": {
       "dr_enabled" : false,
-      "use_postgres13" : false,
+      "use_postgres13" : true,
       "performance_platform_enabled" : false,
       "deletion_protection" :true,
       "aurora_enabled" : false,
@@ -129,13 +129,13 @@
       "auth_token_ttl_secs": 4500,
       "backup_retention_period": 30,
       "skip_final_snapshot" : false,
-      "psql_engine_version": "10.18",
+      "psql_engine_version": "13.8",
       "psql_parameter_group_family": "postgres10",
       "psql13_parameter_group_family": "postgres13",
       "log_retention_in_days": 120,
       "account_name_short" : "prod",
       "associate_alb_with_waf_web_acl_enabled": true,
-      "rds_instance_type" : "db.m3.medium",
+      "rds_instance_type" : "db.m5.large",
       "autoscaling": {
         "front": {
           "minimum": 3,


### PR DESCRIPTION
## Purpose

Reflect manual changes made to upgrade the production database to use PG 13.6 in Terraform.

Fixes LPAL-854

## Approach

Manual changes to be made before this is merged:

1) Redirect users to maintenance;
2) Ensure there are no connections to the Postgres instance (SELECT * FROM pg_stat_activity; - unsure how reliable RDS stats are);
3) Scale down the API service to zero;
4) Manually set default_transaction_read_only to true in PG13 AND PG10 parameter groups;
5) Take a manual snapshot of the instance;
6) Manually upgrade the instance type from db.m3.medium to db.m5.large;
7) Manually upgrade the Postgres engine from 10.18 to 13.4;
8) Manually upgrade the Postgres engine from 13.4 to 13.6;
9) Run VACUUM FULL ANALYZE;
10) Set default_transactions_read_only to false in PG13 and PG10 parameter groups;
11) Run the below commands to ensure Terraform state is updated:

```bash
git checkout lpal-854-postgres-upgrade-production
tf workspace select production
tf state rm "module.eu-west-1.aws_db_instance.api[0]"
tf import "module.eu-west-1.aws_db_instance.api[0]" api-production
tf state show "module.eu-west-1.aws_db_instance.api[0]"
tf plan
```

12) Scale the API service back up;
13) Remove maintenance redirect;
14) Perform manual smoke test:

- Is https://www.lastingpowerofattorney.service.gov.uk/ accessible?
- Can you sign in?
- Is there a single LPA when signed in?

15) Merge if TF plan shows no unexpected changes;
16) Monitor CloudWatch for 40x errors.

## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [X] The product team have tested these changes
