### PR TITLE
LPAL-1203 Change version of local redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 
   redis:
     container_name: lpa-redis
-    image: library/redis:alpine
+    image: library/redis:6.2-alpine
     ports:
       - 6379:6379
 


### PR DESCRIPTION
## Purpose

Use a version of Redis in docker-compose that matches the major version used in AWS.

Fixes LPAL-1203

## Approach

Change the version of redis in docker-compose.yml to a fixed version.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
