### PR TITLE
LPAL-1021 fix no-unused-vars for cypress code

### DIFF
--- a/cypress/e2e/common/.eslintrc.json
+++ b/cypress/e2e/common/.eslintrc.json
@@ -13,7 +13,6 @@
 
   "rules": {
     "no-undef": "off",
-    "no-unused-vars": "off",
     "prettier/prettier": "off"
   }
 }

--- a/cypress/e2e/common/attorney.js
+++ b/cypress/e2e/common/attorney.js
@@ -1,14 +1,14 @@
 import { Then } from "@badeball/cypress-cucumber-preprocessor";
 
-Then(`I can find save pointing to primary attorney decisions page`, (linkAddr) => {
+Then(`I can find save pointing to primary attorney decisions page`, () => {
     canFindButtonLinkedTo('how-primary-attorneys-make-decision');
 })
 
-Then(`I can find save pointing to replacement attorney page`, (linkAddr) => {
+Then(`I can find save pointing to replacement attorney page`, () => {
     canFindButtonLinkedTo('replacement-attorney');
 })
 
-Then(`I can find save pointing to people to notify page`, (linkAddr) => {
+Then(`I can find save pointing to people to notify page`, () => {
     canFindButtonLinkedTo('people-to-notify');
 })
 

--- a/cypress/e2e/common/i_am_taken_to.js
+++ b/cypress/e2e/common/i_am_taken_to.js
@@ -1,7 +1,5 @@
 import { Then } from "@badeball/cypress-cucumber-preprocessor";
 
-var lpaid;
-
 Then(`I am taken to {string}`, (url) => {
     cy.url().should('eq', Cypress.config().baseUrl + url);
     cy.OPGCheckA11y();

--- a/cypress/e2e/common/i_can_find.js
+++ b/cypress/e2e/common/i_can_find.js
@@ -4,7 +4,7 @@ Then(`I can find {string}`, (object) => {
   cy.get("[data-cy=" + object + "]");
 })
 
-Then(`I can find use-my-details if lpa is new`, (object) => {
+Then(`I can find use-my-details if lpa is new`, () => {
   if (Cypress.env('clonedLpa') !== true) {
       cy.get("[data-cy=use-my-details]");
   }
@@ -31,7 +31,7 @@ Then(`I can find {string} and it is visible`, (object) => {
 })
 
 Then(`I can find {string} wrapped with error highlighting`, (object) => {
-    cy.get("div.form-group-error").within((el) => {
+    cy.get("div.form-group-error").within(() => {
       cy.get("[data-cy=" + object + "]");
     })
 })

--- a/cypress/e2e/common/i_can_see_popup.js
+++ b/cypress/e2e/common/i_can_see_popup.js
@@ -5,6 +5,6 @@ Then(`I can see popup`, () => {
   cy.get("#popup");
 })
 
-Then(`I cannot see popup`, (object) => {
+Then(`I cannot see popup`, () => {
   cy.get("#popup").should('not.exist');
 })

--- a/cypress/e2e/common/i_ignore_application_exceptions.js
+++ b/cypress/e2e/common/i_ignore_application_exceptions.js
@@ -1,7 +1,7 @@
 import { Given } from "@badeball/cypress-cucumber-preprocessor";
 
 Given(`I ignore application exceptions`, () => {
-    Cypress.on('uncaught:exception', (err, runnable) => {
+    Cypress.on('uncaught:exception', () => {
         return false
     })
 })

--- a/cypress/e2e/common/json.js
+++ b/cypress/e2e/common/json.js
@@ -1,4 +1,4 @@
-import { And, Then, When } from "@badeball/cypress-cucumber-preprocessor";
+import { Then, When } from "@badeball/cypress-cucumber-preprocessor";
 
 When('I visit the {string} JSON endpoint and save the response as {string}', (path, key) => {
     cy.request(path).then((response) => {

--- a/cypress/e2e/common/pdfs.js
+++ b/cypress/e2e/common/pdfs.js
@@ -14,7 +14,7 @@ const requestUntilRefreshUrl = (href, tries) => {
         if (content.includes('url')) {
             const refreshUrl = content.substring(7);
 
-            return new Cypress.Promise((resolve, reject) => {
+            return new Cypress.Promise((resolve) => {
                 resolve(refreshUrl);
             });
         }

--- a/cypress/e2e/common/reuse_details.js
+++ b/cypress/e2e/common/reuse_details.js
@@ -18,12 +18,12 @@ const seeReuseDetailsLink = (shouldExist) => {
 
 // should('be.checked')  or not checked exists here to ensure that cypress doesn't race off
 // and carry out the next operation without making sure first that the check or uncheck has taken effect
-Then(`I opt not to re-use details`, (checkable) => {
+Then(`I opt not to re-use details`, () => {
     cy.get("[data-cy=reuse-details--1]").check().should('be.checked');
     cy.get("[data-cy=continue]").click();
 })
 
-Then(`I opt not to re-use details if lpa is a clone`, (checkable) => {
+Then(`I opt not to re-use details if lpa is a clone`, () => {
     if (Cypress.env('clonedLpa') === true) {
       cy.get("[data-cy=reuse-details--1]").check().should('be.checked');
       cy.get("[data-cy=continue]").click();


### PR DESCRIPTION
## Purpose

_Fix no-unused-vars reported by eslint for cypress code, and take the rule out from eslint config_

## Approach

_Take rule out, fix issues by hand. (not fixable automatically)_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
