### PR TITLE
LPAL-970 Run Cypress tests on Github Actions runner

### DIFF
--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -79,6 +79,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
+            ~/.cache/Cypress
             node_modules
           key: node-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 

--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -96,6 +96,10 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: OPGLPACypressTestsCypressS3Monitor
 
+      - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3.5.1
+        with:
+          node-version: 16
+
       - name: Run Cypress Tests - ${{ inputs.cypress_tags }}
         env:
           CYPRESS_adminUrl: ${{ inputs.admin_url }}
@@ -106,30 +110,21 @@ jobs:
           CYPRESS_RUNNER_TAGS: ${{ inputs.cypress_tags }}
           CYPRESS_RUNNER_BASE_URL: ${{ inputs.front_url }}
           CYPRESS_RUNNER_ADMIN_URL: ${{ inputs.admin_url }}
+          CYPRESS_VIDEO: false
+          CYPRESS_RUN_A11Y_TESTS: true
 
         run: |
-          docker run --pull never \
-                  -e AWS_ACCESS_KEY_ID \
-                  -e AWS_SECRET_ACCESS_KEY \
-                  -e AWS_SESSION_TOKEN \
-                  -e CYPRESS_NO_COMMAND_LOG \
-                  -e CYPRESS_numTestsKeptInMemory \
-                  -e CYPRESS_RUNNER_IN_CI \
-                  -e CYPRESS_RUNNER_TAGS \
-                  -e CYPRESS_RUNNER_BASE_URL \
-                  -e CYPRESS_RUNNER_ADMIN_URL \
-                  -e CYPRESS_baseUrl \
-                  -e CYPRESS_adminUrl \
-                  --mount type=bind,source="/tmp/screenshots",target="/app/cypress/screenshots" \
-                  --entrypoint ./cypress/cypress_start.sh \
-                  cypress:latest
+          pip install boto3
+          npm install . 
+          mkdir -p /app/cypress/screenshots
+          ./cypress/cypress_start.sh
 
       - name: Upload Screenshot Artifact
         if: failure()
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: cypress-screenshots
-          path: /tmp/screenshots/
+          path: /app/cypress/screenshots
 
       - name: Configure AWS Credentials
         if: always()

--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          pwd
+          ls -la
           python -m pip install --upgrade pip
           pip install -r scripts/pipeline/ci_ingress/requirements.txt
 

--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -96,9 +96,20 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: OPGLPACypressTestsCypressS3Monitor
 
+      - uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+          key: node-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
       - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3.5.1
         with:
           node-version: 16
+
+      - name: Cypress install
+        uses: cypress-io/github-action@v5.0.2
+        with:
+          runTests: false
 
       - name: Run Cypress Tests - ${{ inputs.cypress_tags }}
         env:

--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -33,6 +33,9 @@ jobs:
   cypress_tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+
       - name: Configure AWS Credentials - Security Group & ECR
         uses: aws-actions/configure-aws-credentials@abcf4fe216d7ea3638573156b36c79de8439257a # pin@v1-node16
         with:
@@ -50,8 +53,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pwd
-          ls -la
           python -m pip install --upgrade pip
           pip install -r scripts/pipeline/ci_ingress/requirements.txt
 
@@ -85,11 +86,6 @@ jobs:
         with:
           node-version: 16
 
-      - name: Cypress install
-        uses: cypress-io/github-action@v5.0.2
-        with:
-          runTests: false
-
       - name: Run Cypress Tests - ${{ inputs.cypress_tags }}
         env:
           CYPRESS_adminUrl: ${{ inputs.admin_url }}
@@ -102,7 +98,6 @@ jobs:
           CYPRESS_RUNNER_ADMIN_URL: ${{ inputs.admin_url }}
           CYPRESS_VIDEO: false
           CYPRESS_RUN_A11Y_TESTS: true
-
         run: |
           pip install boto3
           npm install . 

--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -33,9 +33,6 @@ jobs:
   cypress_tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-
       - name: Configure AWS Credentials - Security Group & ECR
         uses: aws-actions/configure-aws-credentials@abcf4fe216d7ea3638573156b36c79de8439257a # pin@v1-node16
         with:
@@ -65,26 +62,6 @@ jobs:
       - name: Add GitHub Actions runner Ingress Rule
         run: |
           python scripts/pipeline/ci_ingress/ci_ingress.py /tmp/environment_pipeline_tasks_config.json --add
-
-      - name: Create screenshots directory
-        run: |
-          mkdir -p /tmp/screenshots
-
-      - name: ECR Login
-        id: login_ecr
-        uses: aws-actions/amazon-ecr-login@9149ade017c57f86dea2f76a01f8b2d5bd06b10f # pin@v1.5.1
-        with:
-          registries: 311462405659
-
-      - name: Pull Cypress Container Image
-        env:
-          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
-          ECR_REGISTRY_ALIAS: online-lpa
-          IMAGE_TAG: latest
-          IMAGE_NAME: cypress
-        run: |
-          docker pull $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$IMAGE_NAME:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$IMAGE_NAME:$IMAGE_TAG $IMAGE_NAME:$IMAGE_TAG
 
       - name: Configure AWS Credentials - Cypress / S3Monitor
         uses: aws-actions/configure-aws-credentials@abcf4fe216d7ea3638573156b36c79de8439257a # pin@v1-node16
@@ -127,7 +104,6 @@ jobs:
         run: |
           pip install boto3
           npm install . 
-          sudo mkdir -p /app/cypress/screenshots && sudo chmod -R 777 /app/cypress/screenshots
           ./cypress/cypress_start.sh
 
       - name: Upload Screenshot Artifact
@@ -135,7 +111,7 @@ jobs:
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: cypress-screenshots
-          path: /app/cypress/screenshots
+          path: cypress/screenshots/
 
       - name: Configure AWS Credentials
         if: always()

--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           pip install boto3
           npm install . 
-          mkdir -p /app/cypress/screenshots
+          sudo mkdir -p /app/cypress/screenshots && sudo chmod -R 777 /app/cypress/screenshots
           ./cypress/cypress_start.sh
 
       - name: Upload Screenshot Artifact

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -58,11 +58,6 @@ jobs:
             dockerfile_path: ./service-seeding/docker/app
             service_path: ./service-seeding
 
-          - image_name: online-lpa/cypress
-            dockerfile_path: ./cypress/
-            service_path: ./cypress/
-            override_tag: latest
-
           - image_name: lambda-aurora_scheduler
             dockerfile_path: ./aurora-scheduler/docker
             service_path: ./aurora-scheduler


### PR DESCRIPTION
## Purpose

Reduce the amount of time taken for Cypress tests to run

Fixes LPAL-970

## Approach

Run Cypress tests directly on Github Actions runner, removing the need to build the Cypress docker container in CI and remove the need to docker pull it.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes


[LPAL-970]: https://opgtransform.atlassian.net/browse/LPAL-970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ