### PR TITLE
LPAL-573 Move Cloudwatch Log Group to region

### DIFF
--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -1,19 +1,5 @@
-#tfsec:ignore:aws-cloudwatch-log-group-customer-key
-resource "aws_cloudwatch_log_group" "online-lpa" {
-  name              = "online-lpa"
-  retention_in_days = local.account.retention_in_days
-
-  tags = merge(
-    local.shared_component_tag,
-    {
-      "Name" = "online-lpa"
-    },
-  )
-}
-
 data "aws_cloudwatch_log_group" "cloudtrail" {
-  name     = "online_lpa_cloudtrail_${local.account_name}"
-  provider = aws.eu-west-1
+  name = "online_lpa_cloudtrail_${local.account_name}"
 }
 
 resource "aws_cloudwatch_log_metric_filter" "breakglass_metric" {

--- a/terraform/region/modules/region/cloudwatch.tf
+++ b/terraform/region/modules/region/cloudwatch.tf
@@ -90,3 +90,16 @@ data "aws_iam_policy_document" "task_stopped_topic_policy" {
     resources = [aws_sns_topic.cloudwatch_to_account_ops_alerts.arn]
   }
 }
+
+#tfsec:ignore:aws-cloudwatch-log-group-customer-key
+resource "aws_cloudwatch_log_group" "online-lpa" {
+  name              = "online-lpa"
+  retention_in_days = local.account.retention_in_days
+
+  tags = merge(
+    local.shared_component_tag,
+    {
+      "Name" = "online-lpa"
+    },
+  )
+}


### PR DESCRIPTION
## Purpose

Move Cloudwatch Log Group from Account Terraform state to Region Terraform state

Fixes LPAL-573

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
