### PR TITLE
LPAL-1163 Occasionally we get images with no imageTags array

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -188,7 +188,7 @@ jobs:
             MAIN_IMAGE_TAG=main-${{ matrix.override_tag }}
           else
             MAIN_IMAGE_TAG=`aws ecr describe-images --repository-name=$IMAGE_NAME | \
-              jq '.imageDetails | map(select(.imageTags[] | test("main"))) | sort_by(.imagePushedAt) | .[-1].imageTags | map(select(test("main")))[0]' | \
+              jq '.imageDetails | map(select(.imageTags)) | map(select(.imageTags[] | test("main"))) | sort_by(.imagePushedAt) | .[-1].imageTags | map(select(test("main")))[0]' | \
               sed -e 's/"//g'`
           fi
 


### PR DESCRIPTION

## Purpose

My incorrect assumption was that every image returned by aws ecr would have an imageTags property, even if empty. However, this property appears to be omitted if the image doesn't have any tags. Not sure how we are making images without tags, but it is happening. Add an extra guard to ensure we only consider tagged images when trying to find the latest.

[LPAL-1163](https://opgtransform.atlassian.net/browse/LPAL-1163)

## Approach

See ticket.

## Learning

aws ecr is unintuitive and inconsistent

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
