### PR TITLE
make cookies test more lenient as it keeps failing in CI

### DIFF
--- a/cypress/e2e/common/cookies.js
+++ b/cypress/e2e/common/cookies.js
@@ -10,7 +10,7 @@ const checkCookies = function (shouldBeSet, tries) {
     tries = 0;
   }
 
-  if (tries > 2) {
+  if (tries > 10) {
     cy.log('TOO MANY TRIES');
     return cy.wrap(false).should('be.true');
   }


### PR DESCRIPTION
## Purpose

_make cookies test more lenient as it keeps failing in CI_

## Approach

_Increase no of retries from 2 to 10_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
