### PR TITLE
LPAL-1126 Remove check which fails if lastLogin > 5 years ago

### DIFF
--- a/service-front/module/Application/src/Model/Service/ApiClient/Response/AuthResponse.php
+++ b/service-front/module/Application/src/Model/Service/ApiClient/Response/AuthResponse.php
@@ -67,8 +67,8 @@ class AuthResponse
         $this->userId = isset($array['userId']) ? $array['userId'] : null;
         $this->token = isset($array['token']) ? $array['token'] : null;
 
-        // If lastLogin is not set (user has never logged in before), set to "now"
-        $this->lastLogin = isset($array['last_login']) ? $array['last_login'] : 'now';
+        // If last_login is not set (user has never logged in before), set to null
+        $this->lastLogin = $array['last_login'] ?? null;
 
         $this->username = isset($array['username']) ? $array['username'] : null;
         $this->expiresIn = isset($array['expiresIn']) ? $array['expiresIn'] : null;

--- a/service-front/module/Application/src/Model/Service/Authentication/Adapter/LpaAuthAdapter.php
+++ b/service-front/module/Application/src/Model/Service/Authentication/Adapter/LpaAuthAdapter.php
@@ -108,6 +108,7 @@ class LpaAuthAdapter implements AdapterInterface
             ]);
         }
 
+        // if response lastLogin is null, this returns now as the datetime
         $lastLogin = new DateTime($response->getLastLogin());
         $identity = new User($response->getUserId(), $response->getToken(), $response->getExpiresIn(), $lastLogin);
 

--- a/service-front/module/Application/src/Model/Service/Authentication/Identity/User.php
+++ b/service-front/module/Application/src/Model/Service/Authentication/Identity/User.php
@@ -35,19 +35,20 @@ class User
      * @param string $userId The user's internal ID.
      * @param string $token The user's authentication token.
      * @param int $expiresIn The number of seconds in which the token expires.
-     * @param DateTime $lastLogin The DateTime the user las logged in.
+     * @param ?DateTime $lastLogin The DateTime the user logged in, or null if they've never logged in
      * @param bool $isAdmin Whether of not the user is an admin.
      */
-    public function __construct($userId, $token, $expiresIn, DateTime $lastLogin, $isAdmin = false)
+    public function __construct($userId, $token, $expiresIn, ?DateTime $lastLogin, $isAdmin = false)
     {
         $this->id = $userId;
         $this->token = $token;
-        $this->lastLogin = $lastLogin;
 
-        // If $lastLogin's TS is zero, they have not logged in before, so last login is now.
-        if ($this->lastLogin < new DateTime("-5 years")) {
-            $this->lastLogin = new DateTime();
+        // If $lastLogin is null, they have not logged in before, so last login is now.
+        if (is_null($lastLogin)) {
+            $lastLogin = new DateTime();
         }
+
+        $this->lastLogin = $lastLogin;
 
         $this->tokenExpiresIn($expiresIn);
 

--- a/service-front/module/Application/tests/Model/Service/Authentication/Identity/UserTest.php
+++ b/service-front/module/Application/tests/Model/Service/Authentication/Identity/UserTest.php
@@ -19,7 +19,7 @@ class UserTest extends TestCase
     /**
      * @throws Exception
      */
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->user = new User('User ID', 'test token', 1, new DateTime('2019-01-02'), true);
     }
@@ -27,17 +27,16 @@ class UserTest extends TestCase
     /**
      * @throws Exception
      */
-    public function testConstructorNeverLoggedIn() : void
+    public function testConstructorNeverLoggedIn(): void
     {
-        $user = new User('User ID', 'test token', 1, new DateTime('2010-01-01'), true);
-
-        ServiceTestHelper::assertTimeNear(new DateTime('now'), $user->lastLogin());
+        $user = new User('User ID', 'test token', 1, null, true);
+        ServiceTestHelper::assertTimeNear(new DateTime('now'), $user->lastLogin(), 5);
     }
 
     /**
      * @throws Exception
      */
-    public function testConstructorNotAdmin() : void
+    public function testConstructorNotAdmin(): void
     {
         $user = new User('User ID', 'test token', 1, new DateTime('2019-01-01'), false);
 


### PR DESCRIPTION
Unit tests were failing because of a condition which sets the last login for the user to 'now' if the supplied last login datetime is more than 5 years ago. This was tripped when we passed 2023-01-04, as some of the tests set the last login date to 2018-01-02.

Remove this condition and instead set a default lastLogin if one is not available for a user during an authentication attempt. Also allow the lastLogin to be null when constructing a User, and default to 'now' if this is the case. As we only construct users in LpaAuthAdapter, we shouldn't hit this case, but it is covered anyway.

In LpaAuthAdapter, default the last login to null if the user doesn't have one. Then, when constructing the last login datetime, a null value will mean we default to 'now'.

## Purpose

Fixes LPAL-1126

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes


[LPAL-1126]: https://opgtransform.atlassian.net/browse/LPAL-1126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ