### PR TITLE
Lpal 1249 splitrenovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -109,12 +109,12 @@
     },
     {
       "description": [
-        "composer minor and patch updates (PHP 8.2, stable for 3 days)",
+        "admin composer minor and patch updates (PHP 8.2, stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "minor and patch updates (PHP 8.2)",
-      "groupSlug": "all-minor-patch-updates-php82",
+      "groupName": "admin minor and patch updates (PHP 8.2)",
+      "groupSlug": "admin-minor-patch-updates-php82",
       "labels": ["Dependencies", "Renovate", "PHP 8.2"],
       "matchManagers": ["composer"],
       "matchUpdateTypes": ["minor", "patch"],
@@ -129,13 +129,13 @@
     },
     {
       "description": [
-        "front composer minor and patch updates (PHP 8.1, stable for 3 days)",
+        "front composer minor and patch updates (PHP 8.2, stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "minor and patch updates (PHP 8.1)",
-      "groupSlug": "all-minor-patch-updates-php81",
-      "labels": ["Dependencies", "Renovate", "PHP 8.1"],
+      "groupName": "front minor and patch updates (PHP 8.2)",
+      "groupSlug": "front-minor-patch-updates-php82",
+      "labels": ["Dependencies", "Renovate", "PHP 8.2"],
       "matchManagers": ["composer"],
       "matchUpdateTypes": ["minor", "patch"],
       "excludePackagePatterns": ["cypress"],
@@ -149,13 +149,13 @@
     },
     {
       "description": [
-        "api composer minor and patch updates (PHP 8.1, stable for 3 days)",
+        "api composer minor and patch updates (PHP 8.2, stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "minor and patch updates (PHP 8.1)",
-      "groupSlug": "all-minor-patch-updates-php81",
-      "labels": ["Dependencies", "Renovate", "PHP 8.1"],
+      "groupName": "api minor and patch updates (PHP 8.2)",
+      "groupSlug": "api-minor-patch-updates-php82",
+      "labels": ["Dependencies", "Renovate", "PHP 8.2"],
       "matchManagers": ["composer"],
       "matchUpdateTypes": ["minor", "patch"],
       "excludePackagePatterns": ["cypress"],
@@ -173,8 +173,8 @@
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "minor and patch updates (PHP 8.1)",
-      "groupSlug": "all-minor-patch-updates-php81",
+      "groupName": "pdf minor and patch updates (PHP 8.1)",
+      "groupSlug": "pdf-minor-patch-updates-php81",
       "labels": ["Dependencies", "Renovate", "PHP 8.1"],
       "matchManagers": ["composer"],
       "matchUpdateTypes": ["minor", "patch"],
@@ -189,13 +189,13 @@
     },
     {
       "description": [
-        "shared composer minor and patch updates (PHP 8.1, stable for 3 days)",
+        "shared composer minor and patch updates (PHP 8.2, stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "minor and patch updates (PHP 8.1)",
-      "groupSlug": "all-minor-patch-updates-php81",
-      "labels": ["Dependencies", "Renovate", "PHP 8.1"],
+      "groupName": "shared minor and patch updates (PHP 8.2)",
+      "groupSlug": "shared-minor-patch-updates-php82",
+      "labels": ["Dependencies", "Renovate", "PHP 8.2"],
       "matchManagers": ["composer"],
       "matchUpdateTypes": ["minor", "patch"],
       "excludePackagePatterns": ["cypress"],

--- a/renovate.json
+++ b/renovate.json
@@ -129,7 +129,7 @@
     },
     {
       "description": [
-        "composer minor and patch updates (PHP 8.1, stable for 3 days)",
+        "front composer minor and patch updates (PHP 8.1, stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
@@ -141,9 +141,66 @@
       "excludePackagePatterns": ["cypress"],
       "excludePackageNames": ["php"],
       "matchFiles": [
-        "service-front/composer.json",
-        "service-api/composer.json",
-        "service-pdf/composer.json",
+        "service-front/composer.json"
+      ],
+      "prCreation": "immediate",
+      "prPriority": 4,
+      "stabilityDays": 3
+    },
+    {
+      "description": [
+        "api composer minor and patch updates (PHP 8.1, stable for 3 days)",
+        "These might be automerged once we're comfortable with Renovate"
+      ],
+      "automerge": false,
+      "groupName": "minor and patch updates (PHP 8.1)",
+      "groupSlug": "all-minor-patch-updates-php81",
+      "labels": ["Dependencies", "Renovate", "PHP 8.1"],
+      "matchManagers": ["composer"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackagePatterns": ["cypress"],
+      "excludePackageNames": ["php"],
+      "matchFiles": [
+        "service-api/composer.json"
+      ],
+      "prCreation": "immediate",
+      "prPriority": 4,
+      "stabilityDays": 3
+    },
+    {
+      "description": [
+        "pdf composer minor and patch updates (PHP 8.1, stable for 3 days)",
+        "These might be automerged once we're comfortable with Renovate"
+      ],
+      "automerge": false,
+      "groupName": "minor and patch updates (PHP 8.1)",
+      "groupSlug": "all-minor-patch-updates-php81",
+      "labels": ["Dependencies", "Renovate", "PHP 8.1"],
+      "matchManagers": ["composer"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackagePatterns": ["cypress"],
+      "excludePackageNames": ["php"],
+      "matchFiles": [
+        "service-pdf/composer.json"
+      ],
+      "prCreation": "immediate",
+      "prPriority": 4,
+      "stabilityDays": 3
+    },
+    {
+      "description": [
+        "shared composer minor and patch updates (PHP 8.1, stable for 3 days)",
+        "These might be automerged once we're comfortable with Renovate"
+      ],
+      "automerge": false,
+      "groupName": "minor and patch updates (PHP 8.1)",
+      "groupSlug": "all-minor-patch-updates-php81",
+      "labels": ["Dependencies", "Renovate", "PHP 8.1"],
+      "matchManagers": ["composer"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackagePatterns": ["cypress"],
+      "excludePackageNames": ["php"],
+      "matchFiles": [
         "shared/composer.json"
       ],
       "prCreation": "immediate",

--- a/renovate.json
+++ b/renovate.json
@@ -118,7 +118,6 @@
       "labels": ["Dependencies", "Renovate", "PHP 8.2"],
       "matchManagers": ["composer"],
       "matchUpdateTypes": ["minor", "patch"],
-      "excludePackagePatterns": ["cypress"],
       "excludePackageNames": ["php"],
       "matchFiles": [
         "service-admin/composer.json"
@@ -138,7 +137,6 @@
       "labels": ["Dependencies", "Renovate", "PHP 8.2"],
       "matchManagers": ["composer"],
       "matchUpdateTypes": ["minor", "patch"],
-      "excludePackagePatterns": ["cypress"],
       "excludePackageNames": ["php"],
       "matchFiles": [
         "service-front/composer.json"
@@ -158,7 +156,6 @@
       "labels": ["Dependencies", "Renovate", "PHP 8.2"],
       "matchManagers": ["composer"],
       "matchUpdateTypes": ["minor", "patch"],
-      "excludePackagePatterns": ["cypress"],
       "excludePackageNames": ["php"],
       "matchFiles": [
         "service-api/composer.json"
@@ -178,7 +175,6 @@
       "labels": ["Dependencies", "Renovate", "PHP 8.1"],
       "matchManagers": ["composer"],
       "matchUpdateTypes": ["minor", "patch"],
-      "excludePackagePatterns": ["cypress"],
       "excludePackageNames": ["php"],
       "matchFiles": [
         "service-pdf/composer.json"
@@ -198,7 +194,6 @@
       "labels": ["Dependencies", "Renovate", "PHP 8.2"],
       "matchManagers": ["composer"],
       "matchUpdateTypes": ["minor", "patch"],
-      "excludePackagePatterns": ["cypress"],
       "excludePackageNames": ["php"],
       "matchFiles": [
         "shared/composer.json"


### PR DESCRIPTION
## Purpose

_Seperate renovate config out for the individual services. This alllows us to let through upgrades where the build is passing, and individually target and investigate changes which broke the build in 1 service only_

## Approach

_Update renovate config with these changes_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
