### PR TITLE
LPAL-993 Enable read-only root filesystem on app containers

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Unit Tests
         if: matrix.unit_test == true && ( steps.image_exists.outputs.image_exists == 'false' || matrix.force_push_to_repo == true )
         run: |
-          docker run --pull never --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name tests ${{ matrix.image_name }}:latest /app/vendor/bin/phpunit -d memory_limit=256M --do-not-cache-result --tmpfs /app/build/twig-cache
+          docker run --pull never --tmpfs /app/build/twig-cache --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name tests ${{ matrix.image_name }}:latest /app/vendor/bin/phpunit -d memory_limit=256M --do-not-cache-result 
 
       - name: ECR Login
         id: login_ecr

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Unit Tests
         if: matrix.unit_test == true && ( steps.image_exists.outputs.image_exists == 'false' || matrix.force_push_to_repo == true )
         run: |
-          docker run --pull never --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name tests ${{ matrix.image_name }}:latest /app/vendor/bin/phpunit -d memory_limit=256M
+          docker run --pull never --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name tests ${{ matrix.image_name }}:latest /app/vendor/bin/phpunit -d memory_limit=256M --do-not-cache-result
 
       - name: ECR Login
         id: login_ecr

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Unit Tests
         if: matrix.unit_test == true && ( steps.image_exists.outputs.image_exists == 'false' || matrix.force_push_to_repo == true )
         run: |
-          docker run --pull never --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name tests ${{ matrix.image_name }}:latest /app/vendor/bin/phpunit -d memory_limit=256M --do-not-cache-result
+          docker run --pull never --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name tests ${{ matrix.image_name }}:latest /app/vendor/bin/phpunit -d memory_limit=256M --do-not-cache-result --tmpfs /app/build/twig-cache
 
       - name: ECR Login
         id: login_ecr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
   front-web:
     container_name: lpa-front-web
     image: lpa-front-web
+    read_only: true
     depends_on:
       - front-app
       - front-v2-app
@@ -118,6 +119,7 @@ services:
   front-v2-app:
     container_name: lpa-front-v2-app
     image: lpa-front-v2-app
+    read_only: true
     build:
       context: ./
       dockerfile: service-front-v2/docker/app/Dockerfile
@@ -129,6 +131,7 @@ services:
   feedback-app:
     container_name: lpa-feedback-app
     image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/opg-feedback/front-app
+    read_only: true
     depends_on:
       - feedback-api
     environment:
@@ -139,6 +142,7 @@ services:
   front-app:
     container_name: lpa-front-app
     image: lpa-front-app
+    read_only: true
     build:
       context: ./
 # Ideally, debug would always be enabled for front-app, as we often want to debug it. In practice, this still runs too slowly so we leave it off as default
@@ -226,6 +230,7 @@ services:
   api-web:
     container_name: lpa-api-web
     image: lpa-api-web
+    read_only: true
     depends_on:
       - api-app
     build:
@@ -241,6 +246,7 @@ services:
   api-app:
     container_name: lpa-api-app
     image: lpa-api-app
+    read_only: true
     build:
       context: ./
 # Enable debug is recommended to default to off for api to avoid slowness. Turn this on if you ever need to debug the api
@@ -343,6 +349,7 @@ services:
   admin-web:
     container_name: lpa-admin-web
     image: lpa-admin-web
+    read_only: true
     depends_on:
       - admin-app
     volumes:
@@ -358,6 +365,7 @@ services:
   admin-app:
     container_name: lpa-admin-app
     image: lpa-admin-app
+    read_only: true
     build:
       context: ./
       dockerfile: service-admin/docker/app/Dockerfile
@@ -433,6 +441,7 @@ services:
   pdf-app:
     container_name: lpa-pdf-app
     image: lpa-pdf-app
+    read_only: true
     depends_on:
       localstack:
         condition: service_healthy
@@ -440,6 +449,8 @@ services:
         condition: service_started
     volumes:
       - ./service-pdf:/app
+    tmpfs:
+      - /tmp/
     build:
       context: ./
       dockerfile: service-pdf/docker/app/Dockerfile

--- a/docs/architecture/0011-implement-read-only-filesystems.md
+++ b/docs/architecture/0011-implement-read-only-filesystems.md
@@ -1,0 +1,26 @@
+# 0011. Refactor container images to use read-only root filesystems
+
+Date: 16/11/2022
+
+## Status
+
+Accepted: 16/11/2022
+
+## Context
+
+Disabling write access to the root file system ensures that we are following best container practices as documented by AWS. ECS_CONTAINERS_READONLY_ACCESS will flag as non-compliant if root file systems are not set to read only whilst containers running on ECS.
+
+This will make it difficult for an attacker to make application changes if they are able to gain access through remote code execution or remote shell on any of our application containers.
+
+## Final Proposal
+
+`readonlyRootFilesystem` will be set to true in all application container definitions. This will prevent the container from being able to write to `/` and subdirectories.
+
+The exception to this will be `/tmp`, which all containers will have R+W access to. This, however, prevents the application code from being changed during runtime.
+
+In a similar vein as to Kuberetes' [InitContainers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/), an initial container will be started as part of each task which will run a chmod command against the `app_tmp` volume. This will change the permissions from the default of `755` to `766` as the former would not allow `appuser` to write to it. Once this is completed, the initContainer will exit and the volume will be mounted as `tmp` in the main app container.
+
+## Consequences
+
+- Although we don't use it, ECS Exec will no longer be usable in ECS.
+- Manual UAT should be performed in case there are any gaps in testing

--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -24,29 +24,29 @@ RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
     fi ;
 
 # Install composer dependencies
-COPY --chown=appuser:appuser service-admin/composer.json /app/composer.json
-COPY --chown=appuser:appuser service-admin/composer.lock /app/composer.lock
+COPY --chown=root:root service-admin/composer.json /app/composer.json
+COPY --chown=root:root service-admin/composer.lock /app/composer.lock
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version 2.4.1 \
-    && su - appuser -c "composer install --prefer-dist --no-interaction --no-cache --no-scripts --optimize-autoloader -d /app" \
-    && chown -R appuser:appuser /app/vendor \
+    && composer install --prefer-dist --no-interaction --no-cache --no-scripts --optimize-autoloader -d /app \
+    && chown -R root:root /app/vendor \
     && rm /app/composer.json \
     && rm /usr/bin/composer
 
 # Clean up build dependencies, but only after everything else we need has been installed
 RUN apk del .build-dependencies
 
-COPY --chown=appuser:appuser service-admin/config /app/config
-COPY --chown=appuser:appuser service-admin/public /app/public
-COPY --chown=appuser:appuser service-admin/src /app/src
+COPY --chown=root:root service-admin/config /app/config
+COPY --chown=root:root service-admin/public /app/public
+COPY --chown=root:root service-admin/src /app/src
 
 # Need this to run unit tests in CI
-COPY --chown=appuser:appuser service-admin/phpunit.xml.dist /app/phpunit.xml.dist
-COPY --chown=appuser:appuser service-admin/test /app/test
+COPY --chown=root:root service-admin/phpunit.xml.dist /app/phpunit.xml.dist
+COPY --chown=root:root service-admin/test /app/test
 
-COPY --chown=appuser:appuser shared /shared
+COPY --chown=root:root shared /shared
 
-COPY --chown=appuser:appuser service-admin/docker/app/app-php.ini /usr/local/etc/php/conf.d/
-COPY --chown=appuser:appuser service-admin/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
+COPY --chown=root:root service-admin/docker/app/app-php.ini /usr/local/etc/php/conf.d/
+COPY --chown=root:root service-admin/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
 COPY --chown=root:root scripts/containers/health-check.sh /usr/local/bin/health-check.sh
 

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -29,11 +29,11 @@ RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
     fi ;
 
 # Install composer dependencies
-COPY --chown=appuser:appuser service-api/composer.json /app/composer.json
-COPY --chown=appuser:appuser service-api/composer.lock /app/composer.lock
+COPY --chown=root:root service-api/composer.json /app/composer.json
+COPY --chown=root:root service-api/composer.lock /app/composer.lock
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version 2.4.1 \
-    && su - appuser -c "composer install --prefer-dist --no-interaction --no-cache --no-scripts --optimize-autoloader -d /app" \
-    && chown -R appuser:appuser /app/vendor \
+    && composer install --prefer-dist --no-interaction --no-cache --no-scripts --optimize-autoloader -d /app \
+    && chown -R root:root /app/vendor \
     && rm /app/composer.json \
     && rm /usr/bin/composer
 
@@ -44,24 +44,24 @@ ENV OPG_LPA_COMMON_APP_VERSION=${OPG_LPA_COMMON_APP_VERSION}
 RUN apk del .build-dependencies
 
 # Core files for the application
-COPY --chown=appuser:appuser service-api/db/migrations /app/db/migrations
-COPY --chown=appuser:appuser service-api/config /app/config
-COPY --chown=appuser:appuser service-api/module /app/module
-COPY --chown=appuser:appuser service-api/public /app/public
+COPY --chown=root:root service-api/db/migrations /app/db/migrations
+COPY --chown=root:root service-api/config /app/config
+COPY --chown=root:root service-api/module /app/module
+COPY --chown=root:root service-api/public /app/public
 
 # For tests in CI
-COPY --chown=appuser:appuser service-api/phpunit.xml /app/phpunit.xml
+COPY --chown=root:root service-api/phpunit.xml /app/phpunit.xml
 
 # Shared code
-COPY --chown=appuser:appuser shared /shared
+COPY --chown=root:root shared /shared
 
 # PHP config files
-COPY --chown=appuser:appuser service-api/docker/app/app-php.ini /usr/local/etc/php/conf.d/
-COPY --chown=appuser:appuser service-api/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
+COPY --chown=root:root service-api/docker/app/app-php.ini /usr/local/etc/php/conf.d/
+COPY --chown=root:root service-api/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
 # Migration script
-COPY --chown=appuser:appuser service-api/docker/app/db-migrations.sh /app/db-migrations.sh
-COPY --chown=appuser:appuser service-api/phinx.php /app/phinx.php
+COPY --chown=root:root service-api/docker/app/db-migrations.sh /app/db-migrations.sh
+COPY --chown=root:root service-api/phinx.php /app/phinx.php
 COPY --chown=root:root scripts/containers/health-check.sh /usr/local/bin/health-check.sh
 
 RUN chmod +x /app/db-migrations.sh /usr/local/bin/health-check.sh

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -31,11 +31,11 @@ RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
 fi
 
 # Install composer dependencies
-COPY --chown=appuser:appuser service-front/composer.json /app/composer.json
-COPY --chown=appuser:appuser service-front/composer.lock /app/composer.lock
+COPY --chown=root:root service-front/composer.json /app/composer.json
+COPY --chown=root:root service-front/composer.lock /app/composer.lock
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version 2.4.1 \
-    && su - appuser -c "composer install --prefer-dist --no-interaction --no-cache --no-scripts --optimize-autoloader -d /app" \
-    && chown -R appuser:appuser /app/vendor \
+    && composer install --prefer-dist --no-interaction --no-cache --no-scripts --optimize-autoloader -d /app \
+    && chown -R root:root /app/vendor \
     && rm /app/composer.json \
     && rm /usr/bin/composer
 
@@ -43,22 +43,22 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 RUN apk del .build-dependencies
 
 # Core files for the application
-COPY --chown=appuser:appuser service-front/assets /app/assets
-COPY --chown=appuser:appuser service-front/config /app/config
-COPY --chown=appuser:appuser service-front/content /app/content
-COPY --chown=appuser:appuser service-front/data /app/data
-COPY --chown=appuser:appuser service-front/module /app/module
-COPY --chown=appuser:appuser service-front/public /app/public
+COPY --chown=root:root service-front/assets /app/assets
+COPY --chown=root:root service-front/config /app/config
+COPY --chown=root:root service-front/content /app/content
+COPY --chown=root:root service-front/data /app/data
+COPY --chown=root:root service-front/module /app/module
+COPY --chown=root:root service-front/public /app/public
 
 # For tests in CI
-COPY --chown=appuser:appuser service-front/phpunit.xml /app/phpunit.xml
+COPY --chown=root:root service-front/phpunit.xml /app/phpunit.xml
 
 # Shared code
-COPY --chown=appuser:appuser shared /shared
+COPY --chown=root:root shared /shared
 
 # PHP config files
-COPY --chown=appuser:appuser service-front/docker/app/app-php.ini /usr/local/etc/php/conf.d/
-COPY --chown=appuser:appuser service-front/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
+COPY --chown=root:root service-front/docker/app/app-php.ini /usr/local/etc/php/conf.d/
+COPY --chown=root:root service-front/docker/app/php-fpm-logging.conf /usr/local/etc/php-fpm.d/
 
 COPY --chown=root:root scripts/containers/health-check.sh /usr/local/bin/health-check.sh
 

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -24,11 +24,11 @@ RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
     fi
 
 # Install composer dependencies
-COPY --chown=appuser:appuser service-pdf/composer.json /app/composer.json
-COPY --chown=appuser:appuser service-pdf/composer.lock /app/composer.lock
+COPY --chown=root:root service-pdf/composer.json /app/composer.json
+COPY --chown=root:root service-pdf/composer.lock /app/composer.lock
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version 2.4.1 \
-    && su - appuser -c "composer install --prefer-dist --no-interaction --no-cache --no-scripts --optimize-autoloader -d /app" \
-    && chown -R appuser:appuser /app/vendor \
+    && composer install --prefer-dist --no-interaction --no-cache --no-scripts --optimize-autoloader -d /app \
+    && chown -R root:root /app/vendor \
     && rm /app/composer.json \
     && rm /usr/bin/composer
 
@@ -37,14 +37,14 @@ RUN apk del .build-dependencies
 
 # This is version 3.2.1 of this tool, we will need to check this regularly.
 # PDFTK does have a community based docker container, but the version is not up to date.
-COPY --chown=appuser:appuser service-pdf/bin/pdftk /usr/local/bin/pdftk
+COPY --chown=root:root service-pdf/bin/pdftk /usr/local/bin/pdftk
 
 RUN curl -sS -o /usr/local/bin/pdftk-all.jar https://gitlab.com/pdftk-java/pdftk/-/jobs/812582458/artifacts/raw/build/libs/pdftk-all.jar \
-    && chmod u+x /usr/local/bin/pdftk
+    && chmod 755 /usr/local/bin/pdftk
 
-COPY --chown=appuser:appuser shared /shared
-COPY --chown=appuser:appuser service-pdf /app
-COPY --chown=appuser:appuser service-pdf/docker/app/app-php.ini /usr/local/etc/php/conf.d/
+COPY --chown=root:root shared /shared
+COPY --chown=root:root service-pdf /app
+COPY --chown=root:root service-pdf/docker/app/app-php.ini /usr/local/etc/php/conf.d/
 
 WORKDIR /app
 

--- a/terraform/environment/modules/environment/ecs_admin.tf
+++ b/terraform/environment/modules/environment/ecs_admin.tf
@@ -68,10 +68,13 @@ resource "aws_ecs_task_definition" "admin" {
   network_mode             = "awsvpc"
   cpu                      = 256
   memory                   = 512
-  container_definitions    = "[${local.admin_web}, ${local.admin_app}]"
+  container_definitions    = "[${local.admin_web}, ${local.admin_app}, ${local.admin_app_init_container}]"
   task_role_arn            = aws_iam_role.admin_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
   tags                     = local.admin_component_tag
+  volume {
+    name = "app_tmp"
+  }
 }
 
 //----------------
@@ -142,6 +145,7 @@ locals {
     {
       "cpu" : 1,
       "essential" : true,
+      # "readonlyRootFilesystem" : true,
       "image" : "${data.aws_ecr_repository.lpa_admin_web.repository_url}:${var.container_version}",
       "mountPoints" : [],
       "name" : "web",
@@ -170,12 +174,39 @@ locals {
     }
   )
 
+  admin_app_init_container = jsonencode(
+    {
+      "name" : "permissions-init",
+      "image" : "busybox:latest",
+      "entryPoint" : [
+        "sh",
+        "-c"
+      ],
+      "command" : [
+        "chmod 766 /tmp/"
+      ],
+      "mountPoints" : [
+        {
+          "containerPath" : "/tmp",
+          "sourceVolume" : "app_tmp"
+        }
+      ],
+      "essential" : false
+    }
+  )
+
   admin_app = jsonencode(
     {
       "cpu" : 1,
       "essential" : true,
+      "readonlyRootFilesystem" : true,
       "image" : "${data.aws_ecr_repository.lpa_admin_app.repository_url}:${var.container_version}",
-      "mountPoints" : [],
+      "mountPoints" : [
+        {
+          "containerPath" : "/tmp",
+          "sourceVolume" : "app_tmp"
+        }
+      ],
       "name" : "app",
       "portMappings" : [
         {
@@ -200,6 +231,12 @@ locals {
           "awslogs-stream-prefix" : "${var.environment_name}.admin-app.online-lpa"
         }
       },
+      "dependsOn" : [
+        {
+          "containerName" : "permissions-init",
+          "condition" : "SUCCESS"
+        }
+      ],
       "secrets" : [
         { "name" : "OPG_LPA_ADMIN_JWT_SECRET", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_admin_jwt_secret.name}" },
         { "name" : "OPG_LPA_COMMON_ACCOUNT_CLEANUP_NOTIFICATION_RECIPIENTS", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_common_account_cleanup_notification_recipients.name}" },

--- a/terraform/environment/modules/environment/ecs_admin.tf
+++ b/terraform/environment/modules/environment/ecs_admin.tf
@@ -68,7 +68,7 @@ resource "aws_ecs_task_definition" "admin" {
   network_mode             = "awsvpc"
   cpu                      = 256
   memory                   = 512
-  container_definitions    = "[${local.admin_web}, ${local.admin_app}, ${local.admin_app_init_container}]"
+  container_definitions    = "[${local.admin_web}, ${local.admin_app}, ${local.app_init_container}]"
   task_role_arn            = aws_iam_role.admin_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
   tags                     = local.admin_component_tag
@@ -145,7 +145,6 @@ locals {
     {
       "cpu" : 1,
       "essential" : true,
-      # "readonlyRootFilesystem" : true,
       "image" : "${data.aws_ecr_repository.lpa_admin_web.repository_url}:${var.container_version}",
       "mountPoints" : [],
       "name" : "web",
@@ -171,27 +170,6 @@ locals {
         { "name" : "TIMEOUT", "value" : "60" },
         { "name" : "CONTAINER_VERSION", "value" : var.container_version }
       ]
-    }
-  )
-
-  admin_app_init_container = jsonencode(
-    {
-      "name" : "permissions-init",
-      "image" : "busybox:latest",
-      "entryPoint" : [
-        "sh",
-        "-c"
-      ],
-      "command" : [
-        "chmod 766 /tmp/"
-      ],
-      "mountPoints" : [
-        {
-          "containerPath" : "/tmp",
-          "sourceVolume" : "app_tmp"
-        }
-      ],
-      "essential" : false
     }
   )
 

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -123,7 +123,7 @@ resource "aws_ecs_task_definition" "api" {
   network_mode             = "awsvpc"
   cpu                      = 256
   memory                   = 512
-  container_definitions    = "[${local.api_web}, ${local.api_app}, ${local.api_app_init_container}]"
+  container_definitions    = "[${local.api_web}, ${local.api_app}, ${local.app_init_container}]"
   task_role_arn            = aws_iam_role.api_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
   tags                     = local.api_component_tag
@@ -286,27 +286,6 @@ locals {
         { "name" : "TIMEOUT", "value" : "60" },
         { "name" : "CONTAINER_VERSION", "value" : var.container_version }
       ]
-    }
-  )
-
-  api_app_init_container = jsonencode(
-    {
-      "name" : "permissions-init",
-      "image" : "busybox:latest",
-      "entryPoint" : [
-        "sh",
-        "-c"
-      ],
-      "command" : [
-        "chmod 766 /tmp/"
-      ],
-      "mountPoints" : [
-        {
-          "containerPath" : "/tmp",
-          "sourceVolume" : "app_tmp"
-        }
-      ],
-      "essential" : false
     }
   )
 

--- a/terraform/environment/modules/environment/ecs_api_cron.tf
+++ b/terraform/environment/modules/environment/ecs_api_cron.tf
@@ -77,10 +77,13 @@ resource "aws_ecs_task_definition" "api_crons" {
   network_mode             = "awsvpc"
   cpu                      = 512
   memory                   = 1024
-  container_definitions    = "[${local.api_app}]"
+  container_definitions    = "[${local.api_app}, ${local.api_app_init_container}]"
   task_role_arn            = aws_iam_role.api_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
   tags                     = local.api_component_tag
+  volume {
+    name = "app_tmp"
+  }
 }
 
 //------------------------------------------------

--- a/terraform/environment/modules/environment/ecs_api_cron.tf
+++ b/terraform/environment/modules/environment/ecs_api_cron.tf
@@ -77,7 +77,7 @@ resource "aws_ecs_task_definition" "api_crons" {
   network_mode             = "awsvpc"
   cpu                      = 512
   memory                   = 1024
-  container_definitions    = "[${local.api_app}, ${local.api_app_init_container}]"
+  container_definitions    = "[${local.api_app}, ${local.app_init_container}]"
   task_role_arn            = aws_iam_role.api_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
   tags                     = local.api_component_tag

--- a/terraform/environment/modules/environment/ecs_feedbackdb.tf
+++ b/terraform/environment/modules/environment/ecs_feedbackdb.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_task_definition" "feedbackdb" {
   network_mode             = "awsvpc"
   cpu                      = 2048
   memory                   = 4096
-  container_definitions    = "[${local.feedbackdb_app}, ${local.feedback_app_init_container}]"
+  container_definitions    = "[${local.feedbackdb_app}, ${local.app_init_container}]"
   task_role_arn            = aws_iam_role.feedbackdb_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
   tags                     = local.feedbackdb_component_tag
@@ -55,27 +55,6 @@ data "aws_ecr_repository" "lpa_feedbackdb_app" {
 // feedbackdb ECS Service Task Container level config
 
 locals {
-
-  feedback_app_init_container = jsonencode(
-    {
-      "name" : "permissions-init",
-      "image" : "busybox:latest",
-      "entryPoint" : [
-        "sh",
-        "-c"
-      ],
-      "command" : [
-        "chmod 766 /tmp/"
-      ],
-      "mountPoints" : [
-        {
-          "containerPath" : "/tmp",
-          "sourceVolume" : "app_tmp"
-        }
-      ],
-      "essential" : false
-    }
-  )
 
   feedbackdb_app = jsonencode(
     {

--- a/terraform/environment/modules/environment/ecs_feedbackdb.tf
+++ b/terraform/environment/modules/environment/ecs_feedbackdb.tf
@@ -27,10 +27,13 @@ resource "aws_ecs_task_definition" "feedbackdb" {
   network_mode             = "awsvpc"
   cpu                      = 2048
   memory                   = 4096
-  container_definitions    = "[${local.feedbackdb_app}]"
+  container_definitions    = "[${local.feedbackdb_app}, ${local.feedback_app_init_container}]"
   task_role_arn            = aws_iam_role.feedbackdb_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
   tags                     = local.feedbackdb_component_tag
+  volume {
+    name = "app_tmp"
+  }
 }
 
 
@@ -52,12 +55,40 @@ data "aws_ecr_repository" "lpa_feedbackdb_app" {
 // feedbackdb ECS Service Task Container level config
 
 locals {
+
+  feedback_app_init_container = jsonencode(
+    {
+      "name" : "permissions-init",
+      "image" : "busybox:latest",
+      "entryPoint" : [
+        "sh",
+        "-c"
+      ],
+      "command" : [
+        "chmod 766 /tmp/"
+      ],
+      "mountPoints" : [
+        {
+          "containerPath" : "/tmp",
+          "sourceVolume" : "app_tmp"
+        }
+      ],
+      "essential" : false
+    }
+  )
+
   feedbackdb_app = jsonencode(
     {
       "cpu" : 1,
       "essential" : true,
+      "readonlyRootFilesystem" : true,
       "image" : "${data.aws_ecr_repository.lpa_feedbackdb_app.repository_url}:latest",
-      "mountPoints" : [],
+      "mountPoints" : [
+        {
+          "containerPath" : "/tmp",
+          "sourceVolume" : "app_tmp"
+        }
+      ],
       "name" : "app",
       "portMappings" : [
         {
@@ -75,6 +106,12 @@ locals {
           "awslogs-stream-prefix" : "${var.environment_name}.feedbackdb.online-lpa"
         }
       },
+      "dependsOn" : [
+        {
+          "containerName" : "permissions-init",
+          "condition" : "SUCCESS"
+        }
+      ],
       "secrets" : [
         { "name" : "OPG_LPA_POSTGRES_USERNAME", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.api_rds_username.name}" },
         { "name" : "OPG_LPA_POSTGRES_PASSWORD", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.api_rds_password.name}" },

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -79,7 +79,7 @@ resource "aws_ecs_task_definition" "front" {
   network_mode             = "awsvpc"
   cpu                      = 256
   memory                   = 512
-  container_definitions    = "[${local.front_web}, ${local.front_app}, ${local.front_v2_app}, ${local.front_app_init_container}]"
+  container_definitions    = "[${local.front_web}, ${local.front_app}, ${local.front_v2_app}, ${local.app_init_container}]"
   task_role_arn            = aws_iam_role.front_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
   tags                     = local.front_component_tag
@@ -207,27 +207,6 @@ locals {
       { "name" : "APP_V2_HOST", "value" : "127.0.0.1" },
       { "name" : "APP_V2_PORT", "value" : "8005" },
     ]
-    }
-  )
-
-  front_app_init_container = jsonencode(
-    {
-      "name" : "permissions-init",
-      "image" : "busybox:latest",
-      "entryPoint" : [
-        "sh",
-        "-c"
-      ],
-      "command" : [
-        "chmod 766 /tmp/"
-      ],
-      "mountPoints" : [
-        {
-          "containerPath" : "/tmp",
-          "sourceVolume" : "app_tmp"
-        }
-      ],
-      "essential" : false
     }
   )
 

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -79,11 +79,13 @@ resource "aws_ecs_task_definition" "front" {
   network_mode             = "awsvpc"
   cpu                      = 256
   memory                   = 512
-  container_definitions    = "[${local.front_web}, ${local.front_app}, ${local.front_v2_app}]"
+  container_definitions    = "[${local.front_web}, ${local.front_app}, ${local.front_v2_app}, ${local.front_app_init_container}]"
   task_role_arn            = aws_iam_role.front_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
   tags                     = local.front_component_tag
-
+  volume {
+    name = "app_tmp"
+  }
 }
 
 //----------------
@@ -208,12 +210,39 @@ locals {
     }
   )
 
+  front_app_init_container = jsonencode(
+    {
+      "name" : "permissions-init",
+      "image" : "busybox:latest",
+      "entryPoint" : [
+        "sh",
+        "-c"
+      ],
+      "command" : [
+        "chmod 766 /tmp/"
+      ],
+      "mountPoints" : [
+        {
+          "containerPath" : "/tmp",
+          "sourceVolume" : "app_tmp"
+        }
+      ],
+      "essential" : false
+    }
+  )
+
   front_app = jsonencode(
     {
       "cpu" : 1,
       "essential" : true,
+      "readonlyRootFilesystem" : true,
       "image" : "${data.aws_ecr_repository.lpa_front_app.repository_url}:${var.container_version}",
-      "mountPoints" : [],
+      "mountPoints" : [
+        {
+          "containerPath" : "/tmp",
+          "sourceVolume" : "app_tmp"
+        }
+      ],
       "name" : "app",
       "portMappings" : [
         {
@@ -238,6 +267,12 @@ locals {
           "awslogs-stream-prefix" : "${var.environment_name}.front-app.online-lpa"
         }
       },
+      "dependsOn" : [
+        {
+          "containerName" : "permissions-init",
+          "condition" : "SUCCESS"
+        }
+      ],
       "secrets" : [
         { "name" : "OPG_LPA_FRONT_CSRF_SALT", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_front_csrf_salt.name}" },
         { "name" : "OPG_LPA_FRONT_EMAIL_SENDGRID_WEBHOOK_TOKEN", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_front_email_sendgrid_webhook_token.name}" },

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -51,7 +51,7 @@ resource "aws_ecs_task_definition" "pdf" {
   network_mode             = "awsvpc"
   cpu                      = 2048
   memory                   = 4096
-  container_definitions    = "[${local.pdf_app},  ${local.pdf_app_init_container}]"
+  container_definitions    = "[${local.pdf_app},  ${local.app_init_container}]"
   task_role_arn            = aws_iam_role.pdf_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
   tags                     = local.pdf_component_tag
@@ -164,27 +164,6 @@ data "aws_ecr_repository" "lpa_pdf_app" {
 // pdf ECS Service Task Container level config
 
 locals {
-
-  pdf_app_init_container = jsonencode(
-    {
-      "name" : "permissions-init",
-      "image" : "busybox:latest",
-      "entryPoint" : [
-        "sh",
-        "-c"
-      ],
-      "command" : [
-        "chmod 766 /tmp/"
-      ],
-      "mountPoints" : [
-        {
-          "containerPath" : "/tmp/",
-          "sourceVolume" : "app_tmp"
-        }
-      ],
-      "essential" : false
-    }
-  )
 
   pdf_app = jsonencode(
     {

--- a/terraform/environment/modules/environment/locals.tf
+++ b/terraform/environment/modules/environment/locals.tf
@@ -78,4 +78,26 @@ locals {
   feedbackdb_component_tag = {
     component = "feedbackdb"
   }
+
+  app_init_container = jsonencode(
+    {
+      "name" : "permissions-init",
+      "image" : "busybox:latest",
+      "entryPoint" : [
+        "sh",
+        "-c"
+      ],
+      "command" : [
+        "chmod 766 /tmp/"
+      ],
+      "mountPoints" : [
+        {
+          "containerPath" : "/tmp",
+          "sourceVolume" : "app_tmp"
+        }
+      ],
+      "essential" : false
+    }
+  )
+
 }


### PR DESCRIPTION
## Purpose

Change the ownership of files in the container images to root and disable writing to the root file system.

Fixes LPAL-993

## Approach

- Change the `chown` commands in the Dockerfiles of all of the images to use root;
- Enable readonlyRootFilesystem in ECS containers;
- Enable read_only in docker-compose;
- Create init containers which mount the /tmp volume of containers and chmod 766 to prevent the `appuser` from being able to write and execute files.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
