### PR TITLE
LPAL-1020 fix cypress no-undef eslint issues

### DIFF
--- a/cypress/e2e/common/.eslintrc.json
+++ b/cypress/e2e/common/.eslintrc.json
@@ -9,10 +9,17 @@
     "browser": true
   },
 
+  "globals": {
+    "cy": "readonly",
+    "Cypress": "readonly",
+    "require": "readonly",
+    "expect": "readonly",
+    "assert": "readonly"
+  },
+
   "extends": ["plugin:prettier/recommended", "eslint:recommended"],
 
   "rules": {
-    "no-undef": "off",
     "prettier/prettier": "off"
   }
 }


### PR DESCRIPTION
## Purpose

_Take out the no-undef rule, so that eslint does apply this.  This is a particularly important rule_


## Approach

_Took out the no-undef rule from eslint config. That has meant I had to also add a number of cypress-specific globals. The end result is that the no-undef rule is now applied for everything else_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
