### PR TITLE
LPAL-1041 Allow Jira actions to fail in GHA

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -259,12 +259,14 @@ jobs:
     steps:
     - name: Login to Jira
       uses: atlassian/gajira-login@master
+      continue-on-error: true
       env:
         JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
         JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
         JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
     - name: Find in commit messages
       uses: atlassian/gajira-find-issue-key@master
+      continue-on-error: true
       id: jira_ticket
       with:
         string: ${{ github.event.pull_request.title }}
@@ -408,6 +410,7 @@ jobs:
     steps:
     - name: Login to Jira
       uses: atlassian/gajira-login@master
+      continue-on-error: true
       env:
         JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
         JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -416,6 +419,7 @@ jobs:
     - name: Find in commit messages
       uses: atlassian/gajira-find-issue-key@master
       id: jira_ticket
+      continue-on-error: true
       with:
         string: ${{ github.event.pull_request.title }}
 


### PR DESCRIPTION
## Purpose

Allow Jira actions to fail in Github Actions in case ticket number is missing 

Fixes LPAL-1041

## Approach

Add `continue-on-error: true` to Jira steps.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
