### PR TITLE
LPAL-971 Remove deprecated aws_subnet_ids data source

### DIFF
--- a/terraform/environment/modules/environment/ecs_admin.tf
+++ b/terraform/environment/modules/environment/ecs_admin.tf
@@ -12,7 +12,7 @@ resource "aws_ecs_service" "admin" {
   wait_for_steady_state = true
   network_configuration {
     security_groups  = [aws_security_group.admin_ecs_service.id]
-    subnets          = data.aws_subnet_ids.private.ids
+    subnets          = data.aws_subnets.private.ids
     assign_public_ip = false
   }
 

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -15,7 +15,7 @@ resource "aws_ecs_service" "api" {
       aws_security_group.api_ecs_service.id,
       aws_security_group.rds-client.id,
     ]
-    subnets          = data.aws_subnet_ids.private.ids
+    subnets          = data.aws_subnets.private.ids
     assign_public_ip = false
   }
 

--- a/terraform/environment/modules/environment/ecs_api_cron.tf
+++ b/terraform/environment/modules/environment/ecs_api_cron.tf
@@ -106,7 +106,7 @@ resource "aws_cloudwatch_event_target" "api_ecs_cron_event_account_cleanup" {
         aws_security_group.api_ecs_service.id,
         aws_security_group.rds-client.id,
       ]
-      subnets          = data.aws_subnet_ids.private.ids
+      subnets          = data.aws_subnets.private.ids
       assign_public_ip = false
     }
   }
@@ -143,7 +143,7 @@ resource "aws_cloudwatch_event_target" "api_ecs_cron_event_generate_stats" {
         aws_security_group.api_ecs_service.id,
         aws_security_group.rds-client.id,
       ]
-      subnets          = data.aws_subnet_ids.private.ids
+      subnets          = data.aws_subnets.private.ids
       assign_public_ip = false
     }
   }

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -12,7 +12,7 @@ resource "aws_ecs_service" "front" {
   wait_for_steady_state = true
   network_configuration {
     security_groups  = [aws_security_group.front_ecs_service.id]
-    subnets          = data.aws_subnet_ids.private.ids
+    subnets          = data.aws_subnets.private.ids
     assign_public_ip = false
   }
 

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -12,7 +12,7 @@ resource "aws_ecs_service" "pdf" {
   wait_for_steady_state = true
   network_configuration {
     security_groups  = [aws_security_group.pdf_ecs_service.id]
-    subnets          = data.aws_subnet_ids.private.ids
+    subnets          = data.aws_subnets.private.ids
     assign_public_ip = false
   }
 

--- a/terraform/environment/modules/environment/load_balancer_admin.tf
+++ b/terraform/environment/modules/environment/load_balancer_admin.tf
@@ -22,7 +22,7 @@ resource "aws_lb" "admin" {
   #tfsec:ignore:aws-elb-alb-not-public - public facing load balancer
   internal                   = false
   load_balancer_type         = "application"
-  subnets                    = data.aws_subnet_ids.public.ids
+  subnets                    = data.aws_subnets.public.ids
   tags                       = local.admin_component_tag
   drop_invalid_header_fields = true
   security_groups = [

--- a/terraform/environment/modules/environment/load_balancer_front.tf
+++ b/terraform/environment/modules/environment/load_balancer_front.tf
@@ -22,7 +22,7 @@ resource "aws_lb" "front" {
   #tfsec:ignore:aws-elb-alb-not-public - public facing load balancer
   internal                   = false
   load_balancer_type         = "application"
-  subnets                    = data.aws_subnet_ids.public.ids
+  subnets                    = data.aws_subnets.public.ids
   tags                       = local.front_component_tag
   drop_invalid_header_fields = true
 

--- a/terraform/environment/modules/environment/vpc_data.sources.tf
+++ b/terraform/environment/modules/environment/vpc_data.sources.tf
@@ -2,21 +2,26 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "private" {
-  vpc_id = data.aws_vpc.default.id
-
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
   tags = {
     Name = "private*"
   }
 }
 
-data "aws_subnet_ids" "public" {
-  vpc_id = data.aws_vpc.default.id
-
+data "aws_subnets" "public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
   tags = {
     Name = "public*"
   }
 }
+
 
 module "allowed_ip_list" {
   source = "github.com/ministryofjustice/terraform-aws-moj-ip-whitelist.git"

--- a/terraform/region/modules/region/subnet.tf
+++ b/terraform/region/modules/region/subnet.tf
@@ -1,9 +1,13 @@
-data "aws_subnet_ids" "private" {
-  vpc_id = aws_default_vpc.default.id
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [aws_default_vpc.default.id]
+  }
 
   tags = {
     Name = "private*"
   }
+
   depends_on = [
     aws_subnet.private
   ]
@@ -38,12 +42,14 @@ resource "aws_subnet" "private" {
 
 resource "aws_db_subnet_group" "data_persistence" {
   name       = "data-persistence-subnet-default"
-  subnet_ids = data.aws_subnet_ids.data_persistence.ids # todo: create new subnet for data layer.
+  subnet_ids = data.aws_subnets.data_persistence.ids # todo: create new subnet for data layer.
 }
 
-data "aws_subnet_ids" "data_persistence" {
-  vpc_id = aws_default_vpc.default.id # todo: create new subnet for data layer.
-
+data "aws_subnets" "data_persistence" {
+  filter {
+    name   = "vpc-id"
+    values = [aws_default_vpc.default.id] # todo: create new subnet for data layer.
+  }
   filter {
     name   = "tag:Name"
     values = ["private"]


### PR DESCRIPTION
## Purpose

Remove deprecated aws_subnet_ids data source to allow Terraform version upgrades in the future

Fixes LPAL-971

## Approach

Replace aws_subnet_ids data sources with aws_subnet data sources

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
