### PR TITLE
LPAL-1215 Correct cypress asserts on num of option

### DIFF
--- a/cypress/e2e/DonorHW.feature
+++ b/cypress/e2e/DonorHW.feature
@@ -27,8 +27,8 @@ Feature: Add donor to Health and Welfare LPA
         # cypress is not reliable at filling in postcode fully before hitting next button, so, ensure it is now filled in
         And I see "postcode-lookup" prepopulated within timeout with "B1 1TF"
         And I click element marked "Find UK address"
-        # casper simply checked for 6 options so we do too, but we may ultimately wish to check the values
-        Then I can find "address-search-result" with 6 options
+        # casper simply checked for 6 options. PAF was updated to remove some of the addresses from the tested postcode so we check for 3. We may ultimately wish to check the values
+        Then I can find "address-search-result" with 3 options
 
         # Check error message when donor > 100 years old
         When I force fill out

--- a/cypress/e2e/DonorPF.feature
+++ b/cypress/e2e/DonorPF.feature
@@ -27,8 +27,8 @@ Feature: Add donor to Property and Finance LPA
         # cypress is not reliable at filling in postcode fully before hitting next button, so, ensure it is now filled in
         And I see "postcode-lookup" prepopulated within timeout with "B1 1TF"
         And I click element marked "Find UK address"
-        # casper simply checked for 6 options so we do too, but we may ultimately wish to check the values
-        Then I can find "address-search-result" with 6 options
+        # casper simply checked for 6 options. PAF was updated to remove some of the addresses from the tested postcode so we check for 3. We may ultimately wish to check the values
+        Then I can find "address-search-result" with 3 options
         # casper simply checked for 8 options so we do too, but we may ultimately wish to check the values
         And I can find "name-title" with 8 options
         When I force fill out


### PR DESCRIPTION
## Purpose

Fix broken cypress tests where 5 addresses were expected but only 2 were returned.

Fixes LPAL-1215

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
