### PR TITLE
LPAL-1044 Fail docker job if unit tests fail

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Unit Tests
         if: matrix.unit_test == true && ( steps.image_exists.outputs.image_exists == 'false' || matrix.force_push_to_repo == true )
         run: |
-          docker run --pull never --detach --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name tests ${{ matrix.image_name }}:latest /app/vendor/bin/phpunit -d memory_limit=256M
+          docker run --pull never --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name tests ${{ matrix.image_name }}:latest /app/vendor/bin/phpunit -d memory_limit=256M
 
       - name: ECR Login
         id: login_ecr


### PR DESCRIPTION
## Purpose

Fail a PR workflow if unit tests fail

Fixes LPAL-1044

## Approach

Remove --detach flag from the `docker run` command in the unit tests GHA step.

## Learning


## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
