### PR TITLE
Find latest main image via aws rather than guessing from git commit ID

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -184,14 +184,22 @@ jobs:
           IMAGE_NAME: ${{ matrix.image_name }}
           IMAGE_TAG: ${{ steps.set_image_tag.outputs.image_tag }}
         run: |
-          git fetch origin main:main --depth 2
-          git checkout main
-          MAIN_IMAGE_TAG=$(git rev-list --no-merges -n 1 main | cut -c1-7)
           if [[ "${{ matrix.override_tag }}X" != "X" ]]; then
-            MAIN_IMAGE_TAG=${{ matrix.override_tag }}
+            MAIN_IMAGE_TAG=main-${{ matrix.override_tag }}
+          else
+            MAIN_IMAGE_TAG=`aws ecr describe-images --repository-name=$IMAGE_NAME | \
+              jq '.imageDetails | map(select(.imageTags[] | test("main"))) | sort_by(.imagePushedAt) | .[-1].imageTags | map(select(test("main")))[0]' | \
+              sed -e 's/"//g'`
           fi
-          docker buildx imagetools create $ECR_REGISTRY/$IMAGE_NAME:main-$MAIN_IMAGE_TAG --tag $ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG
-          git checkout - # return to original branch
+
+          if [ "$MAIN_IMAGE_TAG" = "null" ]; then
+            echo "ERROR: image does not need to be built, but no main-* tagged image available instead"
+            exit 1
+          fi
+
+          echo "Using prod image $ECR_REGISTRY/$IMAGE_NAME:$MAIN_IMAGE_TAG to create $ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG"
+
+          docker buildx imagetools create $ECR_REGISTRY/$IMAGE_NAME:$MAIN_IMAGE_TAG --tag $ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG
 
       - name: Tag and Push Container
         if: steps.build_image.outputs.build == 'true'


### PR DESCRIPTION
## Purpose

[LPAL-1158](https://opgtransform.atlassian.net/browse/LPAL-1158)

## Approach

Use `aws ecr describe-images | jq` to find the latest main-* image.

## Learning

AWS ECR CLI

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes


[LPAL-1158]: https://opgtransform.atlassian.net/browse/LPAL-1158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ