### PR TITLE
LPAL-573 Remove hardcoded EU-WEST-1 values

### DIFF
--- a/service-admin/config/autoload/mezzio.global.php
+++ b/service-admin/config/autoload/mezzio.global.php
@@ -44,7 +44,7 @@ return [
             'client' => [
                 'endpoint' => getenv('OPG_LPA_COMMON_DYNAMODB_ENDPOINT') ?: null,
                 'version' => '2012-08-10',
-                'region' => 'eu-west-1',
+                'region' => getenv('AWS_REGION') ?: 'eu-west-1',
             ],
             'settings' => [
                 'table_name' => getenv('OPG_LPA_COMMON_ADMIN_DYNAMODB_TABLE') ?: null,

--- a/service-api/config/autoload/global.php
+++ b/service-api/config/autoload/global.php
@@ -19,7 +19,7 @@ return [
             'client' => [
                 'endpoint' => getenv('OPG_LPA_COMMON_DYNAMODB_ENDPOINT') ?: null,
                 'version' => '2012-08-10',
-                'region' => 'eu-west-1',
+                'region' => getenv('AWS_REGION') ?: 'eu-west-1',
                 'credentials' => (getenv('AWS_ACCESS_KEY_ID') && getenv('AWS_SECRET_ACCESS_KEY')) ? [
                     'key'    => getenv('AWS_ACCESS_KEY_ID'),
                     'secret' => getenv('AWS_SECRET_ACCESS_KEY'),
@@ -65,7 +65,7 @@ return [
                     'endpoint' => getenv('OPG_LPA_COMMON_S3_ENDPOINT') ?: null,
                     'use_path_style_endpoint' => true,
                     'version' => '2006-03-01',
-                    'region' => 'eu-west-1',
+                    'region' => getenv('AWS_REGION') ?: 'eu-west-1',
                 ],
             ], // S3
 
@@ -77,7 +77,7 @@ return [
                     'url' => getenv('OPG_LPA_COMMON_PDF_QUEUE_URL') ?: null,
                 ],
                 'client' => [
-                    'region' => 'eu-west-1',
+                    'region' => getenv('AWS_REGION') ?: 'eu-west-1',
                     'version' => '2012-11-05',
                 ],
             ],
@@ -92,7 +92,7 @@ return [
                 'client' => [
                     'endpoint' => getenv('OPG_LPA_COMMON_DYNAMODB_ENDPOINT') ?: null,
                     'version' => '2012-08-10',
-                    'region' => 'eu-west-1',
+                    'region' => getenv('AWS_REGION') ?: 'eu-west-1',
                     'credentials' => (getenv('AWS_ACCESS_KEY_ID') && getenv('AWS_SECRET_ACCESS_KEY')) ? [
                         'key'    => getenv('AWS_ACCESS_KEY_ID'),
                         'secret' => getenv('AWS_SECRET_ACCESS_KEY'),
@@ -114,7 +114,7 @@ return [
             'client' => [
                 'endpoint' => getenv('OPG_LPA_COMMON_DYNAMODB_ENDPOINT') ?: null,
                 'version' => '2012-08-10',
-                'region' => 'eu-west-1',
+                'region' => getenv('AWS_REGION') ?: 'eu-west-1',
                 'credentials' => (getenv('AWS_ACCESS_KEY_ID') && getenv('AWS_SECRET_ACCESS_KEY')) ? [
                     'key'    => getenv('AWS_ACCESS_KEY_ID'),
                     'secret' => getenv('AWS_SECRET_ACCESS_KEY'),

--- a/service-front/config/autoload/global.php
+++ b/service-front/config/autoload/global.php
@@ -3,7 +3,7 @@
 $DYNAMO_DB_CONFIG = [
     'endpoint' => getenv('OPG_LPA_COMMON_DYNAMODB_ENDPOINT') ?: null,
     'version' => '2012-08-10',
-    'region' => 'eu-west-1',
+    'region' => getenv('AWS_REGION') ?: 'eu-west-1',
 ];
 
 return [

--- a/service-pdf/config/global.php
+++ b/service-pdf/config/global.php
@@ -16,7 +16,7 @@ return [
                 'url' => getenv('OPG_LPA_COMMON_PDF_QUEUE_URL') ?: null,
             ],
             'client' => [
-                'region' => 'eu-west-1',
+                'region' => getenv('AWS_REGION') ?: 'eu-west-1',
                 'version' => '2012-11-05',
             ],
         ],
@@ -31,7 +31,7 @@ return [
                 'endpoint' => getenv('OPG_LPA_COMMON_S3_ENDPOINT') ?: null,
                 'use_path_style_endpoint' => true,
                 'version' => '2006-03-01',
-                'region' => 'eu-west-1',
+                'region' => getenv('AWS_REGION') ?: 'eu-west-1',
             ],
             'settings' => [
                 'ACL' => 'private',


### PR DESCRIPTION
## Purpose

Remove hardcoded EU-WEST-1 values and rely on the ECS provided AWS_REGION.

Fixes LPAL-573

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
