### PR TITLE
LPAL-1232 Pin pgbouncer to immutable tag

### DIFF
--- a/service-api/docker/pgbouncer/Dockerfile
+++ b/service-api/docker/pgbouncer/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/pgbouncer:1.19.1
+FROM bitnami/pgbouncer:1.19.1-debian-11-r16
 
 ADD --chmod=444 https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/rds-ca-certificates.crt
 

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -221,6 +221,7 @@ locals {
         { "name" : "PGBOUNCER_DATABASE", "value" : module.api_aurora[0].name },
         { "name" : "POSTGRESQL_HOST", "value" : module.api_aurora[0].endpoint },
         { "name" : "PGBOUNCER_SERVER_TLS_SSLMODE", "value" : "verify-full" },
+        { "name" : "PGBOUNCER_AUTH_TYPE", "value" : "md5" },
       ],
     }
   )


### PR DESCRIPTION
## Purpose

Explicitly set the `PGBOUNCER_AUTH_TYPE` as a breaking change was introduced to the 1.19.1 rolling tag which caused increased CPU usage in the pgbouncer containers.

Fixes LPAL-1232

## Approach

Explicitly set `PGBOUNCER_AUTH_TYPE` to its old default value of `md5` and pin the version used to `1.19.1-debian-11-r16`.

## Learning

https://www.postgresql.org/docs/current/auth-password.html
https://docs.bitnami.com/kubernetes/infrastructure/postgresql/configuration/understand-rolling-immutable-tags/
https://github.com/bitnami/containers/commit/190481f04144fe8ff1247da6fc7ed605951352b4

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
