### PR TITLE
LPAL-1094: Announce Path to Live failures in Slack

### DIFF
--- a/.github/workflows/_smoke_tests.yml
+++ b/.github/workflows/_smoke_tests.yml
@@ -1,0 +1,58 @@
+name: "[Workflow] Run Smoke Tests"
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_call:
+    outputs:
+      smoke_test_status:
+        description: "The status of the smoke tests"
+        value: ${{ steps.run_smoke_tests.outputs.smoke_test_status }}
+
+permissions:
+  contents: read
+  security-events: read
+  pull-requests: read
+  actions: none
+  checks: none
+  deployments: none
+  issues: none
+  packages: none
+  repository-projects: none
+  statuses: none
+
+jobs:
+  run_smoke_tests:
+    runs-on: ubuntu-latest
+    outputs:
+      smoke_test_status: ${{ steps.smoke_tests.outputs.smoke_test_status }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+
+      - name: Download Terraform Task definition
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        with:
+          name: terraform-artifact
+          path: /tmp/
+
+      - name: Setup Python
+        uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # pin@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/pipeline/requirements.txt
+
+      - name: Run smoke tests
+        id: smoke_tests
+        run: |
+          if python scripts/pipeline/healthcheck_test/healthcheck_test.py; then
+            echo "smoke_test_status=passed" >> $GITHUB_OUTPUT
+          else
+            echo "smoke_test_status=failed" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -389,16 +389,16 @@ jobs:
           fi
 
   slack_msg_production_deployed:
-    name: Post-Deployment Slack message
+    name: Post-Deployment Slack message - Success
     runs-on: ubuntu-latest
-    if: always()
+    if: success()
     needs:
       - slack_msg_production_deploy_begin
       - run_smoke_tests
       - image_tag
     steps:
     - uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
-      if: success()
+      if: jobs.run_smoke_tests.result == 'success'
       with:
         channel-id: "C01BDM8T67J"
         update-ts: ${{ needs.slack_msg_production_deploy_begin.outputs.ts }}
@@ -448,11 +448,16 @@ jobs:
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
+  slack_msg_production_failed:
+    name: Post-Deployment Slack message - Failure
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
     - uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
-      if: failure()
+      if: ${{ jobs.run_smoke_tests.result == 'failure' || jobs.run_smoke_tests.result == 'cancelled' || jobs.run_smoke_tests.result == 'skipped' }}
       with:
         channel-id: "C01BDM8T67J"
-        update-ts: ${{ needs.slack_msg_production_deploy_begin.outputs.ts }}
+        update-ts: ${{ jobs.slack_msg_production_deploy_begin.outputs.ts }}
         payload: |
             {
               "icon_emoji": ":robot_face:",
@@ -483,7 +488,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Commit:*\n <https://github.com/ministryofjustice/opg-lpa/commit/${{ github.sha }}|${{ needs.image_tag.outputs.short_sha }}>"
+                      "text": "*Commit:*\n <https://github.com/ministryofjustice/opg-lpa/commit/${{ github.sha }}|${{ jobs.image_tag.outputs.short_sha }}>"
                     }
                   ]
                 },
@@ -500,7 +505,7 @@ jobs:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
     - uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
-      if: ${{ ( failure() ) || ( cancelled() ) }}
+      if: ${{ jobs.run_smoke_tests.result == 'failure' || jobs.run_smoke_tests.result == 'cancelled' || jobs.run_smoke_tests.result == 'skipped' }}
       with:
         channel-id: "C01BDM8T67J"
         payload: |
@@ -518,4 +523,3 @@ jobs:
             }
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -220,7 +220,7 @@ jobs:
     secrets: inherit
 
   slack_msg_production_deploy_begin:
-    name: Annouce Production Deployment
+    name: Announce Production Deployment
     runs-on: ubuntu-latest
     outputs:
       ts: ${{ steps.slack.outputs.ts }}
@@ -352,41 +352,11 @@ jobs:
     secrets: inherit
 
   run_smoke_tests:
-    runs-on: ubuntu-latest
-    outputs:
-      smoke_test_status: ${{ steps.smoke_tests.outputs.smoke_test_status }}
+    uses: ./.github/workflows/_smoke_tests.yml
     needs:
       - terraform_environment_production
       - terraform_region_production
       - terraform_account_production
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-
-      - name: Download Terraform Task definition
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
-        with:
-          name: terraform-artifact
-          path: /tmp/
-
-      - name: Setup Python
-        uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # pin@v4
-        with:
-          python-version: '3.9'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r scripts/pipeline/requirements.txt
-
-      - name: Run smoke tests
-        id: smoke_tests
-        run: |
-          if python scripts/pipeline/healthcheck_test/healthcheck_test.py; then
-            echo "smoke_test_status=passed" >> $GITHUB_OUTPUT
-          else
-            echo "smoke_test_status=failed" >> $GITHUB_OUTPUT
-          fi
 
   slack_msg_production_deployed:
     name: Post-Deployment Slack message - Success
@@ -452,12 +422,15 @@ jobs:
     name: Post-Deployment Slack message - Failure
     runs-on: ubuntu-latest
     if: failure()
+    needs:
+      - slack_msg_production_deploy_begin
+      - image_tag
     steps:
     - uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
       if: ${{ jobs.run_smoke_tests.result == 'failure' || jobs.run_smoke_tests.result == 'cancelled' || jobs.run_smoke_tests.result == 'skipped' }}
       with:
         channel-id: "C01BDM8T67J"
-        update-ts: ${{ jobs.slack_msg_production_deploy_begin.outputs.ts }}
+        update-ts: ${{ needs.slack_msg_production_deploy_begin.outputs.ts }}
         payload: |
             {
               "icon_emoji": ":robot_face:",
@@ -488,7 +461,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Commit:*\n <https://github.com/ministryofjustice/opg-lpa/commit/${{ github.sha }}|${{ jobs.image_tag.outputs.short_sha }}>"
+                      "text": "*Commit:*\n <https://github.com/ministryofjustice/opg-lpa/commit/${{ github.sha }}|${{ needs.image_tag.outputs.short_sha }}>"
                     }
                   ]
                 },


### PR DESCRIPTION
## Purpose

Announce Path to Live failures in Slack

Fixes LPAL-1094

## Approach

Changes the logic so that failure messages display if there is a job failure and the success only sends if smoke tests pass

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
