### PR TITLE
LPAL-1015: Allow PR workflow to be skipped

### DIFF
--- a/.github/workflows/workflow_pr_no_changes.yml
+++ b/.github/workflows/workflow_pr_no_changes.yml
@@ -1,0 +1,42 @@
+name: "[Workflow] PR - No changes"
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "service-*/**"
+      - "cypress/**"
+      - "terraform/**"
+      - "scripts/**"
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+  security-events: none
+  pull-requests: read
+  actions: none
+  checks: none
+  deployments: none
+  issues: none
+  packages: none
+  repository-projects: none
+  statuses: none
+
+jobs:
+  end_of_pr_workflow:
+    name: End of PR Workflow
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: End of PR Workflow
+        run: |
+          echo "No further action required"


### PR DESCRIPTION
## Purpose

Allow the PR workflow to be skipped if it doesn't affect any of the filtered files in the normal PR workflow

Fixes LPAL-1015

## Approach

Add a second workflow that has the inverse path filter of the normal PR workflow which has a generic 'End of PR Workflow' which will always pass.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
