### PR TITLE
LPAL-1235 Use different Slack deploy channel

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -236,7 +236,7 @@ jobs:
       - id: slack
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
-          channel-id: "C01BDM8T67J"
+          channel-id: "C9PNCT2KS"
           payload: |
             {
              "icon_emoji": ":robot_face:",
@@ -391,7 +391,7 @@ jobs:
     - uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
       if: needs.run_smoke_tests.outputs.smoke_test_status == 'passed'
       with:
-        channel-id: "C01BDM8T67J"
+        channel-id: "C9PNCT2KS"
         update-ts: ${{ needs.slack_msg_production_deploy_begin.outputs.ts }}
         payload: |
             {
@@ -442,7 +442,7 @@ jobs:
     - uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
       if: needs.run_smoke_tests.outputs.smoke_test_status != 'passed'
       with:
-        channel-id: "C01BDM8T67J"
+        channel-id: "C9PNCT2KS"
         update-ts: ${{ needs.slack_msg_production_deploy_begin.outputs.ts }}
         payload: |
             {
@@ -493,7 +493,7 @@ jobs:
     - uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
       if: needs.run_smoke_tests.outputs.smoke_test_status != 'passed'
       with:
-        channel-id: "C01BDM8T67J"
+        channel-id: "C9PNCT2KS"
         payload: |
             {
               "icon_emoji": ":warning:",
@@ -502,7 +502,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Production deployment failed. Please check the <https://github.com/ministryofjustice/opg-lpa/actions/runs/${{github.run_id}}|workflow> for more details. @here"
+                    "text": "Production Make deployment failed. Please check the <https://github.com/ministryofjustice/opg-lpa/actions/runs/${{github.run_id}}|workflow> for more details. <!here>"
                   }
                 }
               ]

--- a/.github/workflows/workflow_weekly_refresh.yml
+++ b/.github/workflows/workflow_weekly_refresh.yml
@@ -61,7 +61,7 @@ jobs:
       - id: slack
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
-          channel-id: "C01BDM8T67J"
+          channel-id: "C9PNCT2KS"
           payload: |
             {
               "blocks": [
@@ -214,12 +214,62 @@ jobs:
       - image_tag
     steps:
     - uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
-      if: needs.run_smoke_tests.smoke_test_status == 'passed'
+      if: needs.run_smoke_tests.outputs.smoke_test_status == 'passed'
       with:
-        channel-id: "C01BDM8T67J"
+        channel-id: "C9PNCT2KS"
+        update-ts: ${{ needs.slack_msg_production_deploy_begin.outputs.ts }}
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "Production Deployment",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Status:*\nStarted"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Started by:*\n Cron (Weekly Refresh)"
+                  }
+                ]
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Commit:*\n <https://github.com/ministryofjustice/opg-lpa/commit/${{ github.sha }}|${{ needs.image_tag.outputs.short_sha }}>"
+                  }
+                ]
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "<https://github.com/ministryofjustice/opg-lpa/actions/runs/${{github.run_id}}|View workflow>"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    - uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+      if: needs.run_smoke_tests.outputs.smoke_test_status == 'passed'
+      with:
+        channel-id: "C9PNCT2KS"
         update-ts: ${{ needs.slack_msg_production_deploy_begin.outputs.ts }}
         payload: |
             {
+              "icon_emoji": ":robot_face:",
               "blocks": [
                 {
                   "type": "header",
@@ -234,11 +284,11 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Status:*\nStarted"
+                      "text": "*Status:*\nComplete :white_check_mark:"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Started by:*\n ${{ github.triggering_actor }}"
+                      "text": "*Started by:*\n Cron (Weekly Refresh)"
                     }
                   ]
                 },
@@ -264,12 +314,13 @@ jobs:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
     - uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
-      if: needs.run_smoke_tests.smoke_test_status == 'failed'
+      if: needs.run_smoke_tests.outputs.smoke_test_status != 'passed'
       with:
-        channel-id: "C01BDM8T67J"
+        channel-id: "C9PNCT2KS"
         update-ts: ${{ needs.slack_msg_production_deploy_begin.outputs.ts }}
         payload: |
             {
+              "icon_emoji": ":robot_face:",
               "blocks": [
                 {
                   "type": "header",
@@ -284,11 +335,11 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Status:*\nStarted"
+                      "text": "*Status:*\nFailed! :x:"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Started by:*\n ${{ github.triggering_actor }}"
+                      "text": "*Started by:*\n Cron (Weekly Refresh)"
                     }
                   ]
                 },
@@ -306,6 +357,26 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": "<https://github.com/ministryofjustice/opg-lpa/actions/runs/${{github.run_id}}|View workflow>"
+                  }
+                }
+              ]
+            }
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+    - uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+      if: needs.run_smoke_tests.outputs.smoke_test_status != 'passed'
+      with:
+        channel-id: "C9PNCT2KS"
+        payload: |
+            {
+              "icon_emoji": ":warning:",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Production Make deployment failed. Please check the <https://github.com/ministryofjustice/opg-lpa/actions/runs/${{github.run_id}}|workflow> for more details. <!here>"
                   }
                 }
               ]


### PR DESCRIPTION
## Purpose

Update the Slack channel used to announce prod deployments

Fixes LPAL-1235

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
