### PR TITLE
LPAL-1009 Run Cypress tests in parallel

### DIFF
--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -19,11 +19,10 @@ on:
         description: "URL of the frontend"
         required: true
         type: string
-      ephemeral_environment:
-        description: "True if tests are run against ephemeral environment"
-        required: false
-        default: true
-        type: boolean
+      cypress_tags: 
+        description: "Cypress tags to run"
+        required: true
+        type: string
     secrets:
       AWS_ACCESS_KEY_ID_ACTIONS:
         required: true
@@ -87,131 +86,14 @@ jobs:
           docker pull $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$IMAGE_NAME:$IMAGE_TAG
           docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$IMAGE_NAME:$IMAGE_TAG $IMAGE_NAME:$IMAGE_TAG
 
-      - name: Run Cypress Tests - @Signup,@StitchedPF
+      - name: Run Cypress Tests - ${{ inputs.cypress_tags }}
         env:
           CYPRESS_adminUrl: ${{ inputs.admin_url }}
           CYPRESS_baseUrl: ${{ inputs.front_url }}
           CYPRESS_NO_COMMAND_LOG: 1
           CYPRESS_numTestsKeptInMemory: 1
           CYPRESS_RUNNER_IN_CI: true
-          CYPRESS_RUNNER_TAGS: "@Signup,@StitchedPF"
-          CYPRESS_RUNNER_BASE_URL: ${{ inputs.front_url }}
-          CYPRESS_RUNNER_ADMIN_URL: ${{ inputs.admin_url }}
-
-        run: |
-          docker run --pull never \
-                  -e AWS_ACCESS_KEY_ID \
-                  -e AWS_SECRET_ACCESS_KEY \
-                  -e AWS_SESSION_TOKEN \
-                  -e CYPRESS_NO_COMMAND_LOG \
-                  -e CYPRESS_numTestsKeptInMemory \
-                  -e CYPRESS_RUNNER_IN_CI \
-                  -e CYPRESS_RUNNER_TAGS \
-                  -e CYPRESS_RUNNER_BASE_URL \
-                  -e CYPRESS_RUNNER_ADMIN_URL \
-                  -e CYPRESS_baseUrl \
-                  -e CYPRESS_adminUrl \
-                  --mount type=bind,source="/tmp/screenshots",target="/app/cypress/screenshots" \
-                  --entrypoint ./cypress/cypress_start.sh \
-                  cypress:latest
-
-      - name: Run Cypress Tests - @Signup,@StitchedHW
-        env:
-          CYPRESS_adminUrl: ${{ inputs.admin_url }}
-          CYPRESS_baseUrl: ${{ inputs.front_url }}
-          CYPRESS_NO_COMMAND_LOG: 1
-          CYPRESS_numTestsKeptInMemory: 1
-          CYPRESS_RUNNER_IN_CI: true
-          CYPRESS_RUNNER_TAGS: "@Signup,@StitchedHW"
-          CYPRESS_RUNNER_BASE_URL: ${{ inputs.front_url }}
-          CYPRESS_RUNNER_ADMIN_URL: ${{ inputs.admin_url }}
-
-        run: |
-          docker run --pull never \
-                  -e AWS_ACCESS_KEY_ID \
-                  -e AWS_SECRET_ACCESS_KEY \
-                  -e AWS_SESSION_TOKEN \
-                  -e CYPRESS_NO_COMMAND_LOG \
-                  -e CYPRESS_numTestsKeptInMemory \
-                  -e CYPRESS_RUNNER_IN_CI \
-                  -e CYPRESS_RUNNER_TAGS \
-                  -e CYPRESS_RUNNER_BASE_URL \
-                  -e CYPRESS_RUNNER_ADMIN_URL \
-                  -e CYPRESS_baseUrl \
-                  -e CYPRESS_adminUrl \
-                  --mount type=bind,source="/tmp/screenshots",target="/app/cypress/screenshots" \
-                  --entrypoint ./cypress/cypress_start.sh \
-                  cypress:latest
-
-      - name: Run Cypress Tests - @Signup,@StitchedClone
-        if: ${{ inputs.ephemeral_environment == true }}
-        env:
-          CYPRESS_adminUrl: ${{ inputs.admin_url }}
-          CYPRESS_baseUrl: ${{ inputs.front_url }}
-          CYPRESS_NO_COMMAND_LOG: 1
-          CYPRESS_numTestsKeptInMemory: 1
-          CYPRESS_RUNNER_IN_CI: true
-          CYPRESS_RUNNER_TAGS: "@Signup,@StitchedClone"
-          CYPRESS_RUNNER_BASE_URL: ${{ inputs.front_url }}
-          CYPRESS_RUNNER_ADMIN_URL: ${{ inputs.admin_url }}
-
-        run: |
-          docker run --pull never \
-                  -e AWS_ACCESS_KEY_ID \
-                  -e AWS_SECRET_ACCESS_KEY \
-                  -e AWS_SESSION_TOKEN \
-                  -e CYPRESS_NO_COMMAND_LOG \
-                  -e CYPRESS_numTestsKeptInMemory \
-                  -e CYPRESS_RUNNER_IN_CI \
-                  -e CYPRESS_RUNNER_TAGS \
-                  -e CYPRESS_RUNNER_BASE_URL \
-                  -e CYPRESS_RUNNER_ADMIN_URL \
-                  -e CYPRESS_baseUrl \
-                  -e CYPRESS_adminUrl \
-                  --mount type=bind,source="/tmp/screenshots",target="/app/cypress/screenshots" \
-                  --entrypoint ./cypress/cypress_start.sh \
-                  cypress:latest
-
-      # Remaining tests should ultimately just exclude SignUp and anything already done as part of stitched run.
-      # TODO CorrespondentReuse needs refactoring so that it can be included as part of the stitchedClone run.
-      - name: Run Cypress Tests - Remaining Tests
-        env:
-          CYPRESS_adminUrl: ${{ inputs.admin_url }}
-          CYPRESS_baseUrl: ${{ inputs.front_url }}
-          CYPRESS_NO_COMMAND_LOG: 1
-          CYPRESS_numTestsKeptInMemory: 1
-          CYPRESS_RUNNER_IN_CI: true
-          CYPRESS_RUNNER_TAGS: "@Signup,not @Signup and not @PartOfStitchedRun and not
-            @StitchedHW and not @StitchedPF and not @StitchedClone and not
-            @CorrespondentReuse and not @SignupIncluded"
-          CYPRESS_RUNNER_BASE_URL: ${{ inputs.front_url }}
-          CYPRESS_RUNNER_ADMIN_URL: ${{ inputs.admin_url }}
-
-        run: |
-          docker run --pull never \
-                  -e AWS_ACCESS_KEY_ID \
-                  -e AWS_SECRET_ACCESS_KEY \
-                  -e AWS_SESSION_TOKEN \
-                  -e CYPRESS_NO_COMMAND_LOG \
-                  -e CYPRESS_numTestsKeptInMemory \
-                  -e CYPRESS_RUNNER_IN_CI \
-                  -e CYPRESS_RUNNER_TAGS \
-                  -e CYPRESS_RUNNER_BASE_URL \
-                  -e CYPRESS_RUNNER_ADMIN_URL \
-                  -e CYPRESS_baseUrl \
-                  -e CYPRESS_adminUrl \
-                  --mount type=bind,source="/tmp/screenshots",target="/app/cypress/screenshots" \
-                  --entrypoint ./cypress/cypress_start.sh \
-                  cypress:latest
-
-      - name: Run Cypress Tests - @SignupIncluded
-        env:
-          CYPRESS_adminUrl: ${{ inputs.admin_url }}
-          CYPRESS_baseUrl: ${{ inputs.front_url }}
-          CYPRESS_NO_COMMAND_LOG: 1
-          CYPRESS_numTestsKeptInMemory: 1
-          CYPRESS_RUNNER_IN_CI: true
-          CYPRESS_RUNNER_TAGS: "@SignupIncluded"
+          CYPRESS_RUNNER_TAGS: ${{ inputs.cypress_tags }}
           CYPRESS_RUNNER_BASE_URL: ${{ inputs.front_url }}
           CYPRESS_RUNNER_ADMIN_URL: ${{ inputs.admin_url }}
 

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -26,13 +26,9 @@ jobs:
     outputs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
       - name: Set output to short SHA
         id: short_sha
-        run: |
-          FULL_SHA=$(git rev-parse ${{ github.ref }}^2)
-          echo "::set-output name=short_sha::${FULL_SHA::7}"
+        run: echo "::set-output name=short_sha::${GITHUB_SHA::7}"
 
   docker_build_scan_push:
     name: Docker Build, Scan and Push
@@ -53,7 +49,12 @@ jobs:
       is_ephemeral: false
       terraform_apply: false
       terraform_directory: ./terraform/account
-    secrets: inherit
+    secrets:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
+      AWS_ACCESS_KEY_ID_ACTIONS: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      AWS_SECRET_ACCESS_KEY_ACTIONS: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   terraform_region_preproduction:
     name: TF Preproduction - Region
@@ -64,7 +65,12 @@ jobs:
       is_ephemeral: false
       terraform_apply: false
       terraform_directory: ./terraform/region
-    secrets: inherit
+    secrets:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
+      AWS_ACCESS_KEY_ID_ACTIONS: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      AWS_SECRET_ACCESS_KEY_ACTIONS: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   terraform_email_preproduction:
     name: TF Preproduction - Email
@@ -75,7 +81,12 @@ jobs:
       is_ephemeral: false
       terraform_apply: true
       terraform_directory: ./terraform/email
-    secrets: inherit
+    secrets:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
+      AWS_ACCESS_KEY_ID_ACTIONS: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      AWS_SECRET_ACCESS_KEY_ACTIONS: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   terraform_environment_preproduction:
     name: TF Preproduction - Environment
@@ -88,7 +99,12 @@ jobs:
       terraform_directory: ./terraform/environment
     needs:
       - docker_build_scan_push
-    secrets: inherit
+    secrets:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
+      AWS_ACCESS_KEY_ID_ACTIONS: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      AWS_SECRET_ACCESS_KEY_ACTIONS: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   run_preprodution_feedback_db_task:
     name: Run preproduction feedbackdb
@@ -97,9 +113,11 @@ jobs:
       - terraform_environment_preproduction
     secrets: inherit
 
-  terraform_outputs:
+  preprod_terraform_outputs:
     name: Render terraform outputs
     runs-on: ubuntu-latest
+    outputs:
+      terraform_output_as_json: ${{ steps.terraform_outputs.outputs.terraform_output_as_json }}
     needs:
       - run_preprodution_feedback_db_task
       - terraform_environment_preproduction
@@ -116,16 +134,66 @@ jobs:
         JSON="${JSON//$'\s+'/''}"
         echo "::set-output name=terraform_output_as_json::$JSON"
 
-  # cypress_tests:
+  # cypress_tests_Signup_StichedPF:
   #   name: Run Cypress tests
   #   uses: ./.github/workflows/cypress_tests.yml
-  #   needs: 
-  #     - terraform_outputs
+  #   needs:
+  #     - preprod_terraform_outputs
   #   with:
-  #     admin_url: https://${{ fromJson(steps.terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
-  #     front_url: https://${{ fromJson(steps.terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+  #     admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+  #     front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
   #     account_id: "987830934591"
-  #     ephemeral_environment: false
+  #     cypress_tags: "@Signup,@StitchedPF"
+  #   secrets: inherit
+
+  # cypress_tests_Signup_StichedHW:
+  #   name: Run Cypress tests
+  #   uses: ./.github/workflows/cypress_tests.yml
+  #   needs:
+  #     - preprod_terraform_outputs
+  #   with:
+  #     admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+  #     front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+  #     account_id: "987830934591"
+  #     cypress_tags: "@Signup,@StitchedHW"
+  #   secrets: inherit
+
+  # cypress_tests_Signup_StichedClone:
+  #   name: Run Cypress tests
+  #   uses: ./.github/workflows/cypress_tests.yml
+  #   needs:
+  #     - preprod_terraform_outputs
+  #   with:
+  #     admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+  #     front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+  #     account_id: "987830934591"
+  #     cypress_tags: "@Signup,@StitchedClone"
+  #   secrets: inherit
+
+  # cypress_tests_SignupIncluded:
+  #   name: Run Cypress tests
+  #   uses: ./.github/workflows/cypress_tests.yml
+  #   needs:
+  #     - preprod_terraform_outputs
+  #   with:
+  #     admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+  #     front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+  #     account_id: "987830934591"
+  #     cypress_tags: "@SignupIncluded"
+  #   secrets: inherit
+
+  # # Remaining tests should ultimately just exclude SignUp and anything already done as part of stitched run.
+  # # TODO CorrespondentReuse needs refactoring so that it can be included as part of the stitchedClone run.
+  # cypress_tests_Remaining:
+  #   name: Run Cypress tests
+  #   uses: ./.github/workflows/cypress_tests.yml
+  #   needs:
+  #     - preprod_terraform_outputs
+  #   with:
+  #     admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+  #     front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+  #     account_id: "987830934591"
+  #     cypress_tags: "@Signup,not @Signup and not @PartOfStitchedRun and not @StitchedHW and not @StitchedPF and not @StitchedClone and not @CorrespondentReuse and not @SignupIncluded"
   #   secrets: inherit
 
   slack_msg_production_deploy_begin:
@@ -178,7 +246,12 @@ jobs:
       is_ephemeral: false
       terraform_apply: false
       terraform_directory: ./terraform/region
-    secrets: inherit
+    secrets:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
+      AWS_ACCESS_KEY_ID_ACTIONS: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      AWS_SECRET_ACCESS_KEY_ACTIONS: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
   
   terraform_email_production:
     name: TF Production - Email
@@ -189,7 +262,12 @@ jobs:
       is_ephemeral: false
       terraform_apply: false
       terraform_directory: ./terraform/email
-    secrets: inherit
+    secrets:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
+      AWS_ACCESS_KEY_ID_ACTIONS: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      AWS_SECRET_ACCESS_KEY_ACTIONS: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   terraform_environment_production:
     name: TF Production - Environment
@@ -203,7 +281,12 @@ jobs:
       persist_artifacts: true
     needs:
     - docker_build_scan_push
-    secrets: inherit
+    secrets:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
+      AWS_ACCESS_KEY_ID_ACTIONS: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      AWS_SECRET_ACCESS_KEY_ACTIONS: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   run_production_feedback_db_task:
     name: Run production feedbackdb

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -209,7 +209,7 @@ jobs:
       - seed_dev_environment
       - terraform_environment_development
       - run_dev_feedback_db_task
-    outputs: 
+    outputs:
       terraform_output_as_json: ${{ steps.terraform_outputs.outputs.terraform_output_as_json }}
     steps:
       - name: Checkout
@@ -224,7 +224,7 @@ jobs:
           JSON="${JSON//$'\s+'/''}"
           echo "::set-output name=terraform_output_as_json::$JSON"
 
-  cypress_tests:
+  cypress_tests_Signup_StichedPF:
     name: Run Cypress tests
     uses: ./.github/workflows/cypress_tests.yml
     needs:
@@ -233,13 +233,64 @@ jobs:
       admin_url: https://${{ fromJson(needs.terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
       front_url: https://${{ fromJson(needs.terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
       account_id: "050256574573"
+      cypress_tags: "@Signup,@StitchedPF"
+    secrets: inherit
+
+  cypress_tests_Signup_StichedHW:
+    name: Run Cypress tests
+    uses: ./.github/workflows/cypress_tests.yml
+    needs:
+      - terraform_outputs
+    with:
+      admin_url: https://${{ fromJson(needs.terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+      front_url: https://${{ fromJson(needs.terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+      account_id: "050256574573"
+      cypress_tags: "@Signup,@StitchedHW"
+    secrets: inherit
+
+  cypress_tests_Signup_StichedClone:
+    name: Run Cypress tests
+    uses: ./.github/workflows/cypress_tests.yml
+    needs:
+      - terraform_outputs
+    with:
+      admin_url: https://${{ fromJson(needs.terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+      front_url: https://${{ fromJson(needs.terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+      account_id: "050256574573"
+      cypress_tags: "@Signup,@StitchedClone"
+    secrets: inherit
+
+  cypress_tests_SignupIncluded:
+    name: Run Cypress tests
+    uses: ./.github/workflows/cypress_tests.yml
+    needs:
+      - terraform_outputs
+    with:
+      admin_url: https://${{ fromJson(needs.terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+      front_url: https://${{ fromJson(needs.terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+      account_id: "050256574573"
+      cypress_tags: "@SignupIncluded"
+    secrets: inherit
+
+  # Remaining tests should ultimately just exclude SignUp and anything already done as part of stitched run.
+  # TODO CorrespondentReuse needs refactoring so that it can be included as part of the stitchedClone run.
+  cypress_tests_Remaining:
+    name: Run Cypress tests
+    uses: ./.github/workflows/cypress_tests.yml
+    needs:
+      - terraform_outputs
+    with:
+      admin_url: https://${{ fromJson(needs.terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+      front_url: https://${{ fromJson(needs.terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+      account_id: "050256574573"
+      cypress_tags: "@Signup,not @Signup and not @PartOfStitchedRun and not @StitchedHW and not @StitchedPF and not @StitchedClone and not @CorrespondentReuse and not @SignupIncluded"
     secrets: inherit
 
   end_of_pr_workflow:
     name: End of PR Workflow
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - cypress_tests
       - workspace_name
       - terraform_outputs


### PR DESCRIPTION
## Purpose

Run the Cypress tests in parallel on Github Actions

Fixes LPAL-1009

## Approach

Each Cypress test will be a separate job instead of being a multiple steps of the same job.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
