### PR TITLE
LPAL-951 Correct Cypress test IAM role

### DIFF
--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -42,9 +42,8 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
           aws-region: eu-west-1
-          role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/opg-lpa-ci
           role-duration-seconds: 3600
-          role-session-name: OPGLPABuildPipeline
+          role-session-name: OPGLPACypressTests
 
       - name: Setup Python
         uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # pin@v4
@@ -69,6 +68,16 @@ jobs:
       - name: Create screenshots directory
         run: |
           mkdir -p /tmp/screenshots
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # pin@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+          aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/opg-lpa-ci
+          role-duration-seconds: 3600
+          role-session-name: OPGLPACypressTests
 
       - name: ECR Login
         id: login_ecr


### PR DESCRIPTION
## Purpose

Correct Cypress test IAM role 

Fixes LPAL-951

## Approach

Assume the CI role from the management account instead of trying to assume it from an assumed role

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
