### PR TITLE
LPAL-1120 Fix workspace cleanup to exit cleanly

### DIFF
--- a/scripts/pipeline/workspace_cleanup/destroy_workspace.sh
+++ b/scripts/pipeline/workspace_cleanup/destroy_workspace.sh
@@ -9,9 +9,9 @@ print_usage() {
   echo "Usage: `basename $0` [workspace]"
 }
 
-if [ -z "$1" ]; then
-    print_usage
-    exit 1
+if [ $# -eq 0 ]; then
+  print_usage
+  exit 1
 fi
 
 if [ "$1" == "-h" ]; then

--- a/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
+++ b/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
@@ -9,9 +9,12 @@ print_usage() {
   echo "Usage: `basename $0` [workspace1] [workspace2] [workspace3] ..."
 }
 
-if [ $# -eq 0 ]; then
+if [[ $# -eq 0 && ${CI} != true ]]; then
   print_usage
   exit 1
+elif [[ $# -eq 0 && ${CI} == true ]]; then
+  echo "Nothing to clean up - exiting!"
+  exit 0
 fi
 
 if [ "$1" == "-h" ]; then

--- a/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
+++ b/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
@@ -9,9 +9,9 @@ print_usage() {
   echo "Usage: `basename $0` [workspace1] [workspace2] [workspace3] ..."
 }
 
-if [ -z "$1" ]; then
-    print_usage
-    exit 1
+if [ $# -eq 0 ]; then
+  print_usage
+  exit 1
 fi
 
 if [ "$1" == "-h" ]; then

--- a/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
+++ b/scripts/pipeline/workspace_cleanup/workspace_cleanup.sh
@@ -5,6 +5,8 @@
 
 set -Eeuo pipefail
 
+CI=${CI:-false} # set to true if running in CI
+
 print_usage() {
   echo "Usage: `basename $0` [workspace1] [workspace2] [workspace3] ..."
 }


### PR DESCRIPTION
## Purpose

Fix workspace cleanup to exit cleanly if there are no workspaces to cleanup

Fixes LPAL-1120

## Approach

Change script so that there are no unbound variables

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
