### PR TITLE
LPAL-1116 Use penultimate commit in weekly refresh

### DIFF
--- a/.github/workflows/workflow_destroy_on_merge.yml
+++ b/.github/workflows/workflow_destroy_on_merge.yml
@@ -56,4 +56,4 @@ jobs:
       - name: Run workspace cleanup
         working-directory: ./terraform/environment
         run: |
-          scripts/pipeline/workspace_cleanup/destroy_workspace.sh ${{ needs.workspace_name.outputs.name }}
+          ../../scripts/pipeline/workspace_cleanup/destroy_workspace.sh ${{ needs.workspace_name.outputs.name }}

--- a/.github/workflows/workflow_weekly_refresh.yml
+++ b/.github/workflows/workflow_weekly_refresh.yml
@@ -32,9 +32,14 @@ jobs:
     outputs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
     steps:
-      - name: Set output to short SHA
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+        with:
+          fetch-depth: 2
+      - name: Set output to penultimate short SHA
         id: short_sha
-        run: echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+        run: |
+          echo "short_sha=$(git rev-list --no-merges -n 1 HEAD | cut -c1-7)" >> $GITHUB_OUTPUT
 
   docker_build_scan_push:
     name: Docker Build, Scan and Push


### PR DESCRIPTION
## Purpose

Use the penultimate commit SHA in weekly refresh

Fixes LPAL-1116

## Approach

Change the Weekly Refresh workflow to be consistent with the normal Path to Live

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
