### PR TITLE
LPA-951 Checkout before running git command

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -26,6 +26,8 @@ jobs:
     outputs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       - name: Set output to short SHA
         id: short_sha
         run: |


### PR DESCRIPTION
## Purpose

Run a checkout before a git command in Github Actions workflow

Fixes LPAL-951

## Approach

Add checkout step to Generate image tags in path_to_live

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
