### PR TITLE
LPAL-1074 Correct rule for allowing ON keyword

### DIFF
--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -12,7 +12,7 @@ resource "aws_wafv2_web_acl" "main" {
     priority = 5
 
     action {
-      count {}
+      allow {}
     }
 
     statement {
@@ -20,11 +20,7 @@ resource "aws_wafv2_web_acl" "main" {
         arn = aws_wafv2_regex_pattern_set.allow_on_keyword.arn
 
         field_to_match {
-          json_body {
-            match_pattern {
-              all {}
-            }
-            match_scope       = "ALL"
+          body {
             oversize_handling = "CONTINUE"
           }
         }

--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -20,9 +20,7 @@ resource "aws_wafv2_web_acl" "main" {
         arn = aws_wafv2_regex_pattern_set.allow_on_keyword.arn
 
         field_to_match {
-          body {
-            oversize_handling = "CONTINUE"
-          }
+          body {}
         }
 
         text_transformation {


### PR DESCRIPTION
## Purpose

Correct the rule for allowing ON keyword

Fixes LPAL-1074

## Approach

Change from json_body to just body and explicitly allow to terminate rule evaluation immediately

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
