### PR TITLE
LPAL-980 Remove Postgres 10 references

### DIFF
--- a/terraform/environment/modules/environment/variables.tf
+++ b/terraform/environment/modules/environment/variables.tf
@@ -17,7 +17,6 @@ variable "lambda_container_version" {
 variable "account" {
   type = object({
     dr_enabled                             = bool
-    use_postgres13                         = bool
     performance_platform_enabled           = bool
     pagerduty_service_name                 = string
     account_id                             = string
@@ -29,7 +28,6 @@ variable "account" {
     auth_token_ttl_secs                    = number
     skip_final_snapshot                    = bool
     psql_engine_version                    = string
-    psql_parameter_group_family            = string
     psql13_parameter_group_family          = string
     aurora_enabled                         = bool
     aurora_serverless                      = bool

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -8,7 +8,6 @@
   "accounts": {
     "development": {
       "dr_enabled" : false,
-      "use_postgres13" : true,
       "performance_platform_enabled" : true,
       "deletion_protection" :false,
       "aurora_enabled" :  true,
@@ -24,7 +23,6 @@
       "backup_retention_period": 0,
       "skip_final_snapshot" : true,
       "psql_engine_version": "13.7",
-      "psql_parameter_group_family": "postgres10",
       "psql13_parameter_group_family": "postgres13",
       "log_retention_in_days": 7,
       "account_name_short" : "dev",
@@ -61,7 +59,6 @@
     },
     "preproduction": {
       "dr_enabled" : false,
-      "use_postgres13" : true,
       "performance_platform_enabled" : false,
       "deletion_protection" :false,
       "aurora_enabled" : false,
@@ -77,7 +74,6 @@
       "backup_retention_period": 2,
       "skip_final_snapshot" : true,
       "psql_engine_version": "13.7",
-      "psql_parameter_group_family": "postgres10",
       "psql13_parameter_group_family": "postgres13",
       "log_retention_in_days": 7,
       "account_name_short" : "pre",
@@ -114,7 +110,6 @@
     },
     "production": {
       "dr_enabled" : false,
-      "use_postgres13" : true,
       "performance_platform_enabled" : false,
       "deletion_protection" :true,
       "aurora_enabled" : false,
@@ -130,7 +125,6 @@
       "backup_retention_period": 30,
       "skip_final_snapshot" : false,
       "psql_engine_version": "13.7",
-      "psql_parameter_group_family": "postgres10",
       "psql13_parameter_group_family": "postgres13",
       "log_retention_in_days": 120,
       "account_name_short" : "prod",

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -23,7 +23,6 @@ variable "accounts" {
   type = map(
     object({
       dr_enabled                             = bool
-      use_postgres13                         = bool
       performance_platform_enabled           = bool
       pagerduty_service_name                 = string
       account_id                             = string
@@ -35,7 +34,6 @@ variable "accounts" {
       auth_token_ttl_secs                    = number
       skip_final_snapshot                    = bool
       psql_engine_version                    = string
-      psql_parameter_group_family            = string
       psql13_parameter_group_family          = string
       aurora_enabled                         = bool
       aurora_serverless                      = bool


### PR DESCRIPTION
## Purpose

Clean up the Terraform codebase by removing references to the no longer used Postgres 10.

Fixes LPAL-980

## Approach

Remove all references to the older Postgres in terraform/environment

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
