### PR TITLE
LPAL-1174 Restructure renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,6 +56,16 @@
     },
     {
       "description": [
+        "cypress: bundle updates to package.json and dockerfile"
+      ],
+      "labels": ["devDependencies", "Renovate", "Cypress"],
+      "groupName": "Cypress updates",
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchManagers": ["dockerfile", "npm"],
+      "matchPackagePatterns": ["cypress"]
+    },
+    {
+      "description": [
         "composer and npm Minor and Patch updates (stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
@@ -68,16 +78,6 @@
       "prCreation": "immediate",
       "prPriority": 4,
       "stabilityDays": 3
-    },
-    {
-      "description": [
-        "cypress: bundle updates to package.json and dockerfile"
-      ],
-      "labels": ["devDependencies", "Renovate", "Cypress"],
-      "groupName": "Cypress updates",
-      "matchUpdateTypes": ["major", "minor", "patch"],
-      "matchManagers": ["dockerfile", "npm"],
-      "matchPackagePatterns": ["cypress"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,10 @@
   "labels": ["Dependencies", "Renovate"],
   "prConcurrentLimit": 0,
   "branchConcurrentLimit": 0,
-  "lockFileMaintenance": { "enabled": true },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": "before 5am on monday"
+  },
   "vulnerabilityAlerts": {
     "groupName": "Security Alerts",
     "labels": ["Dependencies", "Renovate", "SecurityAlert"],

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   "branchPrefix": "renovate-",
+  "includeForks": true,
   "labels": ["Renovate", "Dependencies"],
   "commitMessageAction": "Renovate update",
   "lockFileMaintenance": {
@@ -34,6 +35,45 @@
   "packageRules": [
     {
       "description": [
+        "cypress: bundle updates to package.json and dockerfile",
+        "allow major version updates"
+      ],
+      "labels": ["devDependencies", "Renovate", "Cypress"],
+      "groupName": "Cypress",
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchManagers": ["dockerfile", "npm"],
+      "matchPackagePatterns": ["cypress"]
+    },
+    {
+      "description": [
+        "dev tools: allow major updates only for dev tools",
+        "note: this may fail if other packages depend on existing versions"
+      ],
+      "labels": ["devDependencies", "Renovate", "DevTools"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchManagers": ["composer"],
+      "matchPackageNames": ["vimeo/psalm", "phpunit/phpunit"]
+    },
+    {
+      "description": [
+        "Github Actions: bundle all updates together"
+      ],
+      "labels": ["devDependencies", "Renovate", "GithubActions"],
+      "groupName": "Github Actions",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "description": [
+        "Terraform: bundle all updates together"
+      ],
+      "labels": ["devDependencies", "Renovate", "Terraform"],
+      "groupName": "Terraform",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": ["terraform"]
+    },
+    {
+      "description": [
         "No updates to postgres, redis, php or python docker images",
         "postgres: keep in sync with live",
         "redis: keep in sync with live",
@@ -56,37 +96,11 @@
     },
     {
       "description": [
-        "cypress: bundle updates to package.json and dockerfile"
-      ],
-      "labels": ["devDependencies", "Renovate", "Cypress"],
-      "groupName": "Cypress",
-      "matchUpdateTypes": ["major", "minor", "patch"],
-      "matchManagers": ["dockerfile", "npm"],
-      "matchPackagePatterns": ["cypress"]
-    },
-    {
-      "description": [
-        "Github Actions: bundle all updates together"
-      ],
-      "labels": ["devDependencies", "Renovate", "GithubActions"],
-      "groupName": "Github Actions",
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "matchManagers": ["github-actions"]
-    },
-    {
-      "description": [
-        "Terraform: bundle all updates together"
-      ],
-      "labels": ["devDependencies", "Renovate", "Terraform"],
-      "groupName": "Terraform",
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchManagers": ["terraform"]
-    },
-    {
-      "description": [
-        "No major version updates"
+        "No major version updates except for dev tools"
       ],
       "matchUpdateTypes": ["major"],
+      "excludePackageNames": ["vimeo/psalm", "phpunit/phpunit"],
+      "excludePackagePatterns": ["cypress"],
       "enabled": false
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   "branchPrefix": "renovate-",
-  "includeForks": true,
   "labels": ["Renovate", "Dependencies"],
   "commitMessageAction": "Renovate update",
   "lockFileMaintenance": {
@@ -20,9 +19,9 @@
     "prCreation": "immediate",
     "prPriority": 5
   },
-  "prConcurrentLimit": 10,
-  "prHourlyLimit": 500,
-  "branchConcurrentLimit": 10,
+  "prConcurrentLimit": 1,
+  "prHourlyLimit": 1,
+  "branchConcurrentLimit": 1,
   "enabledManagers": ["dockerfile", "docker-compose", "npm", "composer", "github-actions", "gomod", "terraform"],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:base"],
   "branchPrefix": "renovate-",
   "includeForks": true,
+  "labels": ["Renovate", "Dependencies"],
   "commitMessageAction": "Renovate update",
   "lockFileMaintenance": {
     "enabled": true,
@@ -51,10 +52,28 @@
         "cypress: bundle updates to package.json and dockerfile"
       ],
       "labels": ["devDependencies", "Renovate", "Cypress"],
-      "groupName": "Cypress updates",
+      "groupName": "Cypress",
       "matchUpdateTypes": ["major", "minor", "patch"],
       "matchManagers": ["dockerfile", "npm"],
       "matchPackagePatterns": ["cypress"]
+    },
+    {
+      "description": [
+        "Github Actions: bundle all updates together"
+      ],
+      "labels": ["devDependencies", "Renovate", "GithubActions"],
+      "groupName": "Github Actions",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "description": [
+        "Terraform: bundle all updates together"
+      ],
+      "labels": ["devDependencies", "Renovate", "Terraform"],
+      "groupName": "Terraform",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": ["terraform"]
     },
     {
       "description": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,24 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base", ":dependencyDashboard"
-  ],
+  "extends": ["config:base", ":dependencyDashboard"],
   "branchPrefix": "renovate-",
-  "commitMessageAction": "Renovate Update",
-  "labels": [
-    "Dependencies",
-    "Renovate"
-  ],
+  "includeForks": true,
+  "commitMessageAction": "Renovate update",
+  "labels": ["Dependencies", "Renovate"],
   "prConcurrentLimit": 0,
   "branchConcurrentLimit": 0,
   "lockFileMaintenance": { "enabled": true },
   "vulnerabilityAlerts": {
     "groupName": "Security Alerts",
-    "labels": [
-      "Dependencies",
-      "Renovate",
-      "SecurityAlert"
-    ],
+    "labels": ["Dependencies", "Renovate", "SecurityAlert"],
     "dependencyDashboardApproval": false,
     "stabilityDays": 0,
     "rangeStrategy": "update-lockfile",
@@ -27,112 +19,62 @@
     "prCreation": "immediate",
     "prPriority": 5
   },
-  "major": {
-    "labels": [
-        "Dependencies",
-        "Renovate"
-    ],
-    "prCreation": "not-pending",
-    "prPriority": 0
-  },
-  "prHourlyLimit": 1,
+  "prHourlyLimit": 10,
+  "enabledManagers": ["dockerfile", "docker-compose", "npm", "composer", "github-actions", "gomod", "terraform"],
   "packageRules": [
     {
       "description": [
-        "composer and npm Minor and Patch updates",
-        "Make PRs after updated package has been stable for 3 days.",
-        "These might be automerged once we're comfortable with Renovate."
+        "No major version updates"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": [
+        "No updates to PHP PDF libraries (too sensitive and risky)"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchManagers": ["composer"],
+      "matchPackageNames": ["tecnickcom/tcpdf", "mikehaertl/php-pdftk"],
+      "enabled": false
+    },
+    {
+      "description": [
+        "No updates to postgres, redis, php or python docker images",
+        "postgres: keep in sync with live",
+        "redis: keep in sync with live",
+        "php: 8.2 upgrade needs to be managed manually",
+        "python: to be removed"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchPackageNames": ["postgres", "redis", "php", "python"],
+      "enabled": false
+    },
+    {
+      "description": [
+        "composer and npm Minor and Patch updates (stable for 3 days)",
+        "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "Patch & Minor Updates (3 day stability)",
+      "groupName": "minor and patch updates",
       "groupSlug": "all-minor-patch-updates",
-      "labels": [
-        "Dependencies",
-        "Renovate"
-      ],
-      "matchDatasources": [
-        "composer",
-        "npm"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
+      "labels": ["Dependencies", "Renovate"],
+      "matchManagers": ["composer", "npm"],
+      "matchUpdateTypes": ["minor", "patch"],
       "prCreation": "immediate",
       "prPriority": 4,
       "stabilityDays": 3
     },
     {
       "description": [
-        "Docker Major Dependency Exclusions",
-        "postgres - Excluded from updates to allow us to match major versions to the deployed version in AWS",
-        "php - No migration to PHP 9 until we've got 8.2 deployed"
+        "cypress: bundle updates to package.json and dockerfile"
       ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "postgres",
-        "php"
-      ],
-      "enabled": false
-    },
-    {
-      "description": [
-        "Docker Minor Dependency Exclusions",
-        "php - Excluded to allow us to phase migration from PHP 8.1 to 8.2"
-      ],
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "php"
-      ],
-      "enabled": false
-    },
-    {
-      "description": [
-        "Composer Major Dependency Exclusions",
-        "alphagov/notifications-php-client - Requires manual upgrade (LPAL-1166)",
-        "guzzlehttp/guzzle - Stay at v6 until Notify client upgraded (LPAL-1166)"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "matchDatasources": [
-        "composer"
-      ],
-      "matchPackageNames": [
-        "guzzlehttp/guzzle",
-        "guzzlehttp/psr7",
-        "alphagov/notifications-php-client"
-      ],
-      "enabled": false
-    },
-    {
-      "description": [
-        "Composer All Version Dependency Exclusions",
-        "Exclude PDF library updates - they're high risk and should be done manually, even for minor/patch versions."
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch"
-      ],
-      "matchDatasources": [
-        "composer"
-      ],
-      "matchPackageNames": [
-        "mikehaertl/php-pdftk",
-        "tecnickcom/tcpdf"
-      ],
-      "enabled": false
+      "labels": ["devDependencies", "Renovate", "Cypress"],
+      "groupName": "Cypress updates",
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchManagers": ["dockerfile", "npm"],
+      "matchPackagePatterns": ["cypress"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,15 @@
   "prConcurrentLimit": 1,
   "prHourlyLimit": 1,
   "branchConcurrentLimit": 1,
-  "enabledManagers": ["dockerfile", "docker-compose", "npm", "composer", "github-actions", "gomod", "terraform"],
+  "enabledManagers": [
+    "dockerfile",
+    "docker-compose",
+    "npm",
+    "composer",
+    "github-actions",
+    "gomod",
+    "terraform"
+  ],
   "packageRules": [
     {
       "description": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":dependencyDashboard"],
+  "extends": ["config:base"],
   "branchPrefix": "renovate-",
   "includeForks": true,
   "commitMessageAction": "Renovate update",
-  "labels": ["Dependencies", "Renovate"],
-  "prConcurrentLimit": 0,
-  "branchConcurrentLimit": 0,
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": "before 5am on monday"
@@ -22,25 +19,11 @@
     "prCreation": "immediate",
     "prPriority": 5
   },
-  "prHourlyLimit": 10,
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 500,
+  "branchConcurrentLimit": 10,
   "enabledManagers": ["dockerfile", "docker-compose", "npm", "composer", "github-actions", "gomod", "terraform"],
   "packageRules": [
-    {
-      "description": [
-        "No major version updates"
-      ],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
-    },
-    {
-      "description": [
-        "No updates to PHP PDF libraries (too sensitive and risky)"
-      ],
-      "matchUpdateTypes": ["major", "minor", "patch"],
-      "matchManagers": ["composer"],
-      "matchPackageNames": ["tecnickcom/tcpdf", "mikehaertl/php-pdftk"],
-      "enabled": false
-    },
     {
       "description": [
         "No updates to postgres, redis, php or python docker images",
@@ -56,6 +39,15 @@
     },
     {
       "description": [
+        "No updates to PHP PDF libraries (too sensitive and risky)"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchManagers": ["composer"],
+      "matchPackageNames": ["tecnickcom/tcpdf", "mikehaertl/php-pdftk"],
+      "enabled": false
+    },
+    {
+      "description": [
         "cypress: bundle updates to package.json and dockerfile"
       ],
       "labels": ["devDependencies", "Renovate", "Cypress"],
@@ -63,6 +55,13 @@
       "matchUpdateTypes": ["major", "minor", "patch"],
       "matchManagers": ["dockerfile", "npm"],
       "matchPackagePatterns": ["cypress"]
+    },
+    {
+      "description": [
+        "No major version updates"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     },
     {
       "description": [
@@ -75,6 +74,7 @@
       "labels": ["Dependencies", "Renovate"],
       "matchManagers": ["composer", "npm"],
       "matchUpdateTypes": ["minor", "patch"],
+      "excludePackagePatterns": ["cypress"],
       "prCreation": "immediate",
       "prPriority": 4,
       "stabilityDays": 3


### PR DESCRIPTION
## Purpose

[LPAL-1174](https://opgtransform.atlassian.net/browse/LPAL-1174)

## Approach

* Update cypress Dockerfile and package*.json files at the same time.
* Don't do any major updates.
* Prevent updates to php, python, redis and postgres.
* Don't update PHP PDF libraries.

## Learning

Renovate is not my friend.

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes


[LPAL-1174]: https://opgtransform.atlassian.net/browse/LPAL-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ