### PR TITLE
LPAL-99 take out no-use-before-declare rule

### DIFF
--- a/service-front/assets/.eslintrc.json
+++ b/service-front/assets/.eslintrc.json
@@ -16,7 +16,6 @@
   "rules": {
     "no-undef": "off",
     "no-unused-vars": "off",
-    "no-use-before-define": "off",
     "prettier/prettier": "off"
   }
 }


### PR DESCRIPTION
## Purpose

_fixing remaining eslint issues- in this case already fixed_

## Approach

_Remove rule from eslint config. Story was originally to fix the issues, but fixes to other issues have fixed this for free _

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
