### PR TITLE
LPAL-951 Use private key for (pre)prod environment TF

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -19,6 +19,18 @@ on:
       - "scripts/**"
       - ".github/workflows/**"
 
+permissions:
+  contents: write
+  security-events: write
+  pull-requests: read
+  actions: none
+  checks: none
+  deployments: none
+  issues: none
+  packages: none
+  repository-projects: none
+  statuses: none
+
 jobs:
   image_tag:
     name: Generate image tags
@@ -72,22 +84,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY_ACTIONS: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
-  terraform_email_preproduction:
-    name: TF Preproduction - Email
-    uses: ministryofjustice/opg-github-workflows/.github/workflows/build-infrastructure-terraform.yml@2d85e0b1b1b84ca98b6ec27d251d8e6319c95df9 # pin@v1.8.0
-    with:
-      terraform_version: 1.1.2
-      terraform_workspace: preproduction
-      is_ephemeral: false
-      terraform_apply: false
-      terraform_directory: ./terraform/email
-    secrets:
-      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
-      AWS_ACCESS_KEY_ID_ACTIONS: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
-      AWS_SECRET_ACCESS_KEY_ACTIONS: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-
   terraform_environment_preproduction:
     name: TF Preproduction - Environment
     uses: ministryofjustice/opg-github-workflows/.github/workflows/build-infrastructure-terraform.yml@2d85e0b1b1b84ca98b6ec27d251d8e6319c95df9 # pin@v1.8.0
@@ -96,6 +92,7 @@ jobs:
       terraform_workspace: preproduction
       is_ephemeral: false
       terraform_apply: false
+      use_ssh_private_key: true
       terraform_directory: ./terraform/environment
     needs:
       - docker_build_scan_push
@@ -231,7 +228,12 @@ jobs:
       is_ephemeral: false
       terraform_apply: false
       terraform_directory: ./terraform/account
-    secrets: inherit
+    secrets:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
+      AWS_ACCESS_KEY_ID_ACTIONS: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      AWS_SECRET_ACCESS_KEY_ACTIONS: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   terraform_region_production:
     name: TF Production - Region
@@ -251,24 +253,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY_ACTIONS: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
   
-  terraform_email_production:
-    name: TF Production - Email
-    uses: ministryofjustice/opg-github-workflows/.github/workflows/build-infrastructure-terraform.yml@2d85e0b1b1b84ca98b6ec27d251d8e6319c95df9 # pin@v1.8.0
-    needs:
-      - slack_msg_production_deploy_begin
-    with:
-      terraform_version: 1.1.2
-      terraform_workspace: production
-      is_ephemeral: false
-      terraform_apply: false
-      terraform_directory: ./terraform/email
-    secrets:
-      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
-      AWS_ACCESS_KEY_ID_ACTIONS: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
-      AWS_SECRET_ACCESS_KEY_ACTIONS: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-
   terraform_environment_production:
     name: TF Production - Environment
     uses: ministryofjustice/opg-github-workflows/.github/workflows/build-infrastructure-terraform.yml@2d85e0b1b1b84ca98b6ec27d251d8e6319c95df9 # pin@v1.8.0
@@ -278,6 +262,7 @@ jobs:
       is_ephemeral: false
       terraform_apply: false
       terraform_directory: ./terraform/environment
+      use_ssh_private_key: true
       persist_artifacts: true
     needs:
       - docker_build_scan_push


### PR DESCRIPTION
## Purpose

Allow preprod and prod Terraform jobs to download from MOJ repos

Fixes LPAL-951

## Approach

Enable `use_private_ssh_key` in the Github Actions job for `terraform_environment_production` and `terraform_environment_preproduction`

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
