### PR TITLE
LPAL-1113 Auto rollback of failed ECS deployments

### DIFF
--- a/terraform/environment/modules/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/modules/environment/cloudwatch_alarms.tf
@@ -21,6 +21,27 @@ resource "aws_cloudwatch_metric_alarm" "front_5xx_errors" {
   treat_missing_data        = "notBreaching"
 }
 
+resource "aws_cloudwatch_metric_alarm" "front_high_response_latency" {
+  actions_enabled     = true
+  alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  alarm_description   = "High average latency (above 2 seconds) for front users in ${var.environment_name}"
+  alarm_name          = "${var.environment_name} public front high response times"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  dimensions = {
+    "LoadBalancer" = trimprefix(split(":", aws_lb.front.arn)[5], "loadbalancer/")
+  }
+  evaluation_periods        = 2
+  insufficient_data_actions = []
+  metric_name               = "TargetResponseTime"
+  namespace                 = "AWS/ApplicationELB"
+  ok_actions                = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  period                    = 10
+  statistic                 = "Average"
+  tags                      = local.front_component_tag
+  threshold                 = 1.5
+  treat_missing_data        = "notBreaching"
+}
+
 
 resource "aws_cloudwatch_metric_alarm" "admin_5xx_errors" {
   actions_enabled     = true
@@ -40,6 +61,27 @@ resource "aws_cloudwatch_metric_alarm" "admin_5xx_errors" {
   period                    = 60
   statistic                 = "Sum"
   tags                      = local.admin_component_tag
+  threshold                 = 2
+  treat_missing_data        = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "admin_high_response_latency" {
+  actions_enabled     = true
+  alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  alarm_description   = "High average latency (above 2 seconds) for admin users in ${var.environment_name}"
+  alarm_name          = "${var.environment_name} admin high response times"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  dimensions = {
+    "LoadBalancer" = trimprefix(split(":", aws_lb.admin.arn)[5], "loadbalancer/")
+  }
+  evaluation_periods        = 2
+  insufficient_data_actions = []
+  metric_name               = "TargetResponseTime"
+  namespace                 = "AWS/ApplicationELB"
+  ok_actions                = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  period                    = 10
+  statistic                 = "Average"
+  tags                      = local.front_component_tag
   threshold                 = 2
   treat_missing_data        = "notBreaching"
 }
@@ -115,7 +157,7 @@ resource "aws_cloudwatch_metric_alarm" "application_5xx_errors" {
   ok_actions                = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
   period                    = 60
   statistic                 = "Sum"
-  threshold                 = 2
+  threshold                 = 15
   treat_missing_data        = "notBreaching"
 }
 

--- a/terraform/environment/modules/environment/ecs_admin.tf
+++ b/terraform/environment/modules/environment/ecs_admin.tf
@@ -24,6 +24,17 @@ resource "aws_ecs_service" "admin" {
     container_port   = 80
   }
 
+
+  alarms {
+    enable   = true
+    rollback = true
+    alarm_names = [
+      aws_cloudwatch_metric_alarm.admin_5xx_errors.alarm_name,
+      aws_cloudwatch_metric_alarm.admin_high_response_latency.alarm_name,
+      aws_cloudwatch_metric_alarm.application_5xx_errors.alarm_name,
+    ]
+  }
+
   depends_on = [aws_lb.admin, aws_iam_role.admin_task_role, aws_iam_role.execution_role]
   tags       = local.admin_component_tag
 }

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -21,6 +21,16 @@ resource "aws_ecs_service" "api" {
     assign_public_ip = false
   }
 
+  alarms {
+    enable   = true
+    rollback = true
+    alarm_names = [
+      aws_cloudwatch_metric_alarm.front_5xx_errors.alarm_name,
+      aws_cloudwatch_metric_alarm.front_high_response_latency.alarm_name,
+      aws_cloudwatch_metric_alarm.application_5xx_errors.alarm_name,
+    ]
+  }
+
   service_registries {
     registry_arn = aws_service_discovery_service.api_canonical.arn
   }

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -24,6 +24,16 @@ resource "aws_ecs_service" "front" {
     container_port   = 80
   }
 
+  alarms {
+    enable   = true
+    rollback = true
+    alarm_names = [
+      aws_cloudwatch_metric_alarm.front_5xx_errors.alarm_name,
+      aws_cloudwatch_metric_alarm.front_high_response_latency.alarm_name,
+      aws_cloudwatch_metric_alarm.application_5xx_errors.alarm_name,
+    ]
+  }
+
   depends_on = [aws_lb.front, aws_iam_role.front_task_role, aws_iam_role.execution_role]
   tags       = local.front_component_tag
 }

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -16,6 +16,14 @@ resource "aws_ecs_service" "pdf" {
     assign_public_ip = false
   }
 
+  alarms {
+    enable   = true
+    rollback = true
+    alarm_names = [
+      aws_cloudwatch_metric_alarm.pdf_queue_excess_items.alarm_name,
+    ]
+  }
+
   depends_on = [aws_iam_role.pdf_task_role, aws_iam_role.execution_role]
   tags       = local.pdf_component_tag
 


### PR DESCRIPTION
## Purpose

Automatically rollback container versions if alarms are triggered during the deployment.

Fixes LPAL-1113

## Approach

Use the loadbalancers' metrics to trigger an alarm if too many 50X errors or high response times occur immediately following a deployment of new containers. ECS will automatically rollback to the last version of the containers if these alarms trigger in the 'bake time' following a deployment.

## Learning

https://aws.amazon.com/blogs/containers/automate-rollbacks-for-amazon-ecs-rolling-deployments-with-cloudwatch-alarms/

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
