### PR TITLE
LPAL-1047 Fix issue where node-build-assets doesn't work after git clean

### DIFF
--- a/node-build-assets/docker/Dockerfile
+++ b/node-build-assets/docker/Dockerfile
@@ -1,13 +1,13 @@
+# This is only used locally, and depends on the service-front
+# directory being mounted into this image at /service-front
 FROM alpine:latest
 
 RUN apk add ruby npm
 
-WORKDIR /app
+WORKDIR /service-front
 
 COPY ./node-build-assets/docker/start.sh /app/
-COPY ./service-front/package*.json /app/
 
-RUN npm ci && \
-    chmod +x /app/start.sh
+RUN chmod +x /app/start.sh
 
 CMD ["/app/start.sh"]

--- a/node-build-assets/docker/start.sh
+++ b/node-build-assets/docker/start.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 cd /service-front
-export PATH=/app/node_modules/.bin/:$PATH
+export PATH=/service-front/node_modules/.bin/:$PATH
+npm ci
 grunt build_js_dev build_css watch


### PR DESCRIPTION
## Purpose

[LPAL-1047](https://opgtransform.atlassian.net/browse/LPAL-1047)

## Approach

This image (only used locally) depends on the dev having run npm install inside the service-front directory. If this hasn't happened, it doesn't work correctly.

I modified this to just rely on service-front, and to do the npm install as part of the runtime script. This makes sure we populate service-front/node_modules properly and that the container always works from a cold start.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
