### PR TITLE
LPAL-1115 Fix destroy workspace on merge to main

### DIFF
--- a/.github/workflows/workflow_destroy_on_merge.yml
+++ b/.github/workflows/workflow_destroy_on_merge.yml
@@ -55,4 +55,4 @@ jobs:
 
       - name: Run workspace cleanup
         run: |
-          scripts/pipeline/workspace_cleanup/workspace_cleanup.sh ${{ needs.workspace_name.outputs.name }}
+          scripts/pipeline/workspace_cleanup/destroy_workspace.sh ${{ needs.workspace_name.outputs.name }}

--- a/scripts/pipeline/workspace_cleanup/destroy_workspace.sh
+++ b/scripts/pipeline/workspace_cleanup/destroy_workspace.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# A script to destroy a single workspace
+# Usage: ./destroy_workspace.sh <workspace_name>
+
+set -Eeuo pipefail
+
+print_usage() {
+  echo "Usage: `basename $0` [workspace]"
+}
+
+if [ -z "$1" ]; then
+    print_usage
+    exit 1
+fi
+
+if [ "$1" == "-h" ]; then
+  print_usage
+  exit 0
+fi
+
+workspace_name=$1
+reserved_workspaces="default production preproduction development demo ithc"
+
+for workspace in $reserved_workspaces; do
+  if [ "$workspace" == "$workspace_name" ]; then
+    echo "protected workspace: $workspace. refusing to destroy."
+    exit 1
+  fi
+done
+
+echo "cleaning up workspace $workspace_name..."
+terraform workspace select $workspace_name
+terraform init 
+terraform destroy -auto-approve
+terraform workspace select default
+terraform workspace delete $workspace_name

--- a/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
+++ b/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
 
-if [ $# -eq 0 ]
-  then
-    echo "Please provide workspaces to be removed."
+# A script to destroy all workspaces except for the ones passed in as arguments
+# Usage: ./workspace_cleanup.sh <workspace1> <workspace2> <workspace3> ...
+
+set -Eeuo pipefail
+
+print_usage() {
+  echo "Usage: `basename $0` [workspace1] [workspace2] [workspace3] ..."
+}
+
+if [ -z "$1" ]; then
+    print_usage
+    exit 1
 fi
 
 if [ "$1" == "-h" ]; then
-  echo "Usage: `basename $0` [workspaces separated by a space]"
+  print_usage
   exit 0
 fi
-
-function getWorkspaces {
-  terraform workspace list
-}
 
 in_use_workspaces="$@"
 reserved_workspaces="default production preproduction development demo ithc"


### PR DESCRIPTION
## Purpose

Destroy temporary workspaces on merge to main

Fixes LPAL-1115

## Approach

Write a second script to destroy a single workspace and update the workspace_cleanup script to have accurate help text.

## Learning

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
