### PR TITLE
LPAL-1119 Adding missing env vars

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -167,6 +167,8 @@ jobs:
         if: github.ref == 'refs/heads/main'
         env: 
           IMAGE_TAG: ${{ steps.set_image_tag.outputs.image_tag }}
+          IMAGE_NAME: ${{ matrix.image_name }}
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
         run: |
           docker buildx imagetools create $ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG --tag $ECR_REGISTRY/$IMAGE_NAME:main-$IMAGE_TAG
     


### PR DESCRIPTION
## Purpose

Fix Path to Live by adding missing env vars to Docker build step

Fixes LPAL-1119

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
