### PR TITLE
LPAL-1147 Create metric for application errors

### DIFF
--- a/terraform/environment/modules/environment/cloudwatch_logs.tf
+++ b/terraform/environment/modules/environment/cloudwatch_logs.tf
@@ -10,3 +10,29 @@ resource "aws_cloudwatch_log_group" "application_logs" {
     },
   )
 }
+
+resource "aws_cloudwatch_log_metric_filter" "application_5xx_errors" {
+  name           = "${var.environment_name}-5xx-errors"
+  pattern        = "{ $.status = 5* }"
+  log_group_name = aws_cloudwatch_log_group.application_logs.name
+
+  metric_transformation {
+    name          = "${var.environment_name}-5xx-errors"
+    namespace     = "Make/Monitoring"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "application_40x_errors" {
+  name           = "${var.environment_name}-40x-auth-errors"
+  pattern        = "{ ( $.status = 401 ) || ( $.status = 403 ) }"
+  log_group_name = aws_cloudwatch_log_group.application_logs.name
+
+  metric_transformation {
+    name          = "${var.environment_name}-40x-errors"
+    namespace     = "Make/Monitoring"
+    value         = "1"
+    default_value = "0"
+  }
+}


### PR DESCRIPTION
## Purpose

Create two metrics and associated alarms for application 5XX / 401 / 403 errors. These will allow Slack alerts to be generated if we begin generating these in the applications. Currently, we only alert if the ELB generates these.

Fixes LPAL-1147

## Approach

Create two metric filters: one for application 5xx errors and one for 401/403 errors. Due to how we log, these are aggregate stats of all of Make's applications. There is scope to change the way that we log in the future so that these can be broken down by application.

An alarm for each metric is then created.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
