### PR TITLE
LPAL-969 Promote a single artifact through environments

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -62,12 +62,12 @@ jobs:
           - image_name: online-lpa/cypress
             service_path: ./cypress/
             override_tag: latest
-            force_push_to_repo: true
+            force_push_to_repo: false
 
           - image_name: lambda-aurora_scheduler
             service_path: ./aurora-scheduler/docker
             override_tag: latest
-            force_push_to_repo: true
+            force_push_to_repo: false
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -37,9 +37,12 @@ jobs:
     outputs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
     steps:
-      - name: Set output to short SHA
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+      - name: Set output to penultimate short SHA
         id: short_sha
-        run: echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+        run: |
+          echo "short_sha=$(git rev-list --no-merges -n 1 HEAD | cut -c1-7)" >> $GITHUB_OUTPUT
 
   docker_build_scan_push:
     name: Docker Build, Scan and Push

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -44,7 +44,9 @@ jobs:
     steps:
       - name: Set output to short SHA
         id: short_sha
-        run: echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+        env:
+          HEAD_GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+        run: echo "short_sha=${HEAD_GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
   terraform_lint:
     name: TF - Lint


### PR DESCRIPTION
## Purpose

Promote container images through environments rather than rebuilding the same code for higher environments

Fixes LPAL-969

## Approach

The container image gets created in the PR workflow and tagged with the first 7 characters of the commit SHA. When / if this gets merged into `main`, the Path to Live workflow extracts the first 7 characters of the penultimate commit (ignoring the merge commit) and checks if the image with that tag exists in ECR already. If it does, it will deploy that to preprod and prod. If not, it will recreate the image, tag it with the penultimate short commit SHA and then push to ECR.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
