### PR TITLE
LPAL-1111 Make use of Accept* headers and charsets more consistent

### DIFF
--- a/cypress/e2e/common/encoding.js
+++ b/cypress/e2e/common/encoding.js
@@ -1,0 +1,10 @@
+const { After } = require('@badeball/cypress-cucumber-preprocessor');
+
+// Test encoding of every page after loading it during a test
+After(() => {
+  cy.document().then((doc) => {
+    expect(doc.characterSet).to.eql('UTF-8');
+    expect(doc.doctype.name).to.eql('html');
+    expect(doc.contentType).to.eql('text/html');
+  });
+});

--- a/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
+++ b/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
@@ -175,7 +175,10 @@ class Service extends AbstractService
      */
     private function buildHeaders()
     {
-        return ['Accept' => 'application/json'];
+        return [
+            'Accept' => 'application/json',
+            'Accept-Language' => 'en'
+        ];
     }
 
     private function handleResponse(string $responseBodyString)

--- a/service-front/assets/js/moj/moj.modules/moj.postcode-lookup.js
+++ b/service-front/assets/js/moj/moj.modules/moj.postcode-lookup.js
@@ -196,6 +196,10 @@
       $.ajax({
         url: this.settings.postcodeSearchUrl,
         data: { postcode: query },
+        headers: {
+          Accept: 'application/json',
+          'Accept-Language': 'en',
+        },
         dataType: 'json',
         timeout: 10000,
         cache: true,

--- a/service-front/module/Application/src/Model/Service/AddressLookup/OrdnanceSurvey.php
+++ b/service-front/module/Application/src/Model/Service/AddressLookup/OrdnanceSurvey.php
@@ -78,7 +78,12 @@ class OrdnanceSurvey
         $url = URI::withQueryValue($url, 'postcode', $postcode);
         $url = URI::withQueryValue($url, 'lr', 'EN');
 
-        $request = new Request('GET', $url);
+        $headers = [
+            'Accept' => 'application/json',
+            'Accept-Language' => 'en',
+        ];
+
+        $request = new Request('GET', $url, $headers);
 
         $response = $this->httpClient->sendRequest($request);
 

--- a/service-front/module/Application/src/Model/Service/ApiClient/Client.php
+++ b/service-front/module/Application/src/Model/Service/ApiClient/Client.php
@@ -216,9 +216,10 @@ class Client
     private function buildHeaders($anonymous = false)
     {
         $headers = [
-            'Accept'        => 'application/json',
-            'Content-type'  => 'application/json',
-            'User-agent'    => 'LPA-FRONT'
+            'Accept' => 'application/json',
+            'Accept-Language' => 'en',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'LPA-FRONT',
         ];
 
         foreach ($this->defaultHeaders as $name => $value) {

--- a/service-front/module/Application/src/Model/Service/ApiClient/Client.php
+++ b/service-front/module/Application/src/Model/Service/ApiClient/Client.php
@@ -218,7 +218,7 @@ class Client
         $headers = [
             'Accept' => 'application/json',
             'Accept-Language' => 'en',
-            'Content-Type' => 'application/json',
+            'Content-Type' => 'application/json; charset=utf-8',
             'User-Agent' => 'LPA-FRONT',
         ];
 

--- a/service-front/module/Application/tests/Model/Service/ApiClient/ClientTest.php
+++ b/service-front/module/Application/tests/Model/Service/ApiClient/ClientTest.php
@@ -72,7 +72,7 @@ class ClientTest extends MockeryTestCase
                             new Uri($url),
                             ['Accept' => 'application/json',
                                 'Accept-Language' => 'en',
-                                'Content-Type' => 'application/json',
+                                'Content-Type' => 'application/json; charset=utf-8',
                                 'User-Agent' => 'LPA-FRONT',
                                 'Token' => $token]
                         )

--- a/service-front/module/Application/tests/Model/Service/ApiClient/ClientTest.php
+++ b/service-front/module/Application/tests/Model/Service/ApiClient/ClientTest.php
@@ -71,8 +71,9 @@ class ClientTest extends MockeryTestCase
                             $verb,
                             new Uri($url),
                             ['Accept' => 'application/json',
-                                'Content-type' => 'application/json',
-                                'User-agent' => 'LPA-FRONT',
+                                'Accept-Language' => 'en',
+                                'Content-Type' => 'application/json',
+                                'User-Agent' => 'LPA-FRONT',
                                 'Token' => $token]
                         )
                     )]

--- a/service-front/module/Application/view/application/authenticated/dashboard/index.twig
+++ b/service-front/module/Application/view/application/authenticated/dashboard/index.twig
@@ -132,7 +132,9 @@
                     url: "/user/dashboard/statuses/" + ids.join(),
                     dataType: "json",
                     headers: {
-                        'X-SessionReadOnly': 'true'
+                        'X-SessionReadOnly': 'true',
+                        'Accept': 'application/json',
+                        'Accept-Language': 'en'
                     },
                     success: function (results) {
                         // Loop through all the ids that were requested and update the text css style to the new status


### PR DESCRIPTION
## Purpose

[LPAL-1111](https://opgtransform.atlassian.net/browse/LPAL-1111)

## Approach

See ticket.

## Learning

n/a

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [x] I have added mandatory tags to terraformed resources, where possible
* [x] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [x] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
