### PR TITLE
LPAL-1048 Fix psalm errors in service-pdf

### DIFF
--- a/service-pdf/src/Opg/Lpa/Pdf/AbstractLp1.php
+++ b/service-pdf/src/Opg/Lpa/Pdf/AbstractLp1.php
@@ -917,6 +917,12 @@ abstract class AbstractLp1 extends AbstractIndividualPdf
         $pdf->AddPage();
 
         // filename, x position, y position, width, height, type, link, align, resize, dpi
+        /**
+         * Psalm has some inexplicable problem with the next line. I'm not sure if this
+         * is because the TCPDF docblocks are incorrect or something else, but everything
+         * is working and I'm guessing this is a false positive.
+         * @psalm-suppress UndefinedDocblockClass
+         */
         $pdf->Image($barcodePngFile, 40, 789);
 
         $barcodePdfFile = $this->getIntermediatePdfFilePath('barcode.pdf');

--- a/service-pdf/src/Opg/Lpa/Pdf/Worker/SqsWorker.php
+++ b/service-pdf/src/Opg/Lpa/Pdf/Worker/SqsWorker.php
@@ -27,7 +27,7 @@ class SqsWorker
      * @param string $docId Unique ID representing this job/document.
      * @param string $type The type of PDF to generate.
      * @param string $lpaData JSON document representing the LPA document.
-     * @throws Exception
+     * @throws \Exception
      */
     private function run($docId, $type, $lpaData)
     {


### PR DESCRIPTION
## Purpose

[LPAL-1048](https://opgtransform.atlassian.net/browse/LPAL-1048)

## Approach

Did a `./vendor/bin/psalm --no-cache` in all component directories. service-pdf was the only one with issues.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
