### PR TITLE
LPAL-1118 Cleanup DB locals

### DIFF
--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -340,9 +340,9 @@ locals {
       ],
       "environment" : [
         { "name" : "OPG_NGINX_SERVER_NAMES", "value" : "api api-${var.environment_name}.${var.account_name} localhost 127.0.0.1" },
-        { "name" : "OPG_LPA_POSTGRES_HOSTNAME", "value" : local.db.endpoint },
-        { "name" : "OPG_LPA_POSTGRES_PORT", "value" : tostring(local.db.port) },
-        { "name" : "OPG_LPA_POSTGRES_NAME", "value" : local.db.name },
+        { "name" : "OPG_LPA_POSTGRES_HOSTNAME", "value" : module.api_aurora[0].endpoint },
+        { "name" : "OPG_LPA_POSTGRES_PORT", "value" : tostring(module.api_aurora[0].port) },
+        { "name" : "OPG_LPA_POSTGRES_NAME", "value" : module.api_aurora[0].name },
         { "name" : "OPG_LPA_PROCESSING_STATUS_ENDPOINT", "value" : var.account.sirius_api_gateway_endpoint },
         { "name" : "OPG_LPA_API_TRACK_FROM_DATE", "value" : local.track_from_date },
         { "name" : "OPG_LPA_SEED_DATA", "value" : "true" },

--- a/terraform/environment/modules/environment/ecs_feedbackdb.tf
+++ b/terraform/environment/modules/environment/ecs_feedbackdb.tf
@@ -98,9 +98,9 @@ locals {
         { "name" : "OPG_LPA_POSTGRES_FEEDBACK_PASSWORD", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.performance_platform_db_password.name}" }
       ],
       "environment" : [
-        { "name" : "OPG_LPA_POSTGRES_NAME", "value" : "${local.db.name}" },
-        { "name" : "OPG_LPA_POSTGRES_HOSTNAME", "value" : "${local.db.endpoint}" },
-        { "name" : "OPG_LPA_POSTGRES_PORT", "value" : "${tostring(local.db.port)}" },
+        { "name" : "OPG_LPA_POSTGRES_NAME", "value" : "${module.api_aurora[0].name}" },
+        { "name" : "OPG_LPA_POSTGRES_HOSTNAME", "value" : "${module.api_aurora[0].endpoint}" },
+        { "name" : "OPG_LPA_POSTGRES_PORT", "value" : "${tostring(module.api_aurora[0].port)}" },
         { "name" : "OPG_LPA_STACK_ENVIRONMENT", "value" : "${var.account_name}" }
       ]
   })

--- a/terraform/environment/modules/environment/ecs_seeding.tf
+++ b/terraform/environment/modules/environment/ecs_seeding.tf
@@ -83,9 +83,9 @@ locals {
         { "name" : "OPG_LPA_POSTGRES_PASSWORD", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.api_rds_password.name}" }
       ],
       "environment" : [
-        { "name" : "OPG_LPA_POSTGRES_NAME", "value" : "${local.db.name}" },
-        { "name" : "OPG_LPA_POSTGRES_HOSTNAME", "value" : "${local.db.endpoint}" },
-        { "name" : "OPG_LPA_POSTGRES_PORT", "value" : "${tostring(local.db.port)}" },
+        { "name" : "OPG_LPA_POSTGRES_NAME", "value" : "${module.api_aurora[0].name}" },
+        { "name" : "OPG_LPA_POSTGRES_HOSTNAME", "value" : "${module.api_aurora[0].endpoint}" },
+        { "name" : "OPG_LPA_POSTGRES_PORT", "value" : "${tostring(module.api_aurora[0].port)}" },
         { "name" : "OPG_LPA_STACK_ENVIRONMENT", "value" : "${var.account_name}" }
       ]
   })

--- a/terraform/environment/modules/environment/locals.tf
+++ b/terraform/environment/modules/environment/locals.tf
@@ -1,12 +1,5 @@
 locals {
 
-  db = { #will be removed once we use aurora in pre and production.
-    endpoint = var.account.aurora_enabled ? module.api_aurora[0].endpoint : aws_db_instance.api[0].address
-    port     = var.account.aurora_enabled ? module.api_aurora[0].port : aws_db_instance.api[0].port
-    name     = var.account.aurora_enabled ? module.api_aurora[0].name : aws_db_instance.api[0].name
-    username = var.account.aurora_enabled ? module.api_aurora[0].master_username : aws_db_instance.api[0].username
-  }
-
   account_name_short = var.account.account_name_short
 
   cert_prefix_public_facing   = var.environment_name == "production" ? "www." : "*."


### PR DESCRIPTION
## Purpose

Cleanup unnecessary DB local variables in Terraform code

Fixes LPAL-1118

## Approach

Uses the module output values directly rather than having unnecessary ternaries to set local vars
 
## Learning

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
