### PR TITLE
LPAL-1234 Enable pip-compile updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -183,5 +183,8 @@
       "prPriority": 4,
       "stabilityDays": 3
     }
-  ]
+  ],
+  "pip-compile": {
+    "fileMatch": ["(^|/)requirements\\.in$"]
+  }
 }


### PR DESCRIPTION
## Purpose

Enable pip-compile updates in renovate.

Fixes LPAL-1234

## Approach

Allow requirements.in to be updated.

## Learning

https://docs.renovatebot.com/modules/manager/pip-compile/

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
