### PR TITLE
LPAL-1115 Do not assume dev role

### DIFF
--- a/.github/workflows/workflow_destroy_on_merge.yml
+++ b/.github/workflows/workflow_destroy_on_merge.yml
@@ -49,9 +49,8 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
           aws-region: eu-west-1
-          role-to-assume: arn:aws:iam::050256574573:role/opg-lpa-ci
           role-duration-seconds: 900
-          role-session-name: OPGLPABuildPipeline
+          role-session-name: OPGLPADestroyEphemeralEnvironment
 
       - name: Run workspace cleanup
         working-directory: ./terraform/environment

--- a/scripts/pipeline/workspace_cleanup/destroy_workspace.sh
+++ b/scripts/pipeline/workspace_cleanup/destroy_workspace.sh
@@ -30,8 +30,8 @@ for workspace in $reserved_workspaces; do
 done
 
 echo "cleaning up workspace $workspace_name..."
+terraform init -input=false
 terraform workspace select $workspace_name
-terraform init 
 terraform destroy -auto-approve
 terraform workspace select default
 terraform workspace delete $workspace_name


### PR DESCRIPTION
## Purpose

Do not assume the dev role when destroying workspaces

Fixes LPAL-1115

## Approach

Removes the assume-role before running the destroy ephemeral workspace script

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
