### PR TITLE
LPAL-1236 Upgrade to alpine3.18

### DIFF
--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine3.17
+FROM php:8.2-fpm-alpine3.18
 
 ENV OPG_PHP_POOL_CHILDREN_MAX="25"
 

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine3.16
+FROM php:8.2-fpm-alpine3.18
 
 ENV OPG_PHP_POOL_CHILDREN_MAX="25"
 

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine3.16
+FROM php:8.2-fpm-alpine3.18
 
 ENV OPG_PHP_POOL_CHILDREN_MAX="25"
 


### PR DESCRIPTION
## Purpose

Upgrade API, Front and Admin container base images to Alpine 3.18.

Fixes LPAL-1236

## Approach

Change Dockerfile to use `php:8.2-fpm-alpine3.18`. Testing in the dev environment shows that previous performance regressions that existed with OpenSSL 3.0 so not exist in OpenSSL 3.1.

## Learning

https://www.openssl.org/blog/blog/2023/03/07/OpenSSL3.1Release/

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
