### PR TITLE
LPAL-1159 Upgrade to latest "moj tfsec to github security" action

### DIFF
--- a/.github/workflows/analysis-tfsec.yml
+++ b/.github/workflows/analysis-tfsec.yml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   tfsec_analysis_to_github_security:
-    uses: townxelliot/opg-github-workflows/.github/workflows/analysis-infrastructure-tfsec-to-github-security.yml@v1.16.0
+    uses: ministryofjustice/opg-github-workflows/blob/main/.github/workflows/analysis-infrastructure-tfsec-to-github-security.yml@v1.16.0

--- a/.github/workflows/analysis-tfsec.yml
+++ b/.github/workflows/analysis-tfsec.yml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   tfsec_analysis_to_github_security:
-    uses: ministryofjustice/opg-github-workflows/.github/workflows/analysis-infrastructure-tfsec-to-github-security.yml@v1.14.0
+    uses: townxelliot/opg-github-workflows/.github/workflows/analysis-infrastructure-tfsec-to-github-security.yml@v1.16.0

--- a/.github/workflows/analysis-tfsec.yml
+++ b/.github/workflows/analysis-tfsec.yml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   tfsec_analysis_to_github_security:
-    uses: ministryofjustice/opg-github-workflows/blob/main/.github/workflows/analysis-infrastructure-tfsec-to-github-security.yml@v1.16.0
+    uses: ministryofjustice/opg-github-workflows/.github/workflows/analysis-infrastructure-tfsec-to-github-security.yml@v1.16.0


### PR DESCRIPTION
## Purpose

This uses a later tfsec-sarif-action version (0.1.4) which no longer uses wget to fetch the tfsec versions, and instead installs tfsec directly into the docker image. Hopefully this will fix our 403 rate limit exceeded errors.

[LPAL-1159](https://opgtransform.atlassian.net/browse/LPAL-1159)

## Approach

-

## Learning

tf

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes


[LPAL-1159]: https://opgtransform.atlassian.net/browse/LPAL-1159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ