### PR TITLE
LPAL-1160 Remove 6-times loop from ping status page

### DIFF
--- a/service-api/module/Application/tests/Controller/PingControllerTest.php
+++ b/service-api/module/Application/tests/Controller/PingControllerTest.php
@@ -5,13 +5,17 @@ namespace ApplicationTest\Controller;
 use Application\Controller\PingController;
 use Aws\Credentials\CredentialsInterface;
 use Aws\Signature\SignatureV4;
+use Exception;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
 use Aws\Sqs\SqsClient;
 use MakeShared\Constants;
 use MakeShared\Logging\Logger;
-use Laminas\Db\Adapter\Adapter as ZendDbAdapter;
+use MakeShared\Logging\SimpleLogger;
+use Laminas\Db\Adapter\Adapter as DbAdapter;
+use Laminas\Db\Adapter\Driver\ConnectionInterface;
+use Laminas\Db\Adapter\Driver\DriverInterface;
 use Laminas\View\Model\JsonModel;
 use Http\Client\HttpClient;
 use GuzzleHttp\Psr7\Request;
@@ -35,7 +39,7 @@ class PingControllerTest extends MockeryTestCase
     private $signer;
 
     /**
-     * @var ZendDbAdapter|MockInterface
+     * @var DbAdapter|MockInterface
      */
     private $database;
 
@@ -51,7 +55,7 @@ class PingControllerTest extends MockeryTestCase
 
     public function setUp(): void
     {
-        $this->database = Mockery::mock(ZendDbAdapter::class);
+        $this->database = Mockery::mock(DbAdapter::class);
 
         $this->sqsClient = Mockery::mock(SqsClient::class);
 
@@ -75,7 +79,7 @@ class PingControllerTest extends MockeryTestCase
         $this->controller->setLogger($this->logger);
     }
 
-    public function testIndexActionSuccess()
+    public function testIndexActionSuccessDbAndGatewayDown()
     {
         $this->sqsClient->shouldReceive('getQueueAttributes')
             ->andReturn([
@@ -124,5 +128,108 @@ class PingControllerTest extends MockeryTestCase
         $result = $this->controller->indexAction();
 
         $this->assertEquals($expectedResult, $result->getVariables());
+    }
+
+    public function testIndexActionSuccessQueueDownDbAndGatewayExceptions()
+    {
+        $this->controller->setLogger(new SimpleLogger());
+
+        // bad response from SQS, so we throw an exception
+        $this->sqsClient->shouldReceive('getQueueAttributes')
+            ->andReturn([]);
+
+        // exception from Sirius gateway client
+        $this->httpClient->shouldReceive('sendRequest')
+            ->andThrow(new Exception('something went wrong with the client'));
+
+        // ping response JSON we expect
+        $expectedResult = [
+            'database' => [
+                'ok' => false,
+            ],
+            'gateway' => [
+                'ok' => false,
+            ],
+            'ok' => false,
+            'status' => Constants::STATUS_FAIL,
+            'queue' => [
+                'details' => [
+                    'available' => false,
+                    'length' => null,
+                    'lengthAcceptable' => false,
+                ],
+                'ok' => false,
+            ],
+        ];
+
+        /** @var JsonModel $result */
+        $result = $this->controller->indexAction();
+
+        $this->assertEquals($expectedResult, $result->getVariables());
+    }
+
+    public function testIndexActionSuccessAllServicesOk()
+    {
+        $this->controller->setLogger(new SimpleLogger());
+
+        // good response from SQS
+        $this->sqsClient->shouldReceive('getQueueAttributes')
+            ->andReturn([
+                'Attributes' => [
+                    'ApproximateNumberOfMessages' => 1,
+                    'ApproximateNumberOfMessagesNotVisible' => 2,
+                ]
+            ]);
+
+        // good response from Sirius
+        $mockResponse = Mockery::mock(Response::class);
+        $mockResponse->shouldReceive('getStatusCode')->andReturn(200);
+
+        $mockRequest = Mockery::mock(Request::class);
+        $this->signer->shouldReceive('signRequest')->andReturn($mockRequest);
+
+        $this->httpClient->shouldReceive('sendRequest')
+            ->andReturn($mockResponse);
+
+        // good response from db
+        $mockConnection = Mockery::mock(ConnectionInterface::class);
+        $mockConnection->shouldReceive('connect')->andReturn($mockConnection);
+
+        $mockDriver = Mockery::mock(DriverInterface::class);
+        $mockDriver->shouldReceive('getConnection')->andReturn($mockConnection);
+
+        $this->database->shouldReceive('getDriver')->andReturn($mockDriver);
+
+        // ping response JSON we expect
+        $expectedResult = [
+            'database' => [
+                'ok' => true,
+            ],
+            'gateway' => [
+                'ok' => true,
+            ],
+            'ok' => true,
+            'status' => Constants::STATUS_PASS,
+            'queue' => [
+                'details' => [
+                    'available' => true,
+                    'length' => 3,
+                    'lengthAcceptable' => true,
+                ],
+                'ok' => true,
+            ],
+        ];
+
+        /** @var JsonModel $result */
+        $result = $this->controller->indexAction();
+
+        $this->assertEquals($expectedResult, $result->getVariables());
+    }
+
+    public function testElbAction()
+    {
+        $response = $this->controller->elbAction();
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Happy face', $response->getContent());
     }
 }

--- a/service-front/module/Application/tests/Model/Service/System/StatusTest.php
+++ b/service-front/module/Application/tests/Model/Service/System/StatusTest.php
@@ -99,7 +99,7 @@ class StatusTest extends AbstractServiceTest
         $this->apiClient
             ->shouldReceive('httpGet')
             ->withArgs(['/ping'])
-            ->times(1)
+            ->once()
             ->andReturn([
                 'ok' => true,
                 'status' => Constants::STATUS_PASS,
@@ -108,10 +108,10 @@ class StatusTest extends AbstractServiceTest
         $this->dynamoDbClient
             ->shouldReceive('describeTable')
             ->withArgs([['TableName' => 'admin-test-table']])
-            ->times(1)
+            ->once()
             ->andReturn(new AwsResult(['@metadata' => ['statusCode' => 200],'Table' => ['TableStatus' => 'ACTIVE']]));
 
-        $this->sessionSaveHandler->shouldReceive('open')->times(1)->andReturn(true);
+        $this->sessionSaveHandler->shouldReceive('open')->once()->andReturn(true);
 
         $expectedOsResponse = [[
                 'line1' => 'SOME PALACE',
@@ -157,7 +157,6 @@ class StatusTest extends AbstractServiceTest
             ],
             'ok' => true,
             'status' => Constants::STATUS_PASS,
-            'iterations' => 1,
         ], $result);
     }
 
@@ -223,7 +222,6 @@ class StatusTest extends AbstractServiceTest
             ],
             'ok' => true,
             'status' => Constants::STATUS_WARN,
-            'iterations' => 1,
         ], $result);
     }
 
@@ -287,7 +285,6 @@ class StatusTest extends AbstractServiceTest
             ],
             'ok' => true,
             'status' => Constants::STATUS_WARN,
-            'iterations' => 1,
         ], $result);
     }
 
@@ -296,7 +293,7 @@ class StatusTest extends AbstractServiceTest
         $this->apiClient
             ->shouldReceive('httpGet')
             ->withArgs(['/ping'])
-            ->times(6)
+            ->once()
             ->andReturn([
                 'ok' => false,
                 'status' => Constants::STATUS_FAIL,
@@ -305,10 +302,10 @@ class StatusTest extends AbstractServiceTest
         $this->dynamoDbClient
             ->shouldReceive('describeTable')
             ->withArgs([['TableName' => 'admin-test-table']])
-            ->times(6)
+            ->once()
             ->andReturn(new AwsResult(['@metadata' => ['statusCode' => 200],'Table' => ['TableStatus' => 'ACTIVE']]));
 
-        $this->sessionSaveHandler->shouldReceive('open')->times(6)->andReturn(true);
+        $this->sessionSaveHandler->shouldReceive('open')->once()->andReturn(true);
 
         $expectedOsResponse = [[
                 'line1' => 'SOME PALACE',
@@ -354,7 +351,6 @@ class StatusTest extends AbstractServiceTest
             ],
             'ok' => false,
             'status' => Constants::STATUS_FAIL,
-            'iterations' => 6,
         ], $result);
     }
 
@@ -363,7 +359,7 @@ class StatusTest extends AbstractServiceTest
         $this->apiClient
             ->shouldReceive('httpGet')
             ->withArgs(['/ping'])
-            ->times(1)
+            ->once()
             ->andReturn([
                 'ok' => true,
                 'status' => Constants::STATUS_WARN,
@@ -372,10 +368,10 @@ class StatusTest extends AbstractServiceTest
         $this->dynamoDbClient
             ->shouldReceive('describeTable')
             ->withArgs([['TableName' => 'admin-test-table']])
-            ->times(1)
+            ->once()
             ->andReturn(new AwsResult(['@metadata' => ['statusCode' => 200],'Table' => ['TableStatus' => 'ACTIVE']]));
 
-        $this->sessionSaveHandler->shouldReceive('open')->times(1)->andReturn(true);
+        $this->sessionSaveHandler->shouldReceive('open')->once()->andReturn(true);
 
         $expectedOsResponse = [[
                 'line1' => 'SOME PALACE',
@@ -421,7 +417,6 @@ class StatusTest extends AbstractServiceTest
             ],
             'ok' => true,
             'status' => Constants::STATUS_WARN,
-            'iterations' => 1,
         ], $result);
     }
 
@@ -482,7 +477,6 @@ class StatusTest extends AbstractServiceTest
             ],
             'ok' => false,
             'status' => Constants::STATUS_FAIL,
-            'iterations' => 6,
         ], $result);
     }
 
@@ -547,7 +541,6 @@ class StatusTest extends AbstractServiceTest
             ],
             'ok' => false,
             'status' => Constants::STATUS_FAIL,
-            'iterations' => 6,
         ], $result);
     }
 
@@ -556,7 +549,7 @@ class StatusTest extends AbstractServiceTest
         $this->apiClient
             ->shouldReceive('httpGet')
             ->withArgs(['/ping'])
-            ->times(1)
+            ->once()
             ->andReturn([
                 'ok' => true,
                 'status' => Constants::STATUS_PASS,
@@ -565,10 +558,10 @@ class StatusTest extends AbstractServiceTest
         $this->dynamoDbClient
             ->shouldReceive('describeTable')
             ->withArgs([['TableName' => 'admin-test-table']])
-            ->times(1)
+            ->once()
             ->andReturn(new AwsResult(['@metadata' => ['statusCode' => 200],'Table' => ['TableStatus' => 'ACTIVE']]));
 
-        $this->sessionSaveHandler->shouldReceive('open')->times(1)->andReturn(true);
+        $this->sessionSaveHandler->shouldReceive('open')->once()->andReturn(true);
 
         $expectedOsResponse = [[
                 'line1' => 'SOME PALACE',
@@ -609,8 +602,6 @@ class StatusTest extends AbstractServiceTest
             // Unlike the other tests, when os fails it doesn't fail the overall health check as it's not vital to the service
             'ok' => true,
             'status' => Constants::STATUS_WARN,
-
-            'iterations' => 1,
         ], $result);
     }
 
@@ -619,7 +610,7 @@ class StatusTest extends AbstractServiceTest
         $this->apiClient
             ->shouldReceive('httpGet')
             ->withArgs(['/ping'])
-            ->times(1)
+            ->once()
             ->andReturn([
                 'ok' => true,
                 'status' => Constants::STATUS_PASS,
@@ -628,10 +619,10 @@ class StatusTest extends AbstractServiceTest
         $this->dynamoDbClient
             ->shouldReceive('describeTable')
             ->withArgs([['TableName' => 'admin-test-table']])
-            ->times(1)
+            ->once()
             ->andReturn(new AwsResult(['@metadata' => ['statusCode' => 200],'Table' => ['TableStatus' => 'ACTIVE']]));
 
-        $this->sessionSaveHandler->shouldReceive('open')->times(1)->andReturn(true);
+        $this->sessionSaveHandler->shouldReceive('open')->once()->andReturn(true);
 
         // mock os_last_call to within the last second
         $currentTimestamp = (new DateTime('now'))->getTimestamp();
@@ -670,8 +661,6 @@ class StatusTest extends AbstractServiceTest
 
             'ok' => true,
             'status' => Constants::STATUS_PASS,
-
-            'iterations' => 1,
         ], $result, 'OS call within 1 second of previous call should return cached details');
     }
 }

--- a/shared/module/MakeShared/src/Logging/LoggerTrait.php
+++ b/shared/module/MakeShared/src/Logging/LoggerTrait.php
@@ -2,6 +2,9 @@
 
 namespace MakeShared\Logging;
 
+use Laminas\Log\Logger as LaminasLogger;
+use MakeShared\Logging\Logger;
+
 /**
  * Trait LoggerTrait
  * @package MakeShared\Logging
@@ -9,26 +12,26 @@ namespace MakeShared\Logging;
 trait LoggerTrait
 {
     /**
-     * @var Logger
+     * @var LaminasLogger
      */
     private $logger;
 
     /**
-     * @param Logger $logger
+     * @param LaminasLogger $logger
      * @return $this
      */
-    public function setLogger(Logger $logger)
+    public function setLogger(LaminasLogger $logger)
     {
         $this->logger = $logger;
         return $this;
     }
 
     /**
-     * @return Logger $logger
+     * @return LaminasLogger $logger
      */
     public function getLogger()
     {
-        if (!$this->logger instanceof Logger) {
+        if (!$this->logger instanceof LaminasLogger) {
             $this->logger = new Logger();
         }
 


### PR DESCRIPTION
## Purpose

[LPAL-1160](https://opgtransform.atlassian.net/browse/LPAL-1160)

**Note: this branch is based off the LPAL-473 branch, and should be merged after that one.**

## Approach

See ticket.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes


[LPAL-1160]: https://opgtransform.atlassian.net/browse/LPAL-1160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ