### PR TITLE
LPAL-1225 Using Fargate Spot for service-pdf

### DIFF
--- a/terraform/environment/modules/environment/ecs_cluster.tf
+++ b/terraform/environment/modules/environment/ecs_cluster.tf
@@ -10,6 +10,19 @@ resource "aws_ecs_cluster" "online-lpa" {
   depends_on = [aws_iam_role_policy.execution_role]
 }
 
+resource "aws_ecs_cluster_capacity_providers" "online-lpa" {
+  cluster_name = aws_ecs_cluster.online-lpa.name
+
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    base              = 1
+    weight            = 100
+    capacity_provider = "FARGATE"
+  }
+}
+
+
 data "aws_cloudwatch_log_group" "online-lpa" {
   name = "online-lpa"
   tags = local.shared_component_tag

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -17,8 +17,15 @@ resource "aws_ecs_service" "pdf" {
 
   capacity_provider_strategy {
     capacity_provider = "FARGATE_SPOT"
-    weight            = 100
+    weight            = 99
   }
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 1
+  }
+
 
   tags = local.pdf_component_tag
 }

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -6,7 +6,6 @@ resource "aws_ecs_service" "pdf" {
   cluster               = aws_ecs_cluster.online-lpa.id
   task_definition       = aws_ecs_task_definition.pdf.arn
   desired_count         = var.account.autoscaling.pdf.minimum
-  launch_type           = "FARGATE"
   platform_version      = "1.3.0"
   propagate_tags        = "TASK_DEFINITION"
   wait_for_steady_state = true

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -16,6 +16,11 @@ resource "aws_ecs_service" "pdf" {
     assign_public_ip = false
   }
 
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight            = 100
+  }
+
   tags = local.pdf_component_tag
 }
 


### PR DESCRIPTION
## Purpose

Use Fargate Spot for service-pdf to reduce cost of PDF container.

Fixes LPAL-1225

## Approach

Update the Terraform code to use FARGATE_SPOT capacity provider for service-pdf.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
