### PR TITLE
LPAL-1216: Allow ECS cron to role to RunTask

### DIFF
--- a/terraform/environment/iam_ecs_task_roles.tf
+++ b/terraform/environment/iam_ecs_task_roles.tf
@@ -95,6 +95,6 @@ data "aws_iam_policy_document" "cloudwatch_events_role_policy" {
 
 // The assumed role's permissions
 resource "aws_iam_role_policy" "ecs_events_run_task_with_any_role" {
-  role   = aws_iam_role.execution_role.name
+  role   = aws_iam_role.cloudwatch_events_ecs_role.name
   policy = data.aws_iam_policy_document.cloudwatch_events_role_policy.json
 }


### PR DESCRIPTION
## Purpose

Fix an issue where ECS cron jobs are unable to run due to a lack of correct RunTask permissions.

Fixes LPAL-1216

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
