### PR TITLE
LPAL-1123 Remove SendGrid references

### DIFF
--- a/terraform/environment/modules/environment/ecs_cluster.tf
+++ b/terraform/environment/modules/environment/ecs_cluster.tf
@@ -103,8 +103,6 @@ data "aws_iam_policy_document" "execution_role" {
       data.aws_secretsmanager_secret.opg_lpa_front_csrf_salt.arn,
       data.aws_secretsmanager_secret.opg_lpa_api_notify_api_key.arn,
       data.aws_secretsmanager_secret.opg_lpa_admin_jwt_secret.arn,
-      data.aws_secretsmanager_secret.opg_lpa_front_email_sendgrid_webhook_token.arn,
-      data.aws_secretsmanager_secret.opg_lpa_front_email_sendgrid_api_key.arn,
       data.aws_secretsmanager_secret.opg_lpa_front_gov_pay_key.arn,
       data.aws_secretsmanager_secret.opg_lpa_front_os_places_hub_license_key.arn,
       data.aws_secretsmanager_secret.opg_lpa_pdf_owner_password.arn,

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -268,8 +268,6 @@ locals {
       ],
       "secrets" : [
         { "name" : "OPG_LPA_FRONT_CSRF_SALT", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_front_csrf_salt.name}" },
-        { "name" : "OPG_LPA_FRONT_EMAIL_SENDGRID_WEBHOOK_TOKEN", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_front_email_sendgrid_webhook_token.name}" },
-        { "name" : "OPG_LPA_FRONT_EMAIL_SENDGRID_API_KEY", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_front_email_sendgrid_api_key.name}" },
         { "name" : "OPG_LPA_FRONT_EMAIL_NOTIFY_API_KEY", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_api_notify_api_key.name}" },
         { "name" : "OPG_LPA_FRONT_GOV_PAY_KEY", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_front_gov_pay_key.name}" },
         { "name" : "OPG_LPA_COMMON_ACCOUNT_CLEANUP_NOTIFICATION_RECIPIENTS", "valueFrom" : "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_common_account_cleanup_notification_recipients.name}" },

--- a/terraform/environment/modules/environment/secrets.tf
+++ b/terraform/environment/modules/environment/secrets.tf
@@ -22,14 +22,6 @@ data "aws_secretsmanager_secret" "opg_lpa_admin_jwt_secret" {
 }
 
 # front secrets
-data "aws_secretsmanager_secret" "opg_lpa_front_email_sendgrid_webhook_token" {
-  name = "${var.account_name}/opg_lpa_front_email_sendgrid_webhook_token"
-}
-
-data "aws_secretsmanager_secret" "opg_lpa_front_email_sendgrid_api_key" {
-  name = "${var.account_name}/opg_lpa_front_email_sendgrid_api_key"
-}
-
 data "aws_secretsmanager_secret" "opg_lpa_front_gov_pay_key" {
   name = "${var.account_name}/opg_lpa_front_gov_pay_key"
 }

--- a/terraform/region/secrets.tf
+++ b/terraform/region/secrets.tf
@@ -64,30 +64,6 @@ resource "aws_secretsmanager_secret" "opg_lpa_admin_jwt_secret" {
 }
 
 # front secrets
-resource "aws_secretsmanager_secret" "opg_lpa_front_email_sendgrid_webhook_token" {
-  name                           = "${local.account_name}/opg_lpa_front_email_sendgrid_webhook_token"
-  tags                           = local.front_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
-  force_overwrite_replica_secret = true
-
-  replica {
-    region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
-  }
-}
-
-resource "aws_secretsmanager_secret" "opg_lpa_front_email_sendgrid_api_key" {
-  name                           = "${local.account_name}/opg_lpa_front_email_sendgrid_api_key"
-  tags                           = local.front_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
-  force_overwrite_replica_secret = true
-
-  replica {
-    region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
-  }
-}
-
 resource "aws_secretsmanager_secret" "opg_lpa_front_gov_pay_key" {
   name                           = "${local.account_name}/opg_lpa_front_gov_pay_key"
   tags                           = local.front_component_tag


### PR DESCRIPTION
## Purpose

Cleanup of Terraform code

Fixes LPAL-1123

## Approach

Remove no longer needed SendGrid secrets and environment variables

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
