### PR TITLE
LPAL-1136 Retrieve RDS password from AWS Secrets Manager at run time

### DIFF
--- a/service-api/config/autoload/global.php
+++ b/service-api/config/autoload/global.php
@@ -48,6 +48,19 @@ return [
                 'password'  => getenv('OPG_LPA_POSTGRES_PASSWORD') ?: null,
             ],
         ],
+        'secrets' => [
+            'client' => [
+                'version' => '2017-10-17',
+                'region' => 'eu-west-1',
+                'credentials' => (getenv('AWS_ACCESS_KEY_ID') && getenv('AWS_SECRET_ACCESS_KEY')) ? [
+                    'key'    => getenv('AWS_ACCESS_KEY_ID'),
+                    'secret' => getenv('AWS_SECRET_ACCESS_KEY'),
+                ] : null,
+                ],
+            'settings' => [
+                'secret_name' => getenv('OPG_LPA_DB_SECRET_NAME') ?: null,
+            ],
+        ]
     ],
 
     'pdf' => [

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -376,7 +376,8 @@ locals {
         { "name" : "OPG_LPA_COMMON_PDF_CACHE_S3_BUCKET", "value" : data.aws_s3_bucket.lpa_pdf_cache.bucket },
         { "name" : "OPG_LPA_COMMON_PDF_QUEUE_URL", "value" : "https://sqs.${var.region_name}.amazonaws.com/${var.account.account_id}/lpa-pdf-queue-${var.environment_name}.fifo" },
         { "name" : "OPG_LPA_TELEMETRY_HOST", "value" : "127.0.0.1" },
-        { "name" : "OPG_LPA_TELEMETRY_PORT", "value" : "2000" }
+        { "name" : "OPG_LPA_TELEMETRY_PORT", "value" : "2000" },
+        { "name" : "OPG_LPA_DB_SECRET_NAME", "value" : data.aws_secretsmanager_secret.api_rds_password.name }
       ]
     }
   )

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -231,6 +231,27 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
   }
   statement {
+    sid    = "accessDatabasePassword"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+    resources = [
+      data.aws_secretsmanager_secret.api_rds_password.name,
+    ]
+  }
+  statement {
+    sid    = "decryptDatabasePassword"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+    ]
+    resources = [
+      data.aws_kms_alias.multi_region_secrets_encryption_alias.target_key_arn,
+      data.aws_kms_alias.secrets_encryption_alias.target_key_arn,
+    ]
+  }
+  statement {
     sid    = "lpaQueueDecrypt"
     effect = "Allow"
     actions = [

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -237,7 +237,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "secretsmanager:GetSecretValue",
     ]
     resources = [
-      data.aws_secretsmanager_secret.api_rds_password.name,
+      data.aws_secretsmanager_secret.api_rds_password.arn,
     ]
   }
   statement {


### PR DESCRIPTION
## Purpose

Retrieve RDS password from AWS Secrets Manager at run time

Fixes LPAL-1136

## Approach

Create a new SecretsManagerClient when a ZendDbAdapter is created and use the `getSecretValue` method to retrieve the RDS secret value. Use the retrieved password to authenticate against the RDS database.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
