### PR TITLE
LPAL-1084 Fix encryption config error

### DIFF
--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -176,7 +176,7 @@ resource "aws_s3_bucket_acl" "redacted_logs" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "redacted_logs" {
-  bucket = aws_s3_bucket.access_log.id
+  bucket = aws_s3_bucket.redacted_logs.id
 
   rule {
     apply_server_side_encryption_by_default {


### PR DESCRIPTION
## Purpose

Fix error with `aws_s3_bucket_server_side_encryption_configuration` of introduced by bad copy and paste.

Fixes LPAL-1084

## Approach

Change aws_s3_bucket.access_logs to aws_s3_bucket.redacted_logs

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
