### PR TITLE
LPAL-1231 take apk upgrade out of api dockerfile.  

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,8 +111,8 @@ services:
     volumes:
       - ./local-config/:/app/
     environment:
-      AWS_ACCESS_KEY_ID: "-"
-      AWS_SECRET_ACCESS_KEY: "-"
+      AWS_ACCESS_KEY_ID: "devkey"
+      AWS_SECRET_ACCESS_KEY: "devkey"
       AWS_ENDPOINT_DYNAMODB: dynamodb:8000
 
       OPG_LPA_COMMON_SQS_ENDPOINT: localstack:4566
@@ -186,8 +186,8 @@ services:
       OPG_LPA_FRONT_CSRF_SALT: "test"
 
       # Local only
-      AWS_ACCESS_KEY_ID: "-"
-      AWS_SECRET_ACCESS_KEY: "-"
+      AWS_ACCESS_KEY_ID: "devkey"
+      AWS_SECRET_ACCESS_KEY: "devkey"
 
       OPG_LPA_COMMON_DYNAMODB_ENDPOINT: http://dynamodb:8000
 
@@ -253,14 +253,14 @@ services:
 
   api-app:
     container_name: lpa-api-app
-    image: lpa-api-app
+    image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/online-lpa/api_app:34c63f1
     build:
       context: ./
 # Enable debug is recommended to default to off for api to avoid slowness. Turn this on if you ever need to debug the api
       args:
         ENABLE_XDEBUG: 0
         OPG_LPA_COMMON_APP_VERSION: "${OPG_LPA_COMMON_APP_VERSION}"
-      dockerfile: service-api/docker/app/Dockerfile
+          #dockerfile: service-api/docker/app/Dockerfile
     volumes:
 # to speed running, volumes are restricted to source code that may change while container is running
       - ./service-api/bin:/app/bin
@@ -305,8 +305,8 @@ services:
       OPG_LPA_COMMON_ADMIN_ACCOUNTS: "${OPG_LPA_COMMON_ADMIN_ACCOUNTS}"
 
       # Local only
-      AWS_ACCESS_KEY_ID: "-"
-      AWS_SECRET_ACCESS_KEY: "-"
+      AWS_ACCESS_KEY_ID: "devkey"
+      AWS_SECRET_ACCESS_KEY: "devkey"
 
       OPG_LPA_COMMON_DYNAMODB_ENDPOINT: http://dynamodb:8000
       OPG_LPA_COMMON_S3_ENDPOINT: http://localstack:4566
@@ -381,8 +381,8 @@ services:
       OPG_LPA_ADMIN_JWT_SECRET: "test-secret"
 
       # Local only
-      AWS_ACCESS_KEY_ID: "-"
-      AWS_SECRET_ACCESS_KEY: "-"
+      AWS_ACCESS_KEY_ID: "devkey"
+      AWS_SECRET_ACCESS_KEY: "devkey"
 
       OPG_LPA_COMMON_DYNAMODB_ENDPOINT: http://dynamodb:8000
 
@@ -443,8 +443,8 @@ services:
       OPG_LPA_COMMON_PDF_CACHE_S3_BUCKET: "lpacache"
 
       # Local only
-      AWS_ACCESS_KEY_ID: "-"
-      AWS_SECRET_ACCESS_KEY: "-"
+      AWS_ACCESS_KEY_ID: "devkey"
+      AWS_SECRET_ACCESS_KEY: "devkey"
 
       OPG_LPA_COMMON_S3_ENDPOINT: http://localstack:4566
       OPG_LPA_COMMON_PDF_QUEUE_URL: http://localstack:4566/000000000000/pdf-queue.fifo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,7 +260,7 @@ services:
       args:
         ENABLE_XDEBUG: 0
         OPG_LPA_COMMON_APP_VERSION: "${OPG_LPA_COMMON_APP_VERSION}"
-          #dockerfile: service-api/docker/app/Dockerfile
+        dockerfile: service-api/docker/app/Dockerfile
     volumes:
 # to speed running, volumes are restricted to source code that may change while container is running
       - ./service-api/bin:/app/bin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,7 +253,7 @@ services:
 
   api-app:
     container_name: lpa-api-app
-    image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/online-lpa/api_app:34c63f1
+    image: lpa-api-app
     build:
       context: ./
 # Enable debug is recommended to default to off for api to avoid slowness. Turn this on if you ever need to debug the api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,7 +260,7 @@ services:
       args:
         ENABLE_XDEBUG: 0
         OPG_LPA_COMMON_APP_VERSION: "${OPG_LPA_COMMON_APP_VERSION}"
-        dockerfile: service-api/docker/app/Dockerfile
+      dockerfile: service-api/docker/app/Dockerfile
     volumes:
 # to speed running, volumes are restricted to source code that may change while container is running
       - ./service-api/bin:/app/bin

--- a/docs/runbooks/troubleshooting_container_images/troubleshooting_container_images.md
+++ b/docs/runbooks/troubleshooting_container_images/troubleshooting_container_images.md
@@ -73,7 +73,7 @@ docker pull 311462405659.dkr.ecr.eu-west-1.amazonaws.com/online-lpa/api_app:late
 run the image up, enable xdebug on the container and run the tests, using the following commands:
 
 ``` bash
-docker run -d --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name api-tests 311462405659.dkr.ecr.eu-west-1.amazonaws.com/online-lpa/api_app:latest
+docker run -d --env AWS_ACCESS_KEY_ID='devkey' --env AWS_SECRET_ACCESS_KEY='devkey' --name api-tests 311462405659.dkr.ecr.eu-west-1.amazonaws.com/online-lpa/api_app:latest
 docker exec api-tests docker-php-ext-enable xdebug
 docker exec api-tests /app/vendor/bin/phpunit -d memory_limit=256M
 
@@ -88,11 +88,11 @@ docker exec api-tests /app/vendor/bin/phpunit -d memory_limit=256M
    3. set image name (as in previous step)
    4. set container name as set in previous step
    5. you may need to set AWS environment variables - these should be all you need:
-      1. `AWS_ACCESS_KEY_ID='-'; AWS_SECRET_ACCESS_KEY='-'`
+      1. `AWS_ACCESS_KEY_ID='devkey'; AWS_SECRET_ACCESS_KEY='devkey'`
    6. in the command preview you will see the constructed command look like this:
 
 ``` bash
-    docker run -P --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name api-tests 311462405659.dkr.ecr.eu-west-1.amazonaws.com/online-lpa/api_app:latest
+    docker run -P --env AWS_ACCESS_KEY_ID='devkey' --env AWS_SECRET_ACCESS_KEY='devkey' --name api-tests 311462405659.dkr.ecr.eu-west-1.amazonaws.com/online-lpa/api_app:latest
 ```
 
 ## Setting up debugging of PHPUnit tests in PHPStorm
@@ -124,7 +124,7 @@ This consists of 3 main steps:
 7. connect to a running instance of the image above to work this out.
 
     ``` bash
-    docker run -d --env AWS_ACCESS_KEY_ID='-' --env AWS_SECRET_ACCESS_KEY='-' --name api-tests 311462405659.dkr.ecr.eu-west-1.amazonaws.com/online-lpa/api_app:latest
+    docker run -d --env AWS_ACCESS_KEY_ID='devkey' --env AWS_SECRET_ACCESS_KEY='devkey' --name api-tests 311462405659.dkr.ecr.eu-west-1.amazonaws.com/online-lpa/api_app:latest
     docker exec -it api-tests sh
     ```
 

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -4,8 +4,7 @@ ENV OPG_PHP_POOL_CHILDREN_MAX="25"
 
 RUN adduser -D -g '' appuser
 
-RUN apk add --upgrade --no-cache apk-tools
-RUN apk upgrade --no-cache
+RUN apk add --no-cache apk-tools
 
 RUN apk add --no-cache postgresql-libs icu fcgi \
     && apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS postgresql-dev icu-dev linux-headers \

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine3.16
+FROM php:8.2-fpm-alpine3.17
 
 ENV OPG_PHP_POOL_CHILDREN_MAX="25"
 


### PR DESCRIPTION
same time

## Purpose

_Remove the apk upgrade from Dockerfile for api because this is leading to unwanted upgrades that cause performance problems.  Meanwhile change the aws keys for locally running dynamodb from hyphen which is not longer allowed, to devkey. Note - we ought to do a similar removal of apk upgrade in the service-front in future, but , on a seperate PR _

## Approach

_Update Dockerfile and docker-compose.yml_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
