### PR TITLE
Disabling capturing of form validation errors

### DIFF
--- a/service-front/assets/js/moj/moj.js
+++ b/service-front/assets/js/moj/moj.js
@@ -10,8 +10,10 @@
 
     init: function () {
       for (var x in moj.Modules) {
-        if (typeof moj.Modules[x].init === 'function') {
-          moj.Modules[x].init();
+        if (x != 'formErrorTracker') {
+          if (typeof moj.Modules[x].init === 'function') {
+            moj.Modules[x].init();
+          }
         }
       }
       // trigger initial render event


### PR DESCRIPTION
## Purpose

[Incident](https://incident.opg.service.justice.gov.uk/incident/694/) created as we were capturing some personal data in Google Analytics.
This fix should disable the capturing of form validation errors altogether to prevent any event data being sent to GA.

Fixes LPAL-####

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
