### PR TITLE
LPAL-1151 Fix 500 errors caused by invalid scheme in Referer header

### DIFF
--- a/service-front/module/Application/src/Controller/General/RegisterController.php
+++ b/service-front/module/Application/src/Controller/General/RegisterController.php
@@ -38,10 +38,15 @@ class RegisterController extends AbstractBaseController
         /** @var Referer */
         $referer = $request->getHeader('Referer');
 
-        if ($referer !== false) {
-            if (stripos($referer->uri()->getHost(), 'www.gov.uk') !== false) {
-                return $this->redirect()->toRoute('home', ['action' => 'index'], ['query' => ['_ga' => $ga]]);
-            }
+        // despite the implicit cast above, $referer might be a GenericHeader
+        // if the URI has an invalid scheme like android-app://, hence the is_a() check;
+        // otherwise $referer->uri() might throw a "method does not exist exception";
+        // see LPAL-1151
+        if (
+            is_a($referer, Referer::class) &&
+            (stripos($referer->uri()->getHost(), 'www.gov.uk') !== false)
+        ) {
+            return $this->redirect()->toRoute('home', ['action' => 'index'], ['query' => ['_ga' => $ga]]);
         }
 
         $response = $this->preventAuthenticatedUser();


### PR DESCRIPTION
## Purpose

[LPAL-1151](https://opgtransform.atlassian.net/browse/LPAL-1151)

## Approach

See ticket.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes


[LPAL-1151]: https://opgtransform.atlassian.net/browse/LPAL-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ