### PR TITLE
LPAL-1202 locust tests in CI DO NOT MERGE

### DIFF
--- a/.github/workflows/locust_tests.yml
+++ b/.github/workflows/locust_tests.yml
@@ -1,0 +1,103 @@
+name: "[Workflow] Locust Tests"
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_call:
+    inputs:
+      account_id:
+        description: "AWS account ID containing the role to assume for boto commands"
+        required: true
+        type: string
+      front_url:
+        description: "URL of the frontend"
+        required: true
+        type: string
+    secrets:
+      AWS_ACCESS_KEY_ID_ACTIONS:
+        required: true
+      AWS_SECRET_ACCESS_KEY_ACTIONS:
+        required: true
+
+jobs:
+  locust_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Configure AWS Credentials - Security Group & ECR
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # tag=v2.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+          aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/opg-lpa-ci
+          role-duration-seconds: 900
+          role-session-name: OPGLPACypressTestsSecurityGroupECR
+
+      - name: Setup Python
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # tag=v4.5.0
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/pipeline/ci_ingress/requirements.txt
+
+      - name: Download Terraform Task definition
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # tag=v3.0.2
+        with:
+          name: terraform-artifact
+          path: /tmp/
+
+      - name: Add GitHub Actions runner Ingress Rule
+        run: |
+          python scripts/pipeline/ci_ingress/ci_ingress.py /tmp/environment_pipeline_tasks_config.json --add
+
+      - name: Configure AWS Credentials - Cypress / S3Monitor
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # tag=v2.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+          aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::050256574573:role/opg-lpa-ci
+          role-duration-seconds: 3600
+          role-session-name: OPGLPACypressTestsCypressS3Monitor
+
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: |
+            ~/.cache/Cypress
+            node_modules
+          key: node-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # tag=v3.6.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Run Locust Tests
+        env:
+          DISABLE_SSL_VERIFY: True
+        run: |
+          pip install boto3 locust
+          python3 cypress/S3Monitor.py
+
+      - name: Configure AWS Credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # tag=v2.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
+          aws-region: eu-west-1
+          role-duration-seconds: 900
+          role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/opg-lpa-ci
+          role-session-name: OPGLPACypressTestsSecurityGroupEnd
+
+      - name: Remove GitHub Actions runner Ingress Rule
+        if: always()
+        run: |
+          python scripts/pipeline/ci_ingress/ci_ingress.py /tmp/environment_pipeline_tasks_config.json

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -427,6 +427,15 @@ jobs:
       cypress_tags: "@Signup,not @Signup and not @PartOfStitchedRun and not @StitchedHW and not @StitchedPF and not @StitchedClone and not @CorrespondentReuse and not @SignupIncluded and not @AdminSystemMessage and not @CheckoutPaymentGateway"
     secrets: inherit
 
+  locust_tests:
+    name: Run locust tests
+    uses: ./.github/workflows/locust_tests.yml
+    needs:
+      - terraform_outputs
+    with:
+      front_url: https://${{ needs.terraform_outputs.outputs.front_fqdn }}
+      account_id: "050256574573"
+    secrets: inherit
 
   post_tests_slack_msg:
     name: Post-Tests Slack message


### PR DESCRIPTION
## Purpose

_Run locust tests in CI_

## Approach

_Add action similar to that for cypress but kicks off s3monitor and locust instead_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
