### PR TITLE
LPAL-1035 remove unused otherNames from primary attorney form

### DIFF
--- a/service-front/module/Application/src/Form/Lpa/AttorneyForm.php
+++ b/service-front/module/Application/src/Form/Lpa/AttorneyForm.php
@@ -16,9 +16,6 @@ class AttorneyForm extends AbstractActorForm
         'name-last' => [
             'type' => 'Text',
         ],
-        'otherNames' => [
-            'type' => 'Text',
-        ],
         'dob-date' => [
             'type' => 'Application\Form\Fieldset\Dob',
         ],

--- a/service-front/module/Application/tests/Form/Lpa/AttorneyFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/AttorneyFormTest.php
@@ -13,7 +13,7 @@ class AttorneyFormTest extends MockeryTestCase
     /**
      * Set up the form to test
      */
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->setUpForm(new AttorneyForm());
     }
@@ -33,7 +33,6 @@ class AttorneyFormTest extends MockeryTestCase
         $this->assertInstanceOf('Laminas\Form\Element\Text', $this->form->get('name-title'));
         $this->assertInstanceOf('Laminas\Form\Element\Text', $this->form->get('name-first'));
         $this->assertInstanceOf('Laminas\Form\Element\Text', $this->form->get('name-last'));
-        $this->assertInstanceOf('Laminas\Form\Element\Text', $this->form->get('otherNames'));
         $this->assertInstanceOf('Application\Form\Fieldset\Dob', $this->form->get('dob-date'));
         $this->assertInstanceOf('Laminas\Form\Element\Email', $this->form->get('email-address'));
         $this->assertInstanceOf('Laminas\Form\Element\Text', $this->form->get('address-address1'));

--- a/service-front/module/Application/view/application/authenticated/lpa/primary-attorney/person-form.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/primary-attorney/person-form.twig
@@ -20,9 +20,6 @@
         'cannot-be-blank' : 'Enter the attorney\'s last name',
         'must-be-less-than-or-equal:50' : 'Enter a last name that\'s less than 51 characters long'
     },
-    'otherNames' : {
-        'must-be-less-than-or-equal:50' : 'Enter other names that are less than 51 characters long'
-    },
     'email-address' : {
         'invalid-email-address' : 'Enter a valid email address'
     },
@@ -153,7 +150,6 @@
 {{ title.setOptions({label:'Title'}) ? '' }}
 {{ firstname.setOptions({label:'First names'}) ? '' }}
 {{ lastname.setOptions({label:'Last name'}) ? '' }}
-{{ otherNames.setOptions({label:'Other names'}) ? '' }}
 {{ dob.setOptions({label:'Date of Birth'}) ? '' }}
 {{ dobDay.setOptions({label:'Day'}) ? '' }}
 {{ dobMonth.setOptions({label:'Month'}) ? '' }}


### PR DESCRIPTION
## Purpose

_Remove unusued otherNames field from primary attorney form - legacy code cleanup and security improvement. (Note that otherNames IS used for donor,  but only the donor,  not relevant for attorneys)_

## Approach

_Take otherNames out of the relevant php, twig, test_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
