### PR TITLE
LPAL-1075 Fix service-api unit tests so it doesn't need aws-vault in front of it

### DIFF
--- a/service-api/module/Application/src/Controller/PingController.php
+++ b/service-api/module/Application/src/Controller/PingController.php
@@ -23,6 +23,11 @@ class PingController extends AbstractRestfulController
     use LoggerTrait;
 
     /**
+     * @var CredentialProvider
+     */
+    private $credentialProvider;
+
+    /**
      * @var ZendDbAdapter
      */
     private $database;
@@ -49,6 +54,7 @@ class PingController extends AbstractRestfulController
 
     /**
      * PingController constructor.
+     * @param CredentialProvider $credentialProvider
      * @param ZendDbAdapter $database
      * @param SqsClient $sqsClient
      * @param string $queueUrl
@@ -56,12 +62,14 @@ class PingController extends AbstractRestfulController
      * @param HttpClient $httpClient
      */
     public function __construct(
+        CredentialProvider $credentialProvider,
         ZendDbAdapter $database,
         SqsClient $sqsClient,
         string $queueUrl,
         string $trackMyLpaEndpoint,
         HttpClient $httpClient
     ) {
+        $this->credentialProvider = $credentialProvider;
         $this->database = $database;
         $this->sqsClient = $sqsClient;
         $this->sqsQueueUrl = $queueUrl;
@@ -154,7 +162,7 @@ class PingController extends AbstractRestfulController
                 'Content-type'  => 'application/json',
             ]);
 
-            $provider = CredentialProvider::defaultProvider();
+            $provider = this->credentialProvider::defaultProvider();
 
             $signer = new SignatureV4('execute-api', 'eu-west-1');
 

--- a/service-api/module/Application/src/Controller/PingController.php
+++ b/service-api/module/Application/src/Controller/PingController.php
@@ -29,6 +29,11 @@ class PingController extends AbstractRestfulController
     private $awsCredentials;
 
     /**
+     * @var SignatureV4
+     */
+    private $signer;
+
+    /**
      * @var ZendDbAdapter
      */
     private $database;
@@ -56,6 +61,7 @@ class PingController extends AbstractRestfulController
     /**
      * PingController constructor.
      * @param CredentialsInterface $awsCredentials
+     * @param SignatureV4 $signer
      * @param ZendDbAdapter $database
      * @param SqsClient $sqsClient
      * @param string $queueUrl
@@ -64,6 +70,7 @@ class PingController extends AbstractRestfulController
      */
     public function __construct(
         CredentialsInterface $awsCredentials,
+        SignatureV4 $signer,
         ZendDbAdapter $database,
         SqsClient $sqsClient,
         string $queueUrl,
@@ -71,6 +78,7 @@ class PingController extends AbstractRestfulController
         HttpClient $httpClient
     ) {
         $this->awsCredentials = $awsCredentials;
+        $this->signer = $signer;
         $this->database = $database;
         $this->sqsClient = $sqsClient;
         $this->sqsQueueUrl = $queueUrl;
@@ -163,10 +171,8 @@ class PingController extends AbstractRestfulController
                 'Content-type'  => 'application/json',
             ]);
 
-            $signer = new SignatureV4('execute-api', 'eu-west-1');
-
             // Sign the request with an AWS Authorization header.
-            $signedRequest = $signer->signRequest($request, $this->awsCredentials);
+            $signedRequest = $this->signer->signRequest($request, $this->awsCredentials);
 
             $response = $this->httpClient->sendRequest($signedRequest);
 

--- a/service-api/module/Application/src/Controller/PingController.php
+++ b/service-api/module/Application/src/Controller/PingController.php
@@ -2,7 +2,7 @@
 
 namespace Application\Controller;
 
-use Aws\Credentials\CredentialProvider;
+use Aws\Credentials\CredentialsInterface;
 use Aws\Signature\SignatureV4;
 use Closure;
 use GuzzleHttp\Psr7\Request;
@@ -24,9 +24,9 @@ class PingController extends AbstractRestfulController
     use LoggerTrait;
 
     /**
-     * @var Closure
+     * @var CredentialsInterface
      */
-    private $credentialProvider;
+    private $awsCredentials;
 
     /**
      * @var ZendDbAdapter
@@ -55,7 +55,7 @@ class PingController extends AbstractRestfulController
 
     /**
      * PingController constructor.
-     * @param Closure $credentialProvider
+     * @param CredentialsInterface $awsCredentials
      * @param ZendDbAdapter $database
      * @param SqsClient $sqsClient
      * @param string $queueUrl
@@ -63,14 +63,14 @@ class PingController extends AbstractRestfulController
      * @param HttpClient $httpClient
      */
     public function __construct(
-        Closure $credentialProvider,
+        CredentialsInterface $awsCredentials,
         ZendDbAdapter $database,
         SqsClient $sqsClient,
         string $queueUrl,
         string $trackMyLpaEndpoint,
         HttpClient $httpClient
     ) {
-        $this->credentialProvider = $credentialProvider;
+        $this->awsCredentials = $awsCredentials;
         $this->database = $database;
         $this->sqsClient = $sqsClient;
         $this->sqsQueueUrl = $queueUrl;
@@ -166,7 +166,7 @@ class PingController extends AbstractRestfulController
             $signer = new SignatureV4('execute-api', 'eu-west-1');
 
             // Sign the request with an AWS Authorization header.
-            $signedRequest = $signer->signRequest($request, $this->credentialProvider()->wait());
+            $signedRequest = $signer->signRequest($request, $this->awsCredentials);
 
             $response = $this->httpClient->sendRequest($signedRequest);
 

--- a/service-api/module/Application/src/Controller/PingController.php
+++ b/service-api/module/Application/src/Controller/PingController.php
@@ -162,12 +162,12 @@ class PingController extends AbstractRestfulController
                 'Content-type'  => 'application/json',
             ]);
 
-            $provider = this->credentialProvider::defaultProvider();
+            $provider = $this->credentialProvider;
 
             $signer = new SignatureV4('execute-api', 'eu-west-1');
 
             // Sign the request with an AWS Authorization header.
-            $signedRequest = $signer->signRequest($request, $provider()->wait());
+            $signedRequest = $signer->signRequest($request, $provider());
 
             $response = $this->httpClient->sendRequest($signedRequest);
 

--- a/service-api/module/Application/src/ControllerFactory/PingControllerFactory.php
+++ b/service-api/module/Application/src/ControllerFactory/PingControllerFactory.php
@@ -6,6 +6,7 @@ use Laminas\Db\Adapter\Adapter as ZendDbAdapter;
 use Application\Controller\PingController;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Aws\Credentials\CredentialProvider;
 use Aws\Sqs\SqsClient;
 use Http\Client\HttpClient;
 
@@ -35,7 +36,10 @@ class PingControllerFactory implements FactoryInterface
             throw new \RuntimeException('Missing config: Track my LPA endpoint');
         }
 
+        $awsCredential = CredentialProvider::defaultProvider();
+
         return new PingController(
+            $awsCredential,
             $database,
             $sqs,
             $config['pdf']['queue']['sqs']['settings']['url'],

--- a/service-api/module/Application/src/ControllerFactory/PingControllerFactory.php
+++ b/service-api/module/Application/src/ControllerFactory/PingControllerFactory.php
@@ -36,10 +36,10 @@ class PingControllerFactory implements FactoryInterface
             throw new \RuntimeException('Missing config: Track my LPA endpoint');
         }
 
-        $awsCredential = CredentialProvider::defaultProvider();
+        $awsCredentials = $container->get('AwsCredentials');
 
         return new PingController(
-            $awsCredential,
+            $awsCredentials,
             $database,
             $sqs,
             $config['pdf']['queue']['sqs']['settings']['url'],

--- a/service-api/module/Application/src/ControllerFactory/PingControllerFactory.php
+++ b/service-api/module/Application/src/ControllerFactory/PingControllerFactory.php
@@ -6,7 +6,8 @@ use Laminas\Db\Adapter\Adapter as ZendDbAdapter;
 use Application\Controller\PingController;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
-use Aws\Credentials\CredentialProvider as CredentialProvider;
+use Aws\Credentials\CredentialsInterface;
+use Aws\Signature\SignatureV4;
 use Aws\Sqs\SqsClient;
 use Http\Client\HttpClient;
 
@@ -22,6 +23,9 @@ class PingControllerFactory implements FactoryInterface
     {
         /** @var CredentialsInterface $awsCredentials */
         $awsCredentials = $container->get('AwsCredentials');
+
+        /** @var SignatureV4 $awsSigner */
+        $awsSigner = $container->get('AwsApiGatewaySignature');
 
         /** @var ZendDbAdapter $database */
         $database = $container->get('ZendDbAdapter');
@@ -41,6 +45,7 @@ class PingControllerFactory implements FactoryInterface
 
         return new PingController(
             $awsCredentials,
+            $awsSigner,
             $database,
             $sqs,
             $config['pdf']['queue']['sqs']['settings']['url'],

--- a/service-api/module/Application/src/ControllerFactory/PingControllerFactory.php
+++ b/service-api/module/Application/src/ControllerFactory/PingControllerFactory.php
@@ -20,6 +20,9 @@ class PingControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
+        /** @var CredentialsInterface $awsCredentials */
+        $awsCredentials = $container->get('AwsCredentials');
+
         /** @var ZendDbAdapter $database */
         $database = $container->get('ZendDbAdapter');
 
@@ -35,9 +38,6 @@ class PingControllerFactory implements FactoryInterface
         if (!isset($config['processing-status']['endpoint'])) {
             throw new \RuntimeException('Missing config: Track my LPA endpoint');
         }
-
-        /* $awsCredentials = CredentialProvider; */
-        $awsCredentials = CredentialProvider::defaultProvider();
 
         return new PingController(
             $awsCredentials,

--- a/service-api/module/Application/src/ControllerFactory/PingControllerFactory.php
+++ b/service-api/module/Application/src/ControllerFactory/PingControllerFactory.php
@@ -6,7 +6,7 @@ use Laminas\Db\Adapter\Adapter as ZendDbAdapter;
 use Application\Controller\PingController;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
-use Aws\Credentials\CredentialProvider;
+use Aws\Credentials\CredentialProvider as CredentialProvider;
 use Aws\Sqs\SqsClient;
 use Http\Client\HttpClient;
 
@@ -36,7 +36,8 @@ class PingControllerFactory implements FactoryInterface
             throw new \RuntimeException('Missing config: Track my LPA endpoint');
         }
 
-        $awsCredentials = $container->get('AwsCredentials');
+        /* $awsCredentials = CredentialProvider; */
+        $awsCredentials = CredentialProvider::defaultProvider();
 
         return new PingController(
             $awsCredentials,

--- a/service-api/module/Application/tests/Controller/PingControllerTest.php
+++ b/service-api/module/Application/tests/Controller/PingControllerTest.php
@@ -21,6 +21,11 @@ class PingControllerTest extends MockeryTestCase
     private $controller;
 
     /**
+     * @var CredentialProvider
+     */
+    private $credentialProvider;
+
+    /**
      * @var ZendDbAdapter|MockInterface
      */
     private $database;
@@ -43,7 +48,10 @@ class PingControllerTest extends MockeryTestCase
 
         $this->httpClient = Mockery::mock(HttpClient::class);
 
+        $this->credentialProvider = Mockery::mock(CredentialProvider::class);
+
         $this->controller = new PingController(
+            $this->credentialProvider,
             $this->database,
             $this->sqsClient,
             'http://test',
@@ -70,6 +78,9 @@ class PingControllerTest extends MockeryTestCase
 
         $this->httpClient->shouldReceive('sendRequest')
             ->andReturn($mockResponse);
+
+        /* $x = Mockery::mock(CredentialProvider::class); */
+        $this->credentialProvider->shouldReceive('defaultProvider');
 
         $pingResult = [
             'database' => [

--- a/service-api/module/Application/tests/ControllerFactory/PingControllerFactoryTest.php
+++ b/service-api/module/Application/tests/ControllerFactory/PingControllerFactoryTest.php
@@ -24,10 +24,13 @@ class PingControllerFactoryTest extends MockeryTestCase
      */
     private $container;
 
-    public function setUp() : void
+    private $credentialProvider;
+
+    public function setUp(): void
     {
         $this->factory = new PingControllerFactory();
         $this->container = Mockery::mock(ContainerInterface::class);
+        $this->credentialProvider = Mockery::mock(CredentialProvider::class);
     }
 
     public function testInvoke()
@@ -47,9 +50,12 @@ class PingControllerFactoryTest extends MockeryTestCase
         $this->container->shouldReceive('get')
             ->with('config')
             ->andReturn([
-                'pdf'=>['queue'=>['sqs'=>['settings'=>['url'=>'http://test']]]],
-                'processing-status'=>['endpoint'=>'http://test']
+                'pdf' => ['queue' => ['sqs' => ['settings' => ['url' => 'http://test']]]],
+                'processing-status' => ['endpoint' => 'http://test']
             ])
+            ->once();
+
+        $this->credentialProvider->shouldReceive('defaultProvider')
             ->once();
 
         $controller = $this->factory->__invoke($this->container, PingController::class);


### PR DESCRIPTION
## Purpose

Inject AWS credential provider into service-api ping controller so that unit tests can run locally without need for `aws-vault`

Fixes [LPAL-1075](https://opgtransform.atlassian.net/browse/LPAL-1075)

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [x] I have added mandatory tags to terraformed resources, where possible
* [x] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [x] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes


[LPAL-1075]: https://opgtransform.atlassian.net/browse/LPAL-1075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ