### PR TITLE
LPAL-1108 Block download of potentially sensitive filename patterns

### DIFF
--- a/cypress/e2e/Errors.feature
+++ b/cypress/e2e/Errors.feature
@@ -58,8 +58,8 @@ Feature: Errors
         And "error-heading" is a "level 2 heading" element
         And there is "one" "level 1 heading" element on the page
 
-    Scenario: 404 error is returned for potentially sensitive resources (LPAL-1108)
+    Scenario: 403 error is returned for potentially sensitive resources (LPAL-1108)
         Given the forbidden filename patterns
             |zip|gz|lzh|tar|rar|7z|swp|bak|git|ht|exe|dll|py|msi|bin|sh|bat|xml|apk|jar|log|sql|conf|cfg|ini|tmp|doc|xls|rtf|
         When I attempt to fetch a resource matching each forbidden filename pattern
-        Then I get a 404 response code for each resource
+        Then I get a 403 response code for each resource

--- a/cypress/e2e/Errors.feature
+++ b/cypress/e2e/Errors.feature
@@ -6,7 +6,6 @@ Feature: Errors
     Background:
         Given I ignore application exceptions
 
-    @focus
     Scenario: Error message heading level and text / server-rendered (LPAL-247)
         Given I visit "/send-feedback"
         When I submit the feedback
@@ -15,7 +14,6 @@ Feature: Errors
         And "error-heading" is a "level 2 heading" element
         And there is "one" "level 1 heading" element on the page
 
-    @focus
     # requires additional scenarios as login page doesn't use the error macro;
     # this path attempts to log the user in and fails, but doesn't use
     # the same path through the code as invalid form fields (see below);
@@ -31,7 +29,6 @@ Feature: Errors
         And "error-heading" is a "level 2 heading" element
         And there is "one" "level 1 heading" element on the page
 
-    @focus
     Scenario: Fail to select type of LPA to create, error links to first radio (LPAL-248, LPAL-254)
         When I log in as appropriate test user
         And If I am on dashboard I click to create lpa
@@ -51,7 +48,6 @@ Feature: Errors
     # requires additional scenarios as login page doesn't use the error macro;
     # this scenario covers invalid email entered, which uses a different branch
     # of the code from a failed user login
-    @focus
     Scenario: Error message heading level and text / server-rendered auth - invalid email (LPAL-247)
         Given I visit "/login"
         And I type "foo" into "login-email"
@@ -61,3 +57,9 @@ Feature: Errors
         And I see "Error" in the title
         And "error-heading" is a "level 2 heading" element
         And there is "one" "level 1 heading" element on the page
+
+    Scenario: 404 error is returned for potentially sensitive resources (LPAL-1108)
+        Given the forbidden filename patterns
+            |zip|gz|lzh|tar|rar|7z|swp|bak|git|ht|exe|dll|py|msi|bin|sh|bat|xml|apk|jar|log|sql|conf|cfg|ini|tmp|doc|xls|rtf|
+        When I attempt to fetch a resource matching each forbidden filename pattern
+        Then I get a 404 response code for each resource

--- a/cypress/e2e/common/errors.js
+++ b/cypress/e2e/common/errors.js
@@ -21,10 +21,10 @@ Then(
   },
 );
 
-Then('I get a 404 response code for each resource', () => {
+Then('I get a 403 response code for each resource', () => {
   cy.get('@forbiddenFileResponses').each((forbiddenFileResponse) => {
     cy.get(forbiddenFileResponse).then((response) => {
-      expect(response.status).to.eql(404);
+      expect(response.status).to.eql(403);
     });
   });
 });

--- a/cypress/e2e/common/errors.js
+++ b/cypress/e2e/common/errors.js
@@ -1,0 +1,30 @@
+import { Then } from '@badeball/cypress-cucumber-preprocessor';
+
+Then('the forbidden filename patterns', (dataTable) => {
+  cy.wrap(dataTable.rawTable[0]).as('forbiddenFilePatterns');
+});
+
+Then(
+  'I attempt to fetch a resource matching each forbidden filename pattern',
+  () => {
+    let aliases = [];
+
+    cy.get('@forbiddenFilePatterns').each((forbiddenFilePattern) => {
+      aliases.push('@' + forbiddenFilePattern);
+      cy.request({
+        url: '/foo.' + forbiddenFilePattern,
+        failOnStatusCode: false,
+      }).as(forbiddenFilePattern);
+    });
+
+    cy.wrap(aliases).as('forbiddenFileResponses');
+  },
+);
+
+Then('I get a 404 response code for each resource', () => {
+  cy.get('@forbiddenFileResponses').each((forbiddenFileResponse) => {
+    cy.get(forbiddenFileResponse).then((response) => {
+      expect(response.status).to.eql(404);
+    });
+  });
+});

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -91,9 +91,9 @@ server {
     add_header Strict-Transport-Security $sts;
 
     # block potentially sensitive files in case they were accidentally added to web root
-    # using a 404 as per https://httpwg.org/specs/rfc9110.html#status.404
+    # using a 403 to match status returned by WAF for bad filenames
     location ~ "^/.*\.(zip|gz|lzh|tar|rar|7z|swp|bak|git|ht|exe|dll|py|msi|bin|sh|bat|xml|apk|jar|log|sql|conf|cfg|ini|tmp|doc|xls|rtf)" {
-        return 404;
+        return 403;
     }
 
     location / {

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -79,7 +79,7 @@ server {
     gzip on;
     gzip_min_length 100;
     gzip_vary on;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
+    gzip_types text/plain text/css application/json application/javascript image/svg+xml;
 
     root /web;
 
@@ -89,6 +89,11 @@ server {
     add_header X-Frame-Options $xfo;
     add_header X-Content-Type-Options $xcto;
     add_header Strict-Transport-Security $sts;
+
+    # block potentially sensitive files in case they were accidentally added to web root
+    location ~ "^/.*\.(zip|gz|lzh|tar|rar|7z|swp|bak|git|ht|exe|dll|py|msi|bin|sh|bat|xml|apk|jar|log|sql|conf|cfg|ini|tmp|doc|xls|rtf)" {
+        return 403;
+    }
 
     location / {
         try_files $uri /index.php$is_args$args;
@@ -154,13 +159,6 @@ server {
         # http://domain.tld/app.php/some-path
         # Remove the internal directive to allow URIs like this
         #internal;
-    }
-
-    # deny access to .htaccess files, if Apache's document root
-    # concurs with nginx's one
-    #
-    location ~ /\.ht {
-        deny  all;
     }
 
     # Comply with https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -91,8 +91,9 @@ server {
     add_header Strict-Transport-Security $sts;
 
     # block potentially sensitive files in case they were accidentally added to web root
+    # using a 404 as per https://httpwg.org/specs/rfc9110.html#status.404
     location ~ "^/.*\.(zip|gz|lzh|tar|rar|7z|swp|bak|git|ht|exe|dll|py|msi|bin|sh|bat|xml|apk|jar|log|sql|conf|cfg|ini|tmp|doc|xls|rtf)" {
-        return 403;
+        return 404;
     }
 
     location / {


### PR DESCRIPTION
## Purpose

[LPAL-1108](https://opgtransform.atlassian.net/browse/LPAL-1108)

## Approach

See ticket.

## Learning

nginx config

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
