### PR TITLE
LPAL-1239 Remove breakglass alarms

### DIFF
--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -1,35 +1,3 @@
 data "aws_cloudwatch_log_group" "cloudtrail" {
   name = "online_lpa_cloudtrail_${local.account_name}"
 }
-
-resource "aws_cloudwatch_log_metric_filter" "breakglass_metric" {
-  count          = local.account.is_production ? 1 : 0
-  name           = "BreakGlassConsoleLogin"
-  pattern        = "{ ($.eventType = \"AwsConsoleSignIn\") && ($.userIdentity.arn = \"arn:aws:sts::${local.account_id}:assumed-role/breakglass/*\") }"
-  log_group_name = data.aws_cloudwatch_log_group.cloudtrail.name
-
-  metric_transformation {
-    name      = "EventCount"
-    namespace = "online-lpa/Cloudtrail"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "account_breakglass_login_alarm" {
-  count               = local.account.is_production ? 1 : 0
-  actions_enabled     = true
-  alarm_name          = "${local.account_name} breakglass console login check"
-  alarm_actions       = [aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn]
-  ok_actions          = [aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn]
-  alarm_description   = "number of breakglass attempts"
-  namespace           = "online-lpa/Cloudtrail"
-  metric_name         = "EventCount"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  period              = 60
-  evaluation_periods  = 1
-  datapoints_to_alarm = 1
-  statistic           = "Sum"
-  tags                = local.shared_component_tag
-  threshold           = 1
-  treat_missing_data  = "notBreaching"
-}

--- a/terraform/account/pagerduty.tf
+++ b/terraform/account/pagerduty.tf
@@ -26,13 +26,6 @@ resource "pagerduty_service_integration" "db_alerts_integration" {
   vendor  = data.pagerduty_vendor.custom_events.id
 }
 
-resource "aws_sns_topic_subscription" "cloudwatch_breakglass_alerts_sns_subscription" {
-  topic_arn              = aws_sns_topic.cloudwatch_to_slack_breakglass_alerts.arn
-  protocol               = "https"
-  endpoint_auto_confirms = true
-  endpoint               = "https://events.pagerduty.com/integration/${pagerduty_service_integration.cloudwatch_integration.integration_key}/enqueue"
-}
-
 resource "aws_sns_topic_subscription" "cloudwatch_elasticache_alerts_sns_subscription" {
   topic_arn              = aws_sns_topic.cloudwatch_to_slack_elasticache_alerts.arn
   protocol               = "https"

--- a/terraform/account/sns.tf
+++ b/terraform/account/sns.tf
@@ -1,8 +1,3 @@
-#tfsec:ignore:aws-sns-enable-topic-encryption fix for now, to be followed with a CMK KMS
-resource "aws_sns_topic" "cloudwatch_to_slack_breakglass_alerts" {
-  name = "CloudWatch-to-PagerDuty-${local.account_name}-Breakglass-alert"
-  tags = local.shared_component_tag
-}
 #tfsec:ignore:aws-sns-enable-topic-encryption unsupported for this type of alert
 resource "aws_sns_topic" "cloudwatch_to_slack_elasticache_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-elasticache-alert"


### PR DESCRIPTION
## Purpose

Move breakglass alarms to aws-account module.

Fixes LPAL-1239

## Approach

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
