### PR TITLE
LPAL-951 Add branch name for Path to Live Docker build

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -39,6 +39,7 @@ jobs:
       - image_tag
     with:
       tag: ${{ needs.image_tag.outputs.short_sha }}
+      branch_name: "main"
     secrets: inherit
 
   terraform_account_preproduction:
@@ -134,7 +135,7 @@ jobs:
       - id: slack
         uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
         with:
-          channel-id: "CHANNEL_ID"
+          channel-id: "C01BDM8T67J"
           payload: |
             {
               "text": "Deployment started (In Progress)",


### PR DESCRIPTION
## Purpose

Correct errors present in the path to live Github Actions workflow

Fixes LPAL-951

## Approach

Correct the Channel ID used to post the Deployment message for Live and add a missing branch_name in the Docker build job.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
