### PR TITLE
Lpal 1031 otherNames Warning message

### DIFF
--- a/cypress/e2e/DonorPF.feature
+++ b/cypress/e2e/DonorPF.feature
@@ -34,6 +34,7 @@ Feature: Add donor to Property and Finance LPA
         When I force fill out
             | name-first | qo06zCs3DEtroWJF8U7eqo7LWeO47Cc5NVbCLPOfL7TROMO5S7JCCZkNulCD7tpVi0x9kB |
             | name-last | qo06zCs3DEtroWJF8U7eqo7LWeO47Cc5NVbCLPOfL7TROMO5S7JCCZkNulCD7tpVi0x9kB |
+            | otherNames | qo06zCs3DEtroWJF8U7eqo7LWeO47Cc5NVbCLPOfL7TROMO5S7JCCZkNulCD7tpVi0x9kB |
             | dob-date-day | 22 |
             | dob-date-month | 10 |
             | dob-date-year | 1988 |
@@ -48,6 +49,7 @@ Feature: Add donor to Property and Finance LPA
             | Enter the donor's title |
             | Enter a first name that's less than 54 characters long |
             | Enter a last name that's less than 62 characters long |
+            | Enter other names that are less than 51 characters long |
             | Change address line 1 so that it has fewer than 51 characters |
             | Change address line 2 so that it has fewer than 51 characters |
             | Change address line 3 so that it has fewer than 51 characters |
@@ -63,6 +65,7 @@ Feature: Add donor to Property and Finance LPA
             | address-address2| Undercliff Drive |
             | address-address3| Ventnor, Isle of Wight |
             | address-postcode| PO38 1UL |
+        And I clear the value in "otherNames"
         And I check "cannot-sign"
         And I click "form-save"
         Then I cannot find "form-donor"

--- a/service-front/module/Application/view/application/authenticated/lpa/donor/form.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/donor/form.twig
@@ -20,6 +20,9 @@
         'cannot-be-blank' : 'Enter the donor\'s last name',
         'must-be-less-than-or-equal:61' : 'Enter a last name that\'s less than 62 characters long'
     },
+    'otherNames' : {
+        'must-be-less-than-or-equal:50' : 'Enter an other name that\'s less than 51 characters long'
+    },
     'email-address' : {
         'invalid-email-address' : 'Enter a valid email address'
     },

--- a/service-front/module/Application/view/application/authenticated/lpa/donor/form.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/donor/form.twig
@@ -21,7 +21,7 @@
         'must-be-less-than-or-equal:61' : 'Enter a last name that\'s less than 62 characters long'
     },
     'otherNames' : {
-        'must-be-less-than-or-equal:50' : 'Enter an other name that\'s less than 51 characters long'
+        'must-be-less-than-or-equal:50' : 'Enter other names that are less than 51 characters long'
     },
     'email-address' : {
         'invalid-email-address' : 'Enter a valid email address'

--- a/service-front/module/Application/view/application/authenticated/lpa/primary-attorney/person-form.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/primary-attorney/person-form.twig
@@ -21,7 +21,7 @@
         'must-be-less-than-or-equal:50' : 'Enter a last name that\'s less than 51 characters long'
     },
     'otherNames' : {
-        'must-be-less-than-or-equal:50' : 'Enter an other name that\'s less than 51 characters long'
+        'must-be-less-than-or-equal:50' : 'Enter other names that are less than 51 characters long'
     },
     'email-address' : {
         'invalid-email-address' : 'Enter a valid email address'

--- a/service-front/module/Application/view/application/authenticated/lpa/primary-attorney/person-form.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/primary-attorney/person-form.twig
@@ -20,6 +20,9 @@
         'cannot-be-blank' : 'Enter the attorney\'s last name',
         'must-be-less-than-or-equal:50' : 'Enter a last name that\'s less than 51 characters long'
     },
+    'otherNames' : {
+        'must-be-less-than-or-equal:50' : 'Enter an other name that\'s less than 51 characters long'
+    },
     'email-address' : {
         'invalid-email-address' : 'Enter a valid email address'
     },


### PR DESCRIPTION
## Purpose

_Currently, if you input other names longer than 50 chars, you don't get a user friendly message. This puts a user friendly message in. This is for the donor only at the moment_

## Approach

_Add a helpful message in the validation of the twig files.  Add testing of this for cypress tests. Note, this is done for donor so far.  The twig for primary attorney also has an otherNames field. That doesn't currently appear to be used, but I have added a friendly message for it in case it ever is, without an associated test_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
