### PR TITLE
LPAL-990 Tighten security group access to admin service

### DIFF
--- a/terraform/environment/modules/environment/load_balancer_admin.tf
+++ b/terraform/environment/modules/environment/load_balancer_admin.tf
@@ -68,18 +68,6 @@ resource "aws_security_group_rule" "admin_loadbalancer_ingress" {
   description       = "MoJ Sites to Admin ELB - HTTPS"
 }
 
-resource "aws_security_group_rule" "admin_loadbalancer_ingress_production" {
-  count     = var.environment_name == "production" ? 1 : 0
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-  #tfsec:ignore:aws-ec2-no-public-ingress-sgr - public facing inbound rule
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.admin_loadbalancer.id
-  description       = "Anywhere to Production Admin ELB - HTTPS"
-}
-
 resource "aws_security_group_rule" "admin_loadbalancer_egress" {
   type      = "egress"
   from_port = 0


### PR DESCRIPTION
## Purpose

Require Admin users to come from an IP address listed in the https://github.com/ministryofjustice/opg-terraform-aws-moj-ip-allow-list repo.

Fixes LPAL-990

## Approach

Removes the allow all rule on the Admin loadbalancer.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes