### PR TITLE
LPAL-1180 enable python in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -85,7 +85,7 @@
         "php: 8.2 upgrade needs to be managed manually"
       ],
       "matchUpdateTypes": ["major", "minor", "patch"],
-      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchManagers": ["dockerfile", "docker-compose", "composer"],
       "matchPackageNames": ["postgres", "redis", "php", "python"],
       "enabled": false
     },

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,13 @@
     "composer",
     "github-actions",
     "gomod",
-    "terraform"
+    "terraform",
+    "pip-requirements",
+    "pip-compile",
+    "pipenv",
+    "pyenv",
+    "setup-cfg",
+    "pip-setup"
   ],
   "packageRules": [
     {
@@ -73,15 +79,14 @@
     },
     {
       "description": [
-        "No updates to postgres, redis, php or python docker images",
+        "No updates to postgres, redis, or php docker images",
         "postgres: keep in sync with live",
         "redis: keep in sync with live",
-        "php: 8.2 upgrade needs to be managed manually",
-        "python: to be removed"
+        "php: 8.2 upgrade needs to be managed manually"
       ],
       "matchUpdateTypes": ["major", "minor", "patch"],
       "matchManagers": ["dockerfile", "docker-compose"],
-      "matchPackageNames": ["postgres", "redis", "php", "python"],
+      "matchPackageNames": ["postgres", "redis", "php"],
       "enabled": false
     },
     {
@@ -104,14 +109,14 @@
     },
     {
       "description": [
-        "composer and npm Minor and Patch updates (stable for 3 days)",
+        "composer , npm and python Minor and Patch updates (stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
       "groupName": "minor and patch updates",
       "groupSlug": "all-minor-patch-updates",
       "labels": ["Dependencies", "Renovate"],
-      "matchManagers": ["composer", "npm"],
+      "matchManagers": ["composer", "npm", "pip-requirements", "pip-compile", "pipenv", "pyenv", "setup-cfg", "pip-setup"],
       "matchUpdateTypes": ["minor", "patch"],
       "excludePackagePatterns": ["cypress"],
       "prCreation": "immediate",


### PR DESCRIPTION
## Purpose

_LPAL-1180 although we removed service-front-v2 and opg-feedback is built seperately then pulled in, we still have python scripts for the infrastructure side, so enable the python managers in renovate to keep these up to date_

## Approach

_Modify renovate config_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
