### PR TITLE
LPAL-1034 Fix cypress test names

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -136,7 +136,7 @@ jobs:
         echo "::set-output name=terraform_output_as_json::$JSON"
 
   cypress_tests_Signup_StichedPF:
-    name: Run Cypress tests
+    name: Run Cypress tests - @Signup,@StitchedPF
     uses: ./.github/workflows/cypress_tests.yml
     needs:
       - preprod_terraform_outputs
@@ -148,7 +148,7 @@ jobs:
     secrets: inherit
 
   cypress_tests_Signup_StichedHW:
-    name: Run Cypress tests
+    name: Run Cypress tests - @Signup,@StitchedHW
     uses: ./.github/workflows/cypress_tests.yml
     needs:
       - preprod_terraform_outputs
@@ -160,7 +160,7 @@ jobs:
     secrets: inherit
 
   cypress_tests_SignupIncluded:
-    name: Run Cypress tests
+    name: Run Cypress tests - @SignupIncluded
     uses: ./.github/workflows/cypress_tests.yml
     needs:
       - preprod_terraform_outputs
@@ -174,7 +174,7 @@ jobs:
   # Remaining tests should ultimately just exclude SignUp and anything already done as part of stitched run.
   # TODO CorrespondentReuse needs refactoring so that it can be included as part of the stitchedClone run.
   cypress_tests_Remaining:
-    name: Run Cypress tests
+    name: Run Cypress tests - Remaining
     uses: ./.github/workflows/cypress_tests.yml
     needs:
       - preprod_terraform_outputs

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
 
-      - name: Terraform Outputs from JSON
+      - name: Terraform Outputs from JSON 
         id: terraform_outputs
         run: |
           JSON=${{ needs.terraform_environment_development.outputs.terraform_output_as_json }}
@@ -227,7 +227,7 @@ jobs:
           echo "::set-output name=terraform_output_as_json::$JSON"
 
   cypress_tests_Signup_StichedPF:
-    name: Run Cypress tests
+    name: Run Cypress tests - @Signup,@StitchedPF
     uses: ./.github/workflows/cypress_tests.yml
     needs:
       - terraform_outputs
@@ -239,7 +239,7 @@ jobs:
     secrets: inherit
 
   cypress_tests_Signup_StichedHW:
-    name: Run Cypress tests
+    name: Run Cypress tests - @Signup,@StitchedHW
     uses: ./.github/workflows/cypress_tests.yml
     needs:
       - terraform_outputs
@@ -251,7 +251,7 @@ jobs:
     secrets: inherit
 
   cypress_tests_Signup_StichedClone:
-    name: Run Cypress tests
+    name: Run Cypress tests - @Signup,@StitchedClone
     uses: ./.github/workflows/cypress_tests.yml
     needs:
       - terraform_outputs
@@ -263,7 +263,7 @@ jobs:
     secrets: inherit
 
   cypress_tests_SignupIncluded:
-    name: Run Cypress tests
+    name: Run Cypress tests - @SignupIncluded
     uses: ./.github/workflows/cypress_tests.yml
     needs:
       - terraform_outputs
@@ -277,7 +277,7 @@ jobs:
   # Remaining tests should ultimately just exclude SignUp and anything already done as part of stitched run.
   # TODO CorrespondentReuse needs refactoring so that it can be included as part of the stitchedClone run.
   cypress_tests_Remaining:
-    name: Run Cypress tests
+    name: Run Cypress tests - Remaining
     uses: ./.github/workflows/cypress_tests.yml
     needs:
       - terraform_outputs


### PR DESCRIPTION
## Purpose

Fix the Cypress test names so that they are easier to read in the workflow overview

Fixes LPAL-1034

## Approach

The Cypress test names are now included in the job names

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
