### PR TITLE
LPAL-1188/LPAL-1189 Renovate config, dep updates, composer upgrade, PHP pin, Python renovate fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ NOTIFY ?= $(shell aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-va
 # This user is in the test data seeded into the system.
 ADMIN_USERS := "seeded_test_user@digital.justice.gov.uk"
 
-COMPOSER_VERSION := "2.5.1"
+COMPOSER_VERSION := "2.5.5"
 
 # Unique identifier for this version of the application
 APP_VERSION := $(shell echo -n `git rev-parse --short HEAD`)
@@ -30,27 +30,28 @@ reset:
 
 .PHONY: run-front-composer
 run-front-composer:
-	@docker run -v `pwd`/service-front/:/app/ composer:${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
+	@docker run -v `pwd`/service-front/:/app/ -t composer_${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
 
 .PHONY: run-pdf-composer
 run-pdf-composer:
-	@docker run -v `pwd`/service-pdf/:/app/ composer:${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
+	@docker run -v `pwd`/service-pdf/:/app/ -t composer_${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
 
 .PHONY: run-api-composer
 run-api-composer:
-	@docker run -v `pwd`/service-api/:/app/ composer:${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
+	@docker run -v `pwd`/service-api/:/app/ -t composer_${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
 
 .PHONY: run-admin-composer
 run-admin-composer:
-	@docker run -v `pwd`/service-admin/:/app/ composer:${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
+	@docker run -v `pwd`/service-admin/:/app/ -t composer_${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
 
 .PHONY: run-shared-composer
 run-shared-composer:
-	@docker run -v `pwd`/shared/:/app/ composer:${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
+	@docker run -v `pwd`/shared/:/app/ composer_${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
 
 .PHONY: run-composers
 run-composers:
 	@docker pull composer:${COMPOSER_VERSION}; \
+	docker tag composer:${COMPOSER_VERSION} composer_${COMPOSER_VERSION}; \
 	${MAKE} -j run-front-composer run-pdf-composer run-api-composer run-admin-composer run-shared-composer
 
 .PHONY: dc-up

--- a/Makefile
+++ b/Makefile
@@ -30,28 +30,27 @@ reset:
 
 .PHONY: run-front-composer
 run-front-composer:
-	@docker run -v `pwd`/service-front/:/app/ -t composer_${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
+	@docker run -v `pwd`/service-front/:/app/ composer:${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
 
 .PHONY: run-pdf-composer
 run-pdf-composer:
-	@docker run -v `pwd`/service-pdf/:/app/ -t composer_${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
+	@docker run -v `pwd`/service-pdf/:/app/ composer:${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
 
 .PHONY: run-api-composer
 run-api-composer:
-	@docker run -v `pwd`/service-api/:/app/ -t composer_${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
+	@docker run -v `pwd`/service-api/:/app/ composer:${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
 
 .PHONY: run-admin-composer
 run-admin-composer:
-	@docker run -v `pwd`/service-admin/:/app/ -t composer_${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
+	@docker run -v `pwd`/service-admin/:/app/ composer:${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
 
 .PHONY: run-shared-composer
 run-shared-composer:
-	@docker run -v `pwd`/shared/:/app/ composer_${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
+	@docker run -v `pwd`/shared/:/app/ composer:${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
 
 .PHONY: run-composers
 run-composers:
 	@docker pull composer:${COMPOSER_VERSION}; \
-	docker tag composer:${COMPOSER_VERSION} composer_${COMPOSER_VERSION}; \
 	${MAKE} -j run-front-composer run-pdf-composer run-api-composer run-admin-composer run-shared-composer
 
 .PHONY: dc-up

--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,7 @@
   "commitMessageAction": "Renovate update",
   "renovateFork": true,
   "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": "before 5am on monday"
+    "enabled": false
   },
   "vulnerabilityAlerts": {
     "groupName": "Security Alerts",

--- a/renovate.json
+++ b/renovate.json
@@ -19,9 +19,9 @@
     "prCreation": "immediate",
     "prPriority": 5
   },
-  "prConcurrentLimit": 1,
-  "prHourlyLimit": 1,
-  "branchConcurrentLimit": 1,
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 10,
+  "branchConcurrentLimit": 10,
   "enabledManagers": [
     "dockerfile",
     "docker-compose",

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "labels": ["Renovate", "Dependencies"],
   "commitMessageAction": "Renovate update",
   "renovateFork": true,
+  "includeForks": true,
   "lockFileMaintenance": {
     "enabled": false
   },

--- a/renovate.json
+++ b/renovate.json
@@ -31,12 +31,12 @@
     "github-actions",
     "gomod",
     "terraform",
-    "pip-requirements",
+    "pip_requirements",
     "pip-compile",
     "pipenv",
     "pyenv",
     "setup-cfg",
-    "pip-setup"
+    "pip_setup"
   ],
   "packageRules": [
     {
@@ -140,6 +140,20 @@
       "excludePackagePatterns": ["cypress"],
       "excludePackageNames": ["php"],
       "ignorePaths": ["**/service-admin/**"],
+      "prCreation": "immediate",
+      "prPriority": 4,
+      "stabilityDays": 3
+    },
+    {
+      "description": [
+        "python minor and patch updates (stable for 3 days)"
+      ],
+      "automerge": false,
+      "groupName": "minor and patch updates (Python)",
+      "groupSlug": "all-minor-patch-updates-python",
+      "labels": ["Dependencies", "Renovate"],
+      "matchManagers": ["pip_requirements", "pip-compile", "pipenv", "pyenv", "setup-cfg", "pip_setup"],
+      "matchUpdateTypes": ["minor", "patch"],
       "prCreation": "immediate",
       "prPriority": 4,
       "stabilityDays": 3

--- a/renovate.json
+++ b/renovate.json
@@ -114,8 +114,8 @@
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "minor and patch updates 8.2",
-      "groupSlug": "all-minor-patch-updates",
+      "groupName": "minor and patch updates (PHP 8.2, npm)",
+      "groupSlug": "all-minor-patch-updates-82",
       "labels": ["Dependencies", "Renovate"],
       "matchManagers": ["composer", "npm", "pip-requirements", "pip-compile", "pipenv", "pyenv", "setup-cfg", "pip-setup"],
       "matchUpdateTypes": ["minor", "patch"],
@@ -132,8 +132,8 @@
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "minor and patch updates 8.1",
-      "groupSlug": "all-minor-patch-updates",
+      "groupName": "minor and patch updates (PHP 8.1, npm)",
+      "groupSlug": "all-minor-patch-updates-81",
       "labels": ["Dependencies", "Renovate"],
       "matchManagers": ["composer", "npm"],
       "matchUpdateTypes": ["minor", "patch"],

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
   "branchPrefix": "renovate-",
   "labels": ["Renovate", "Dependencies"],
   "commitMessageAction": "Renovate update",
-  "renovateFork": true,
   "includeForks": true,
   "lockFileMaintenance": {
     "enabled": false
@@ -20,9 +19,9 @@
     "prCreation": "immediate",
     "prPriority": 5
   },
-  "prConcurrentLimit": 10,
-  "prHourlyLimit": 10,
-  "branchConcurrentLimit": 10,
+  "prConcurrentLimit": 1,
+  "prHourlyLimit": 1,
+  "branchConcurrentLimit": 1,
   "enabledManagers": [
     "dockerfile",
     "docker-compose",

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "branchPrefix": "renovate-",
   "labels": ["Renovate", "Dependencies"],
   "commitMessageAction": "Renovate update",
+  "renovateFork": true,
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": "before 5am on monday"
@@ -109,7 +110,7 @@
     },
     {
       "description": [
-        "composer , npm and python Minor and Patch updates (stable for 3 days)",
+        "composer and npm minor and patch updates (PHP 8.2, stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
@@ -120,6 +121,25 @@
       "matchUpdateTypes": ["minor", "patch"],
       "excludePackagePatterns": ["cypress"],
       "excludePackageNames": ["php"],
+      "ignorePaths": ["**/service-front/**", "**/service-api/**", "**/service-pdf/**", "**/shared/**"],
+      "prCreation": "immediate",
+      "prPriority": 4,
+      "stabilityDays": 3
+    },
+    {
+      "description": [
+        "composer and npm minor and patch updates (PHP 8.1, stable for 3 days)",
+        "These might be automerged once we're comfortable with Renovate"
+      ],
+      "automerge": false,
+      "groupName": "minor and patch updates",
+      "groupSlug": "all-minor-patch-updates",
+      "labels": ["Dependencies", "Renovate"],
+      "matchManagers": ["composer", "npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackagePatterns": ["cypress"],
+      "excludePackageNames": ["php"],
+      "ignorePaths": ["**/service-admin/**"],
       "prCreation": "immediate",
       "prPriority": 4,
       "stabilityDays": 3

--- a/renovate.json
+++ b/renovate.json
@@ -114,7 +114,7 @@
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "minor and patch updates",
+      "groupName": "minor and patch updates 8.2",
       "groupSlug": "all-minor-patch-updates",
       "labels": ["Dependencies", "Renovate"],
       "matchManagers": ["composer", "npm", "pip-requirements", "pip-compile", "pipenv", "pyenv", "setup-cfg", "pip-setup"],
@@ -132,7 +132,7 @@
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "minor and patch updates",
+      "groupName": "minor and patch updates 8.1",
       "groupSlug": "all-minor-patch-updates",
       "labels": ["Dependencies", "Renovate"],
       "matchManagers": ["composer", "npm"],

--- a/service-admin/composer.json
+++ b/service-admin/composer.json
@@ -10,7 +10,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "laminas/laminas-component-installer": true
-        }
+        },
+        "platform": {"php": "8.2.3"}
     },
     "require": {
         "php": ">=8.2 <8.3.0",

--- a/service-admin/composer.lock
+++ b/service-admin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89dfedca9e082c32099217116af67129",
+    "content-hash": "5f5e1289b154f75cc41a3d269c791ed3",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.263.1",
+            "version": "3.263.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "1f1ca8866e54aabdcde2aba177196ec2f12ee8a2"
+                "reference": "5516a7edae70fff66223b2fd320c20b3b17ced56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/1f1ca8866e54aabdcde2aba177196ec2f12ee8a2",
-                "reference": "1f1ca8866e54aabdcde2aba177196ec2f12ee8a2",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/5516a7edae70fff66223b2fd320c20b3b17ced56",
+                "reference": "5516a7edae70fff66223b2fd320c20b3b17ced56",
                 "shasum": ""
             },
             "require": {
@@ -150,9 +150,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.263.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.263.2"
             },
-            "time": "2023-03-31T18:21:25+00:00"
+            "time": "2023-04-03T18:19:25+00:00"
         },
         {
             "name": "brick/varexporter",
@@ -3772,25 +3772,25 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3819,9 +3819,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "psr/http-server-handler",
@@ -6736,16 +6736,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.16.1",
+            "version": "1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "e27e92d939e2e3636f0a1f0afaba59692c0bf571"
+                "reference": "d3753fcb3abc6f78f5de6f72153d4b9c99c72dee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/e27e92d939e2e3636f0a1f0afaba59692c0bf571",
-                "reference": "e27e92d939e2e3636f0a1f0afaba59692c0bf571",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/d3753fcb3abc6f78f5de6f72153d4b9c99c72dee",
+                "reference": "d3753fcb3abc6f78f5de6f72153d4b9c99c72dee",
                 "shasum": ""
             },
             "require": {
@@ -6775,9 +6775,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.16.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.17.1"
             },
-            "time": "2023-02-07T18:11:17+00:00"
+            "time": "2023-04-04T11:11:22+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -7206,12 +7206,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "859e034a7425f6fd0c30c58198f831ac6c7e6bfb"
+                "reference": "49bcdfcfebe63a59d1b19b1eb12737868011e2c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/859e034a7425f6fd0c30c58198f831ac6c7e6bfb",
-                "reference": "859e034a7425f6fd0c30c58198f831ac6c7e6bfb",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/49bcdfcfebe63a59d1b19b1eb12737868011e2c7",
+                "reference": "49bcdfcfebe63a59d1b19b1eb12737868011e2c7",
                 "shasum": ""
             },
             "conflict": {
@@ -7229,6 +7229,7 @@
                 "amphp/http-client": ">=4,<4.4",
                 "anchorcms/anchor-cms": "<=0.12.7",
                 "andreapollastri/cipi": "<=3.1.15",
+                "andrewhaine/silverstripe-form-capture": ">=0.2,<=0.2.3|>=1,<=1.0.1|>=2,<=2.2.4",
                 "apereo/phpcas": "<1.6",
                 "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6|>=2.6,<2.7.10|>=3,<3.0.12|>=3.1,<3.1.3",
                 "appwrite/server-ce": "<0.11.1|>=0.12,<0.12.2",
@@ -7247,6 +7248,7 @@
                 "barzahlen/barzahlen-php": "<2.0.1",
                 "baserproject/basercms": "<4.7.5",
                 "bassjobsen/bootstrap-3-typeahead": ">4.0.2",
+                "bigfork/silverstripe-form-capture": ">=3,<=3.1",
                 "billz/raspap-webgui": "<=2.6.6",
                 "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
                 "bmarshall511/wordpress_zero_spam": "<5.2.13",
@@ -7330,7 +7332,7 @@
                 "ezsystems/ezplatform-graphql": ">=1-rc.1,<1.0.13|>=2-beta.1,<2.3.12",
                 "ezsystems/ezplatform-kernel": "<1.2.5.1|>=1.3,<1.3.26",
                 "ezsystems/ezplatform-rest": ">=1.2,<=1.2.2|>=1.3,<1.3.8",
-                "ezsystems/ezplatform-richtext": ">=2.3,<=2.3.7",
+                "ezsystems/ezplatform-richtext": ">=2.3,<2.3.7.1",
                 "ezsystems/ezplatform-user": ">=1,<1.0.1",
                 "ezsystems/ezpublish-kernel": "<6.13.8.2|>=7,<7.5.30",
                 "ezsystems/ezpublish-legacy": "<=2017.12.7.3|>=2018.6,<=2019.3.5.1",
@@ -7378,7 +7380,7 @@
                 "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
                 "gree/jose": "<2.2.1",
                 "gregwar/rst": "<1.0.3",
-                "grumpydictator/firefly-iii": "<5.8",
+                "grumpydictator/firefly-iii": "<6",
                 "guzzlehttp/guzzle": "<6.5.8|>=7,<7.4.5",
                 "guzzlehttp/psr7": "<1.8.4|>=2,<2.1.1",
                 "harvesthq/chosen": "<1.8.7",
@@ -7531,6 +7533,7 @@
                 "phpxmlrpc/extras": "<0.6.1",
                 "phpxmlrpc/phpxmlrpc": "<4.9.2",
                 "pimcore/data-hub": "<1.2.4",
+                "pimcore/perspective-editor": "<1.5.1",
                 "pimcore/pimcore": "<10.5.20",
                 "pixelfed/pixelfed": "<=0.11.4",
                 "pocketmine/bedrock-protocol": "<8.0.2",
@@ -7794,7 +7797,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-31T23:04:35+00:00"
+            "time": "2023-04-03T22:04:05+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -9111,5 +9114,8 @@
         "php": ">=8.2 <8.3.0"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.2.3"
+    },
     "plugin-api-version": "2.3.0"
 }

--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine3.17
+FROM php:8.2.3-fpm-alpine3.17
 
 RUN adduser -D -g '' appuser
 
@@ -26,7 +26,7 @@ RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
 # Install composer dependencies
 COPY --chown=root:root service-admin/composer.json /app/composer.json
 COPY --chown=root:root service-admin/composer.lock /app/composer.lock
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version 2.5.1 \
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version 2.5.5 \
     && composer install --prefer-dist --no-interaction --no-cache --no-scripts --no-dev --optimize-autoloader -d /app \
     && chown -R root:root /app/vendor \
     && rm /app/composer.json \

--- a/service-api/composer.json
+++ b/service-api/composer.json
@@ -57,6 +57,7 @@
     "config": {
         "allow-plugins": {
             "laminas/laminas-component-installer": true
-        }
+        },
+        "platform": {"php": "8.1.16"}
     }
 }

--- a/service-api/composer.lock
+++ b/service-api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82b816c2c54b4d8a40fad7950e409358",
+    "content-hash": "2ba838bc9775e82e4f76a966fd23bf01",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -8707,5 +8707,8 @@
         "php": ">=8.1 <8.2.0"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.1.16"
+    },
     "plugin-api-version": "2.3.0"
 }

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-alpine3.15
+FROM php:8.1.16-fpm-alpine3.17
 
 RUN adduser -D -g '' appuser
 
@@ -32,7 +32,7 @@ RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
 # Install composer dependencies
 COPY --chown=root:root service-api/composer.json /app/composer.json
 COPY --chown=root:root service-api/composer.lock /app/composer.lock
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version 2.5.1 \
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version 2.5.5 \
     && composer install --prefer-dist --no-interaction --no-cache --no-scripts --no-dev --optimize-autoloader -d /app \
     && chown -R root:root /app/vendor \
     && rm /app/composer.json \

--- a/service-front/composer.json
+++ b/service-front/composer.json
@@ -63,6 +63,7 @@
     "config": {
         "allow-plugins": {
             "laminas/laminas-component-installer": true
-        }
+        },
+        "platform": {"php": "8.1.16"}
     }
 }

--- a/service-front/composer.lock
+++ b/service-front/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52617c1c0d1bf0a1610a2192d7d6cbcc",
+    "content-hash": "00aa58ebe04dd82af881af6562148c4f",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -8417,5 +8417,8 @@
         "php": ">=8.1 <8.2.0"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.1.16"
+    },
     "plugin-api-version": "2.3.0"
 }

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-alpine3.15
+FROM php:8.1.16-fpm-alpine3.17
 
 RUN adduser -D -g '' appuser
 RUN apk add --upgrade --no-cache apk-tools
@@ -21,7 +21,7 @@ ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
 # Install composer dependencies
 COPY --chown=root:root service-front/composer.json /app/composer.json
 COPY --chown=root:root service-front/composer.lock /app/composer.lock
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version 2.5.1 \
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version 2.5.5 \
     && composer install --prefer-dist --no-interaction --no-cache --no-scripts --no-dev --optimize-autoloader -d /app
 
 # Core files for the application

--- a/service-front/package-lock.json
+++ b/service-front/package-lock.json
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.59.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.59.3.tgz",
-      "integrity": "sha512-QCq98N3hX1jfTCoUAsF3eyGuXLsY7BCnCEg9qAact94Yc21npG2/mVOqoDvE0fCbWDqiM4WlcJQla0gWG2YlxQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.60.0.tgz",
+      "integrity": "sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/service-pdf/composer.json
+++ b/service-pdf/composer.json
@@ -3,6 +3,9 @@
     "description": "Worker service for creating Lasting Power of Attorney PDF documents",
     "minimum-stability": "stable",
     "license": "MIT",
+    "config": {
+        "platform": {"php": "8.1.16"}
+    },
     "repositories": [
     ],
     "require": {

--- a/service-pdf/composer.lock
+++ b/service-pdf/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fea45fe30ffde578db1a9a96a7cc88e4",
+    "content-hash": "8775f67ea0808b06e71277f361f2b403",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.263.1",
+            "version": "3.263.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "1f1ca8866e54aabdcde2aba177196ec2f12ee8a2"
+                "reference": "5516a7edae70fff66223b2fd320c20b3b17ced56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/1f1ca8866e54aabdcde2aba177196ec2f12ee8a2",
-                "reference": "1f1ca8866e54aabdcde2aba177196ec2f12ee8a2",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/5516a7edae70fff66223b2fd320c20b3b17ced56",
+                "reference": "5516a7edae70fff66223b2fd320c20b3b17ced56",
                 "shasum": ""
             },
             "require": {
@@ -150,9 +150,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.263.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.263.2"
             },
-            "time": "2023-03-31T18:21:25+00:00"
+            "time": "2023-04-03T18:19:25+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -1619,25 +1619,25 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -1666,9 +1666,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "psr/log",
@@ -3718,16 +3718,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.16.1",
+            "version": "1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "e27e92d939e2e3636f0a1f0afaba59692c0bf571"
+                "reference": "d3753fcb3abc6f78f5de6f72153d4b9c99c72dee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/e27e92d939e2e3636f0a1f0afaba59692c0bf571",
-                "reference": "e27e92d939e2e3636f0a1f0afaba59692c0bf571",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/d3753fcb3abc6f78f5de6f72153d4b9c99c72dee",
+                "reference": "d3753fcb3abc6f78f5de6f72153d4b9c99c72dee",
                 "shasum": ""
             },
             "require": {
@@ -3757,9 +3757,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.16.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.17.1"
             },
-            "time": "2023-02-07T18:11:17+00:00"
+            "time": "2023-04-04T11:11:22+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5934,6 +5934,9 @@
     },
     "platform-dev": {
         "ext-json": "*"
+    },
+    "platform-overrides": {
+        "php": "8.1.16"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-cli-alpine3.15
+FROM php:8.1.16-cli-alpine3.17
 
 RUN adduser -D -g '' appuser
 
@@ -26,7 +26,7 @@ RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
 # Install composer dependencies
 COPY --chown=root:root service-pdf/composer.json /app/composer.json
 COPY --chown=root:root service-pdf/composer.lock /app/composer.lock
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version 2.5.1 \
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version 2.5.5 \
     && composer install --prefer-dist --no-interaction --no-cache --no-scripts --no-dev --optimize-autoloader -d /app \
     && chown -R root:root /app/vendor \
     && rm /app/composer.json \

--- a/shared/composer.json
+++ b/shared/composer.json
@@ -7,7 +7,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "laminas/laminas-component-installer": true
-        }
+        },
+        "platform": {"php": "8.1.16"}
     },
     "require": {
         "php": "^8.1",

--- a/shared/composer.lock
+++ b/shared/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e01ea1d54e1e5beda941e7f0d446031",
+    "content-hash": "83ca81a1bb12c04d6628df7ae875503d",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1525,25 +1525,25 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -1572,9 +1572,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "psr/log",
@@ -3329,16 +3329,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.16.1",
+            "version": "1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "e27e92d939e2e3636f0a1f0afaba59692c0bf571"
+                "reference": "d3753fcb3abc6f78f5de6f72153d4b9c99c72dee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/e27e92d939e2e3636f0a1f0afaba59692c0bf571",
-                "reference": "e27e92d939e2e3636f0a1f0afaba59692c0bf571",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/d3753fcb3abc6f78f5de6f72153d4b9c99c72dee",
+                "reference": "d3753fcb3abc6f78f5de6f72153d4b9c99c72dee",
                 "shasum": ""
             },
             "require": {
@@ -3368,9 +3368,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.16.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.17.1"
             },
-            "time": "2023-02-07T18:11:17+00:00"
+            "time": "2023-04-04T11:11:22+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5604,5 +5604,8 @@
         "php": "^8.1"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.1.16"
+    },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
## Purpose

[LPAL-1188](https://opgtransform.atlassian.net/browse/LPAL-1188)

[LPAL-1189](https://opgtransform.atlassian.net/browse/LPAL-1189)

The aim is to get everything in the codebase up to date as far as possible, alongside a working Renovate config.

## Approach

* Fix Python renovate config by moving to separate package rule and fixing typos in manager names.
* Define a specific version of PHP for all components, so Renovate doesn't try to use the wrong version. Set this in Dockerfile and composer.json.
* Update all deps manually for npm and composer.
* Split PHP 8.1 and 8.2 updates into different rulesets. This forces Renovate to use the right PHP version, based on the setting in composer.json under config.platform.php.
* Update to composer 2.5.5 throughout.
* Modify how composer containers are used in the Makefile so we pull fewer images.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] I have added mandatory tags to terraformed resources, where possible
* [X] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [X] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes


[LPAL-1188]: https://opgtransform.atlassian.net/browse/LPAL-1188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPAL-1189]: https://opgtransform.atlassian.net/browse/LPAL-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ