### PR TITLE
prevent failure in locust test from failing whole build

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -212,6 +212,7 @@ jobs:
   locust_tests:
     name: Run locust tests
     uses: ./.github/workflows/locust_tests.yml
+    continue-on-error: true
     needs:
       - preprod_terraform_outputs
     with:


### PR DESCRIPTION
## Purpose

_Add continue on error to locust tests, as a failure in the load test is not a reason to fail the build when all other tests have passed_

## Approach

_add continue on error flag to locust test section_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
