### PR TITLE
LPAL-1220 handle null title

### DIFF
--- a/shared/module/MakeShared/src/DataModel/Common/LongName.php
+++ b/shared/module/MakeShared/src/DataModel/Common/LongName.php
@@ -93,6 +93,10 @@ class LongName extends AbstractData
      */
     public function getTitle(): string
     {
+        // title should never be null, but for historical reasons it sometimes can be
+        if (is_null($this->title)) {
+            return "";
+        }
         return $this->title;
     }
 


### PR DESCRIPTION
## Purpose

_Fix problem where a 500 error occurs if title is null_

Fixes LPAL-1220

## Approach

_If title is null return an empty string.  Note- title should never be null in the first place. This is indicative of another problem, which may be historical, i:e in the past people may have been able to save LPAs with a null title and that may have gone away. We will need another story to investigate that, although, we have yet to see how widespread this is_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
