### PR TITLE
LPAL-1043 Allow HTML characters and trailing/leading spaces in passwords

### DIFF
--- a/service-front/module/Application/src/Form/AbstractForm.php
+++ b/service-front/module/Application/src/Form/AbstractForm.php
@@ -23,20 +23,25 @@ abstract class AbstractForm extends Form
      */
     protected function addToInputFilter(array $inputData)
     {
-        //  Merge the required input filters into the input data
-        $inputData = array_merge_recursive([
-            'filters'  => [
-                [
-                    'name' => 'StripTags'
-                ],
-                [
-                    'name' => 'StringTrim'
-                ],
-            ]
-        ], $inputData);
+        // Only add the StripTags and StringTrim filters for
+        // non-password fields; if used for password fields, these
+        // filters strip leading/trailing spaces and remove anything that
+        // looks like HTML, such as <>
+        if (!in_array($inputData['name'], ['password', 'password_confirm', 'password_current'])) {
+            // Merge additional input filters for non-password fields
+            $inputData = array_merge_recursive([
+                'filters'  => [
+                    [
+                        'name' => 'Laminas\Filter\StripTags'
+                    ],
+                    [
+                        'name' => 'Laminas\Filter\StringTrim'
+                    ],
+                ]
+            ], $inputData);
+        }
 
         $filter = $this->getInputFilter();
-
         $filter->add($inputData);
     }
 }

--- a/service-front/module/Application/tests/Form/User/ChangePasswordTest.php
+++ b/service-front/module/Application/tests/Form/User/ChangePasswordTest.php
@@ -15,7 +15,7 @@ class ChangePasswordTest extends MockeryTestCase
     /**
      * Set up the form to test
      */
-    public function setUp() : void
+    public function setUp(): void
     {
         $form = new ChangePasswordForm();
 
@@ -53,6 +53,34 @@ class ChangePasswordTest extends MockeryTestCase
             'password_current'      => 'P@55word',
             'password'              => 'P@55word',
             'password_confirm'      => 'P@55word',
+            'skip_confirm_password' => '0',
+        ], $this->getCsrfData()));
+
+        $this->assertTrue($this->form->isValid());
+
+        $this->assertEquals([], $this->form->getMessages());
+    }
+
+    public function testValidateByModelOKWithHTMLTags()
+    {
+        $this->form->setData(array_merge([
+            'password_current'      => 'P@55word',
+            'password'              => '<>P@55word',
+            'password_confirm'      => '<>P@55word',
+            'skip_confirm_password' => '0',
+        ], $this->getCsrfData()));
+
+        $this->assertTrue($this->form->isValid());
+
+        $this->assertEquals([], $this->form->getMessages());
+    }
+
+    public function testValidateByModelOKWithLeadingAndTrailingSpaces()
+    {
+        $this->form->setData(array_merge([
+            'password_current'      => 'P@55word',
+            'password'              => '  P@55word  ',
+            'password_confirm'      => '  P@55word  ',
             'skip_confirm_password' => '0',
         ], $this->getCsrfData()));
 

--- a/service-front/module/Application/tests/Form/User/RegistrationTest.php
+++ b/service-front/module/Application/tests/Form/User/RegistrationTest.php
@@ -13,7 +13,7 @@ class RegistrationTest extends MockeryTestCase
     /**
      * Set up the form to test
      */
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->setUpForm(new RegistrationForm());
     }
@@ -47,6 +47,54 @@ class RegistrationTest extends MockeryTestCase
             'password'              => 'P@55word',
             'password_confirm'      => 'P@55word',
             'skip_confirm_password' => '0',
+        ], $this->getCsrfData()));
+
+        $this->assertTrue($this->form->isValid());
+
+        $this->assertEquals([], $this->form->getMessages());
+    }
+
+    public function testValidateByModelOKWithHTMLTags()
+    {
+        $this->form->setData(array_merge([
+            'email'                 => 'a@b.com',
+            'email_confirm'         => 'a@b.com',
+            'terms'                 => '1',
+            'password'              => '<>P@55word',
+            'password_confirm'      => '<>P@55word',
+            'skip_confirm_password' => '0',
+        ], $this->getCsrfData()));
+
+        $this->assertTrue($this->form->isValid());
+
+        $this->assertEquals([], $this->form->getMessages());
+    }
+
+    public function testValidateByModelOKWithTrailingAndLeadingSpaces()
+    {
+        $this->form->setData(array_merge([
+            'email'                 => 'a@b.com',
+            'email_confirm'         => 'a@b.com',
+            'terms'                 => '1',
+            'password'              => '  P@55word  ',
+            'password_confirm'      => '  P@55word  ',
+            'skip_confirm_password' => '0',
+        ], $this->getCsrfData()));
+
+        $this->assertTrue($this->form->isValid());
+
+        $this->assertEquals([], $this->form->getMessages());
+    }
+
+    public function testValidateByModelOKWithHTMLTagsAndSkippedConfirm()
+    {
+        $this->form->setData(array_merge([
+            'email'                 => 'a@b.com',
+            'email_confirm'         => 'a@b.com',
+            'terms'                 => '1',
+            'password'              => '<>P@55word',
+            'password_confirm'      => '',
+            'skip_confirm_password' => '1',
         ], $this->getCsrfData()));
 
         $this->assertTrue($this->form->isValid());


### PR DESCRIPTION
## Purpose

[LPAL-1043](https://opgtransform.atlassian.net/browse/LPAL-1043)

## Approach

See ticket.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
