### PR TITLE
LPAL-951 Apply Prod Terraform in Github Actions

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -59,7 +59,7 @@ jobs:
       terraform_version: 1.1.2
       terraform_workspace: preproduction
       is_ephemeral: false
-      terraform_apply: false
+      terraform_apply: true
       terraform_directory: ./terraform/account
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +75,7 @@ jobs:
       terraform_version: 1.1.2
       terraform_workspace: preproduction
       is_ephemeral: false
-      terraform_apply: false
+      terraform_apply: true
       terraform_directory: ./terraform/region
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,9 +91,11 @@ jobs:
       terraform_version: 1.1.2
       terraform_workspace: preproduction
       is_ephemeral: false
-      terraform_apply: false
+      terraform_apply: true
       use_ssh_private_key: true
       terraform_directory: ./terraform/environment
+      terraform_variables: "-var container_version=${{ needs.image_tag.outputs.short_sha }}"
+      persist_artifacts: true
     needs:
       - docker_build_scan_push
     secrets:
@@ -131,67 +133,66 @@ jobs:
         JSON="${JSON//$'\s+'/''}"
         echo "::set-output name=terraform_output_as_json::$JSON"
 
-  # cypress_tests_Signup_StichedPF:
-  #   name: Run Cypress tests
-  #   uses: ./.github/workflows/cypress_tests.yml
-  #   needs:
-  #     - preprod_terraform_outputs
-  #   with:
-  #     admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
-  #     front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
-  #     account_id: "987830934591"
-  #     cypress_tags: "@Signup,@StitchedPF"
-  #   secrets: inherit
+  cypress_tests_Signup_StichedPF:
+    name: Run Cypress tests
+    uses: ./.github/workflows/cypress_tests.yml
+    needs:
+      - preprod_terraform_outputs
+    with:
+      admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+      front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+      account_id: "987830934591"
+      cypress_tags: "@Signup,@StitchedPF"
+    secrets: inherit
 
-  # cypress_tests_Signup_StichedHW:
-  #   name: Run Cypress tests
-  #   uses: ./.github/workflows/cypress_tests.yml
-  #   needs:
-  #     - preprod_terraform_outputs
-  #   with:
-  #     admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
-  #     front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
-  #     account_id: "987830934591"
-  #     cypress_tags: "@Signup,@StitchedHW"
-  #   secrets: inherit
+  cypress_tests_Signup_StichedHW:
+    name: Run Cypress tests
+    uses: ./.github/workflows/cypress_tests.yml
+    needs:
+      - preprod_terraform_outputs
+    with:
+      admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+      front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+      account_id: "987830934591"
+      cypress_tags: "@Signup,@StitchedHW"
+    secrets: inherit
 
+  cypress_tests_SignupIncluded:
+    name: Run Cypress tests
+    uses: ./.github/workflows/cypress_tests.yml
+    needs:
+      - preprod_terraform_outputs
+    with:
+      admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+      front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+      account_id: "987830934591"
+      cypress_tags: "@SignupIncluded"
+    secrets: inherit
 
-  # cypress_tests_SignupIncluded:
-  #   name: Run Cypress tests
-  #   uses: ./.github/workflows/cypress_tests.yml
-  #   needs:
-  #     - preprod_terraform_outputs
-  #   with:
-  #     admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
-  #     front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
-  #     account_id: "987830934591"
-  #     cypress_tags: "@SignupIncluded"
-  #   secrets: inherit
-
-  # # Remaining tests should ultimately just exclude SignUp and anything already done as part of stitched run.
-  # # TODO CorrespondentReuse needs refactoring so that it can be included as part of the stitchedClone run.
-  # cypress_tests_Remaining:
-  #   name: Run Cypress tests
-  #   uses: ./.github/workflows/cypress_tests.yml
-  #   needs:
-  #     - preprod_terraform_outputs
-  #   with:
-  #     admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
-  #     front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
-  #     account_id: "987830934591"
-  #     cypress_tags: "@Signup,not @Signup and not @PartOfStitchedRun and not @StitchedHW and not @StitchedPF and not @StitchedClone and not @CorrespondentReuse and not @SignupIncluded"
-  #   secrets: inherit
+  # Remaining tests should ultimately just exclude SignUp and anything already done as part of stitched run.
+  # TODO CorrespondentReuse needs refactoring so that it can be included as part of the stitchedClone run.
+  cypress_tests_Remaining:
+    name: Run Cypress tests
+    uses: ./.github/workflows/cypress_tests.yml
+    needs:
+      - preprod_terraform_outputs
+    with:
+      admin_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).admin-fqdn.value }}
+      front_url: https://${{ fromJson(needs.preprod_terraform_outputs.outputs.terraform_output_as_json).front-fqdn.value }}
+      account_id: "987830934591"
+      cypress_tags: "@Signup,not @Signup and not @PartOfStitchedRun and not @StitchedHW and not @StitchedPF and not @StitchedClone and not @CorrespondentReuse and not @SignupIncluded"
+    secrets: inherit
 
   slack_msg_production_deploy_begin:
     name: Annouce Production Deployment
     runs-on: ubuntu-latest
     outputs:
       ts: ${{ steps.slack.outputs.ts }}
-    # needs:
-    #   - cypress_tests_Signup_StichedPF
-    #   - cypress_tests_Signup_StichedHW
-    #   - cypress_tests_SignupIncluded
-    #   - cypress_tests_Remaining
+    needs:
+      - cypress_tests_Signup_StichedPF
+      - cypress_tests_Signup_StichedHW
+      - cypress_tests_SignupIncluded
+      - cypress_tests_Remaining
     steps:
       - id: slack
         uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
@@ -226,7 +227,7 @@ jobs:
       terraform_version: 1.1.2
       terraform_workspace: production
       is_ephemeral: false
-      terraform_apply: false
+      terraform_apply: true
       terraform_directory: ./terraform/account
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -244,7 +245,7 @@ jobs:
       terraform_version: 1.1.2
       terraform_workspace: production
       is_ephemeral: false
-      terraform_apply: false
+      terraform_apply: true
       terraform_directory: ./terraform/region
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -260,10 +261,11 @@ jobs:
       terraform_version: 1.1.2
       terraform_workspace: production
       is_ephemeral: false
-      terraform_apply: false
+      terraform_apply: true
       terraform_directory: ./terraform/environment
       use_ssh_private_key: true
       persist_artifacts: true
+      terraform_variables: "-var container_version=${{ needs.image_tag.outputs.short_sha }}"
     needs:
       - docker_build_scan_push
       - slack_msg_production_deploy_begin
@@ -281,39 +283,39 @@ jobs:
       - terraform_environment_production
     secrets: inherit
 
-  # run_smoke_tests:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - terraform_environment_production
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+  run_smoke_tests:
+    runs-on: ubuntu-latest
+    needs:
+      - terraform_environment_production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
 
-  #     - name: Download Terraform Task definition
-  #       uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3
-  #       with:
-  #         name: terraform-artifact
-  #         path: /tmp/
+      - name: Download Terraform Task definition
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3
+        with:
+          name: terraform-artifact
+          path: /tmp/
 
-  #     - name: Setup Python
-  #       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # pin@v4
-  #       with:
-  #         python-version: '3.9'
+      - name: Setup Python
+        uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # pin@v4
+        with:
+          python-version: '3.9'
 
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install -r scripts/pipeline/requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/pipeline/requirements.txt
 
-  #     - name: Run test
-  #       run: python scripts/pipeline/healthcheck_test/healthcheck_test.py
+      - name: Run test
+        run: python scripts/pipeline/healthcheck_test/healthcheck_test.py
 
   slack_msg_production_deploy_complete:
     name: Post-Deployment Slack message
     runs-on: ubuntu-latest
     needs: 
       - slack_msg_production_deploy_begin
-      # - run_smoke_tests
+      - run_smoke_tests
     steps:
     - uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
       if: success()

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -98,6 +98,7 @@ jobs:
       persist_artifacts: true
     needs:
       - docker_build_scan_push
+      - image_tag
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
@@ -269,6 +270,7 @@ jobs:
     needs:
       - docker_build_scan_push
       - slack_msg_production_deploy_begin
+      - image_tag
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}


### PR DESCRIPTION
## Purpose

Run Terraform apply in preprod and prod in Github Actions pipeline

Fixes LPAL-951

## Approach

Change `terraform_apply` to true for preprod and prod. Uncomment the relevant `needs`  that relied on these these applies.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
