### PR TITLE
LPAL-1162 Tweak Renovate config for exclusions and range strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,14 +12,6 @@
   "prConcurrentLimit": 0,
   "branchConcurrentLimit": 0,
   "lockFileMaintenance": { "enabled": true },
-  "major": {
-    "labels": [
-        "Dependencies",
-        "Renovate"
-    ],
-    "prCreation": "not-pending",
-    "prPriority": 0
-  },
   "vulnerabilityAlerts": {
     "groupName": "Security Alerts",
     "labels": [
@@ -93,8 +85,9 @@
     {
       "description": [
         "composer and npm Minor and Patch updates",
-        "Make PRs after updated package has been stable for 3 days",
-        "These might be automerged once we're comfortable with Renovate"
+        "Make PRs after updated package has been stable for 3 days.",
+        "These might be automerged once we're comfortable with Renovate.",
+        "Exclude PDF library updates - they're high risk and better done manually, even for minor/patch versions."
       ],
       "automerge": false,
       "groupName": "Patch & Minor Updates (3 day stability)",
@@ -114,9 +107,21 @@
         "minor",
         "patch"
       ],
+      "excludePackageNames": [
+        "mikehaertl/php-pdftk",
+        "tecnickcom/tcpdf"
+      ],
       "prCreation": "immediate",
       "prPriority": 4,
       "stabilityDays": 3
     }
-  ]
+  ],
+  "major": {
+    "labels": [
+        "Dependencies",
+        "Renovate"
+    ],
+    "prCreation": "not-pending",
+    "prPriority": 0
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base", ":dependencyDashboard"
   ],
   "branchPrefix": "renovate-",
   "commitMessageAction": "Renovate Update",

--- a/renovate.json
+++ b/renovate.json
@@ -122,6 +122,7 @@
         "minor",
         "patch"
       ],
+      "rangeStrategy": "update-lockfile",
       "prCreation": "immediate",
       "prPriority": 4,
       "stabilityDays": 3

--- a/renovate.json
+++ b/renovate.json
@@ -27,8 +27,42 @@
     "prCreation": "immediate",
     "prPriority": 5
   },
+  "major": {
+    "labels": [
+        "Dependencies",
+        "Renovate"
+    ],
+    "prCreation": "not-pending",
+    "prPriority": 0
+  },
   "prHourlyLimit": 1,
   "packageRules": [
+    {
+      "description": [
+        "composer and npm Minor and Patch updates",
+        "Make PRs after updated package has been stable for 3 days.",
+        "These might be automerged once we're comfortable with Renovate."
+      ],
+      "automerge": false,
+      "groupName": "Patch & Minor Updates (3 day stability)",
+      "groupSlug": "all-minor-patch-updates",
+      "labels": [
+        "Dependencies",
+        "Renovate"
+      ],
+      "matchDatasources": [
+        "composer",
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "rangeStrategy": "update-lockfile",
+      "prCreation": "immediate",
+      "prPriority": 4,
+      "stabilityDays": 3
+    },
     {
       "description": [
         "Docker Major Dependency Exclusions",
@@ -100,40 +134,6 @@
         "tecnickcom/tcpdf"
       ],
       "enabled": false
-    },
-    {
-      "description": [
-        "composer and npm Minor and Patch updates",
-        "Make PRs after updated package has been stable for 3 days.",
-        "These might be automerged once we're comfortable with Renovate."
-      ],
-      "automerge": false,
-      "groupName": "Patch & Minor Updates (3 day stability)",
-      "groupSlug": "all-minor-patch-updates",
-      "labels": [
-        "Dependencies",
-        "Renovate"
-      ],
-      "matchDatasources": [
-        "composer",
-        "npm"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "rangeStrategy": "update-lockfile",
-      "prCreation": "immediate",
-      "prPriority": 4,
-      "stabilityDays": 3
     }
-  ],
-  "major": {
-    "labels": [
-        "Dependencies",
-        "Renovate"
-    ],
-    "prCreation": "not-pending",
-    "prPriority": 0
-  }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -66,7 +66,8 @@
     {
       "description": [
         "Composer Major Dependency Exclusions",
-        "guzzlehttp/guzzle - Stay at v6 until notify client upgraded (LPAL-1166)"
+        "alphagov/notifications-php-client - Requires manual upgrade (LPAL-1166)",
+        "guzzlehttp/guzzle - Stay at v6 until Notify client upgraded (LPAL-1166)"
       ],
       "matchUpdateTypes": [
         "major"
@@ -78,7 +79,9 @@
         "composer"
       ],
       "matchPackageNames": [
-        "guzzlehttp/guzzle"
+        "guzzlehttp/guzzle",
+        "guzzlehttp/psr7",
+        "alphagov/notifications-php-client"
       ],
       "enabled": false
     },

--- a/renovate.json
+++ b/renovate.json
@@ -72,8 +72,8 @@
       "matchUpdateTypes": [
         "major"
       ],
-      "matchFiles": [
-        "service-front/composer.json"
+      "matchPaths": [
+        "**/composer.json"
       ],
       "matchDatasources": [
         "composer"

--- a/renovate.json
+++ b/renovate.json
@@ -72,9 +72,6 @@
       "matchUpdateTypes": [
         "major"
       ],
-      "matchPaths": [
-        "**/composer.json"
-      ],
       "matchDatasources": [
         "composer"
       ],
@@ -87,10 +84,28 @@
     },
     {
       "description": [
+        "Composer All Version Dependency Exclusions",
+        "Exclude PDF library updates - they're high risk and should be done manually, even for minor/patch versions."
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDatasources": [
+        "composer"
+      ],
+      "matchPackageNames": [
+        "mikehaertl/php-pdftk",
+        "tecnickcom/tcpdf"
+      ],
+      "enabled": false
+    },
+    {
+      "description": [
         "composer and npm Minor and Patch updates",
         "Make PRs after updated package has been stable for 3 days.",
-        "These might be automerged once we're comfortable with Renovate.",
-        "Exclude PDF library updates - they're high risk and better done manually, even for minor/patch versions."
+        "These might be automerged once we're comfortable with Renovate."
       ],
       "automerge": false,
       "groupName": "Patch & Minor Updates (3 day stability)",
@@ -99,20 +114,13 @@
         "Dependencies",
         "Renovate"
       ],
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchPaths": [
-        "**/composer.json",
-        "**/package.json"
+      "matchDatasources": [
+        "composer",
+        "npm"
       ],
       "matchUpdateTypes": [
         "minor",
         "patch"
-      ],
-      "excludePackageNames": [
-        "mikehaertl/php-pdftk",
-        "tecnickcom/tcpdf"
       ],
       "prCreation": "immediate",
       "prPriority": 4,


### PR DESCRIPTION
## Purpose

[LPAL-1162](https://opgtransform.atlassian.net/browse/LPAL-1162)

## Approach

See ticket.

## Learning

Renovate.

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes


[LPAL-1162]: https://opgtransform.atlassian.net/browse/LPAL-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ