### PR TITLE
LPAL-1036 Add missing download artifact step

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -127,6 +127,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
 
+    - name: Download Terraform Task definition
+      uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3
+      with:
+        name: terraform-artifact
+        path: /tmp/
+
     - name: Terraform Outputs from JSON
       id: set_var
       run: |


### PR DESCRIPTION
## Purpose

Add a missing step to the Github Actions Path to Live to download the Terraform artifact produced by environment run

Fixes LPAL-1036

## Approach

Use the actions/download-artifact action to download the task config in preprod_terraform_outputs job.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
