### PR TITLE
LPAL-1072 Fix typo in Aurora CloudWatch events

### DIFF
--- a/terraform/region/modules/region/lambda_aurora_scheduler.tf
+++ b/terraform/region/modules/region/lambda_aurora_scheduler.tf
@@ -53,7 +53,7 @@ resource "aws_cloudwatch_event_target" "start_schedule_lambda" {
   rule      = aws_cloudwatch_event_rule.start_schedule[0].name
   target_id = "lambda_function"
   arn       = one(module.aurora_scheduler[*].lambda_function.arn)
-  input     = "{\"commands\":[\"start\"]}"
+  input     = "{\"command\":[\"start\"]}"
 }
 
 resource "aws_cloudwatch_event_target" "stop_schedule_lambda" {
@@ -61,7 +61,7 @@ resource "aws_cloudwatch_event_target" "stop_schedule_lambda" {
   rule      = aws_cloudwatch_event_rule.stop_schedule[0].name
   target_id = "lambda_function"
   arn       = one(module.aurora_scheduler[*].lambda_function.arn)
-  input     = "{\"commands\":[\"stop\"]}"
+  input     = "{\"command\":[\"stop\"]}"
 }
 
 resource "aws_lambda_permission" "allow_events_bridge_start_lambda" {


### PR DESCRIPTION
## Purpose

Fix a typo in the Aurora CloudWatch events cron job

Fixes LPAL-1072

## Approach

Change "commands" to "command".

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
