### PR TITLE
LPAL-1084 Create bucket to hold CloudWatch logs

### DIFF
--- a/terraform/region/modules/region/kms.tf
+++ b/terraform/region/modules/region/kms.tf
@@ -20,6 +20,17 @@ resource "aws_kms_alias" "lpa_pdf_cache" {
   target_key_id = aws_kms_key.lpa_pdf_cache.key_id
 }
 
+resource "aws_kms_key" "redacted_logs" {
+  description             = "S3 bucket encryption key for redacted_logs"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "redacted_logs" {
+  name          = "alias/redacted_logs-${terraform.workspace}"
+  target_key_id = aws_kms_key.redacted_logs.key_id
+}
+
 # See the following link for further information
 # https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
 resource "aws_kms_key" "cloudwatch_encryption" {

--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -149,3 +149,47 @@ data "aws_iam_policy_document" "lpa_pdf_cache_policy" {
     }
   }
 }
+
+# A bucket to hold redacted logs until they expired
+
+resource "aws_s3_bucket" "redacted_logs" {
+  bucket = "redacted-logs.${local.account_name}.${local.region_name}.lpa.opg.justice.gov.uk"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "redacted_logs" {
+  bucket = aws_s3_bucket.redacted_logs.bucket
+  rule {
+    id     = "expirelogs"
+    status = "Enabled"
+
+    expiration {
+      days = 120
+    }
+
+
+  }
+}
+
+resource "aws_s3_bucket_acl" "redacted_logs" {
+  bucket = aws_s3_bucket.redacted_logs.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "redacted_logs" {
+  bucket = aws_s3_bucket.access_log.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.redacted_logs.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "redacted_logs" {
+  bucket                  = aws_s3_bucket.redacted_logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+  ignore_public_acls      = true
+}


### PR DESCRIPTION
## Purpose

Create an S3 bucket to hold CloudWatch logs.

Fixes LPAL-1084

## Approach

Create an S3 bucket with 120 day expiration policy and private ACL.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
