### PR TITLE
LPAL-1184 Use PHP 8.1 for all composer updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -125,7 +125,8 @@
       "labels": ["Dependencies", "Renovate", "PHP"],
       "matchManagers": ["dockerfile", "docker-compose", "composer"],
       "matchUpdateTypes": ["patch"],
-      "includePackagePatterns": ["php"],
+      "matchPackageNames": ["php"],
+      "rangeStrategy": "in-range-only",
       "prCreation": "immediate",
       "prPriority": 4,
       "stabilityDays": 3
@@ -141,7 +142,8 @@
       "labels": ["Dependencies", "Renovate"],
       "matchManagers": ["composer", "npm"],
       "matchUpdateTypes": ["minor", "patch"],
-      "excludePackagePatterns": ["cypress", "php"],
+      "excludePackagePatterns": ["cypress"],
+      "excludePackageNames": ["php"],
       "prCreation": "immediate",
       "prPriority": 4,
       "stabilityDays": 3

--- a/renovate.json
+++ b/renovate.json
@@ -78,15 +78,14 @@
     },
     {
       "description": [
-        "No updates to postgres, redis, php or python docker images",
+        "No updates to postgres, redis or python docker images",
         "postgres: keep in sync with live",
         "redis: keep in sync with live",
-        "php: 8.2 upgrade needs to be managed manually",
         "python: to be removed"
       ],
       "matchUpdateTypes": ["major", "minor", "patch"],
       "matchManagers": ["dockerfile", "docker-compose"],
-      "matchPackageNames": ["postgres", "redis", "php", "python"],
+      "matchPackageNames": ["postgres", "redis", "python"],
       "enabled": false
     },
     {
@@ -109,16 +108,40 @@
     },
     {
       "description": [
-        "composer and npm Minor and Patch updates (stable for 3 days)",
+        "No major or minor updates to php"
+      ],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchManagers": ["dockerfile", "docker-compose", "composer"],
+      "matchPackageNames": ["php"],
+      "enabled": false
+    },
+    {
+      "description": [
+        "php patch updates (stable for 3 days)",
+        "Ignore major and minor PHP updates, only apply patches"
+      ],
+      "groupName": "php patch updates",
+      "groupSlug": "php-patch-updates",
+      "labels": ["Dependencies", "Renovate", "PHP"],
+      "matchManagers": ["dockerfile", "docker-compose", "composer"],
+      "matchUpdateTypes": ["patch"],
+      "includePackagePatterns": ["php"],
+      "prCreation": "immediate",
+      "prPriority": 4,
+      "stabilityDays": 3
+    },
+    {
+      "description": [
+        "composer and npm minor and patch updates (stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "minor and patch updates",
-      "groupSlug": "all-minor-patch-updates",
+      "groupName": "other minor and patch updates",
+      "groupSlug": "other-minor-patch-updates",
       "labels": ["Dependencies", "Renovate"],
       "matchManagers": ["composer", "npm"],
       "matchUpdateTypes": ["minor", "patch"],
-      "excludePackagePatterns": ["cypress"],
+      "excludePackagePatterns": ["cypress", "php"],
       "prCreation": "immediate",
       "prPriority": 4,
       "stabilityDays": 3

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,11 @@
   "branchPrefix": "renovate-",
   "labels": ["Renovate", "Dependencies"],
   "commitMessageAction": "Renovate update",
+  "force": {
+    "constraints": {
+      "php": ">=8.1 <8.2.0"
+    }
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": "before 5am on monday"


### PR DESCRIPTION
## Purpose

[LPAL-1184](https://opgtransform.atlassian.net/browse/LPAL-1184)

## Approach

Force PHP 8.1 in an attempt to make Renovate stop using incorrect PHP versions when updating composer.json.

## Learning

https://github.com/renovatebot/renovate/issues/2355#issuecomment-1452830039

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes


[LPAL-1184]: https://opgtransform.atlassian.net/browse/LPAL-1184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ