### PR TITLE
LPAL-1098 Correct path of well-known in nginx

### DIFF
--- a/service-api/docker/web/etc/confd/templates/nginx.conf
+++ b/service-api/docker/web/etc/confd/templates/nginx.conf
@@ -109,5 +109,5 @@ server {
     }
 
     # Comply with https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt
-    rewrite ^/.well_known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt permanent;
+    rewrite ^/.well-known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt permanent;
 }

--- a/service-api/docker/web/etc/confd/templates/nginx.conf.dev
+++ b/service-api/docker/web/etc/confd/templates/nginx.conf.dev
@@ -114,5 +114,5 @@ server {
     }
 
     # Comply with https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt
-    rewrite ^/.well_known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt permanent;
+    rewrite ^/.well-known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt permanent;
 }

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -163,5 +163,5 @@ server {
     }
 
     # Comply with https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt
-    rewrite ^/.well_known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt permanent;
+    rewrite ^/.well-known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt permanent;
 }

--- a/shared/docker/web/etc/confd/templates/nginx.conf.service-admin
+++ b/shared/docker/web/etc/confd/templates/nginx.conf.service-admin
@@ -114,5 +114,5 @@ server {
     }
 
     # Comply with https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt
-    rewrite ^/.well_known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt permanent;
+    rewrite ^/.well-known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt permanent;
 }


### PR DESCRIPTION
## Purpose

Fix the path for ./well-known/security.txt so that security researchers are able to contact the MOJ Digital & Technology Security & Privacy team

Fixes LPAL-1098

## Approach

Rename well_known to well-known in nginx configs

## Learning

https://www.rfc-editor.org/rfc/rfc5785

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
