### PR TITLE
LPAL-1071 Pull busybox from ECR

### DIFF
--- a/terraform/environment/modules/environment/locals.tf
+++ b/terraform/environment/modules/environment/locals.tf
@@ -82,7 +82,7 @@ locals {
   app_init_container = jsonencode(
     {
       "name" : "permissions-init",
-      "image" : "busybox:latest",
+      "image" : "public.ecr.aws/docker/library/busybox:stable",
       "entryPoint" : [
         "sh",
         "-c"


### PR DESCRIPTION
## Purpose

Pull busybox from official DockerHub ECR mirror to avoid DockerHub pull limits.

Fixes LPAL-1071

## Approach

Changes image of initContainer.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
