### PR TITLE
LPAL-1082 Handle connection errors gracefully without leaking stacktrace to logs

### DIFF
--- a/service-api/module/Application/src/Model/DataAccess/Postgres/DbWrapper.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/DbWrapper.php
@@ -4,6 +4,7 @@ namespace Application\Model\DataAccess\Postgres;
 
 use Laminas\Db\Adapter\Adapter;
 use Laminas\Db\Adapter\Driver\ResultInterface;
+use Laminas\Db\Adapter\Exception\RuntimeException as LaminasDbAdapterRuntimeException;
 use Laminas\Db\Metadata\Object\TableObject;
 use Laminas\Db\Metadata\Source\Factory as DbMetadataFactory;
 use Laminas\Db\ResultSet\ResultSet;
@@ -104,6 +105,7 @@ class DbWrapper
      * ]
      *
      * @return ResultInterface
+     * @throws LaminasDbAdapterRuntimeException
      */
     public function select(string $tableName, array $criteria = [], array $options = []): ResultInterface
     {
@@ -140,6 +142,7 @@ class DbWrapper
             $select->columns($options['columns']);
         }
 
+        /** @throws LaminasDbAdapterRuntimeException */
         return $sql->prepareStatementForSqlObject($select)->execute();
     }
 }

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/UserData.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/UserData.php
@@ -13,6 +13,7 @@ use Laminas\Db\Sql\Predicate\IsNull;
 use Laminas\Db\Sql\Predicate\IsNotNull;
 use Laminas\Db\Sql\Predicate\Like;
 use Laminas\Db\Sql\Predicate\PredicateSet;
+use Laminas\Db\Adapter\Exception\RuntimeException as LaminasDbAdapterRuntimeException;
 use MakeShared\DataModel\User\User as ProfileUserModel;
 use Application\Model\DataAccess\Postgres\AbstractBase;
 use Application\Model\DataAccess\Postgres\ApplicationData;
@@ -33,7 +34,12 @@ class UserData extends AbstractBase implements UserRepository\UserRepositoryInte
      */
     private function getByField(array $where): ?array
     {
-        $result = $this->dbWrapper->select(self::USERS_TABLE, $where, ['limit' => 1]);
+        try {
+            $result = $this->dbWrapper->select(self::USERS_TABLE, $where, ['limit' => 1]);
+        } catch (LaminasDbAdapterRuntimeException $e) {
+            // this occurs where the select against the db fails
+            return null;
+        }
 
         if (!$result->isQueryResult() || $result->count() != 1) {
             return null;


### PR DESCRIPTION
## Purpose

[LPAL-1082](https://opgtransform.atlassian.net/browse/LPAL-1082)

## Approach

Catch errors from laminas-db adapter when connect() fails.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
