### PR TITLE
LPAL-1174 Fix incorrect property in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   "branchPrefix": "renovate-",
-  "includeForks": true,
   "labels": ["Renovate", "Dependencies"],
   "commitMessageAction": "Renovate update",
   "lockFileMaintenance": {


### PR DESCRIPTION
## Purpose

Missed this when reworking the config. Causes a validation error.

[LPAL-1174](https://opgtransform.atlassian.net/browse/LPAL-1174)

## Approach

n/a

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes


[LPAL-1174]: https://opgtransform.atlassian.net/browse/LPAL-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ