### PR TITLE
LPAL-998 fix no-unused-vars eslint warnings

### DIFF
--- a/service-front/assets/.eslintrc.json
+++ b/service-front/assets/.eslintrc.json
@@ -15,7 +15,6 @@
 
   "rules": {
     "no-undef": "off",
-    "no-unused-vars": "off",
     "prettier/prettier": "off"
   }
 }

--- a/service-front/assets/js/govuk/stageprompt.js
+++ b/service-front/assets/js/govuk/stageprompt.js
@@ -48,7 +48,7 @@ GOVUK.performance.stageprompt = (function () {
       analyticsCallback.apply(null, splitAction(journeyStage));
     }
 
-    journeyHelpers.on('click', function (event) {
+    journeyHelpers.on('click', function () {
       analyticsCallback.apply(null, splitAction($(this).data('journey-click')));
     });
   };

--- a/service-front/assets/js/moj/moj.modules/moj.cookie-consent.js
+++ b/service-front/assets/js/moj/moj.modules/moj.cookie-consent.js
@@ -14,12 +14,12 @@
             var saveCookieConsent = this.saveCookieConsent.bind(this);
 
             var acceptButton = document.querySelector('.global-cookie-message__button_accept');
-            acceptButton.addEventListener('click', function(evt) {
+            acceptButton.addEventListener('click', function() {
                 return saveCookieConsent(true);
             });
 
             var rejectButton = document.querySelector('.global-cookie-message__button_reject');
-            rejectButton.addEventListener('click', function(evt) {
+            rejectButton.addEventListener('click', function() {
                 return saveCookieConsent(false);
             });
 
@@ -31,7 +31,7 @@
                 noJsMessage.setAttribute('hidden', true);
 
                 var submit = document.querySelector('input[type="submit"]');
-                submit.addEventListener('click', function(evt) {
+                submit.addEventListener('click', function() {
                     var flashBanner = document.querySelector('#govuk-notification-banner-title');
                     var input = document.querySelector('#usageCookies-yes');
 
@@ -91,7 +91,7 @@
             }
         },
 
-        closeSaveConfirmation: function (evt) {
+        closeSaveConfirmation: function () {
             this.displaySaveConfirmation(false);
             this.displayCookieBanner(false);
         },

--- a/service-front/assets/js/moj/moj.modules/moj.postcode-lookup.js
+++ b/service-front/assets/js/moj/moj.modules/moj.postcode-lookup.js
@@ -67,7 +67,7 @@
       this.$wrap.find('.js-PostcodeLookup__change').closest('div').removeClass('hidden')
     },
 
-    changeClicked: function (e) {
+    changeClicked: function () {
       this.$wrap.find('.js-PostcodeLookup__change').closest('div').addClass('hidden')
       this.$wrap.find('.js-PostcodeLookup__search').removeClass('hidden')
       if (moj.Helpers.hasCleanFields(this.$postalFields) && !$('.error-summary').length) {
@@ -102,7 +102,7 @@
       return false
     },
 
-    toggleClicked: function (e) {
+    toggleClicked: function () {
       this.toggleAddress()
       return false
     },

--- a/service-front/assets/js/moj/moj.modules/moj.single-use.js
+++ b/service-front/assets/js/moj/moj.modules/moj.single-use.js
@@ -5,7 +5,7 @@
     'use strict';
 
     // Define the class
-    var SingleUse = function (options) {
+    var SingleUse = function () {
         this.settings = {
             selector: '.js-single-use'
         };


### PR DESCRIPTION
## Purpose

_fix no-unused-vars eslint warnings_

## Approach

_Took out non-unused-vars rule, fixed code by hand_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
