### PR TITLE
LPAL-1189 Missed these python manager references in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -116,7 +116,7 @@
       "groupName": "minor and patch updates (PHP 8.2, npm)",
       "groupSlug": "all-minor-patch-updates-82",
       "labels": ["Dependencies", "Renovate"],
-      "matchManagers": ["composer", "npm", "pip-requirements", "pip-compile", "pipenv", "pyenv", "setup-cfg", "pip-setup"],
+      "matchManagers": ["composer", "npm", "pip_requirements", "pip-compile", "pipenv", "pyenv", "setup-cfg", "pip_setup"],
       "matchUpdateTypes": ["minor", "patch"],
       "excludePackagePatterns": ["cypress"],
       "excludePackageNames": ["php"],


### PR DESCRIPTION
## Purpose

LPAL-1189

## Approach

See ticket.

## Learning

n/a

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
