### PR TITLE
Revert "always run psalm"

### DIFF
--- a/.github/workflows/analysis-psalm.yml
+++ b/.github/workflows/analysis-psalm.yml
@@ -32,16 +32,25 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: path filters
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            check: '${{ matrix.scan.path }}/**'
       - name: Setup PHP
         if: steps.filter.outputs.check == 'true'
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.2"
       - name: Composer install
+        if: steps.filter.outputs.check == 'true'
         run: composer install --prefer-dist --optimize-autoloader --no-suggest --no-interaction
       - name: Run psalm
+        if: steps.filter.outputs.check == 'true'
         run: ./vendor/bin/psalm --output-format=github --report=psalm-results.sarif
       - name: Upload Security Analysis results to GitHub
+        if: steps.filter.outputs.check == 'true'
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: ${{ matrix.scan.path }}/psalm-results.sarif
@@ -64,15 +73,23 @@ jobs:
         uses: actions/checkout@v3
       - name: path filters
         uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            check: '${{ matrix.scan.path }}/**'
       - name: Setup PHP
+        if: steps.filter.outputs.check == 'true'
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
       - name: Composer install
+        if: steps.filter.outputs.check == 'true'
         run: composer install --prefer-dist --optimize-autoloader --no-suggest --no-interaction
       - name: Run psalm
+        if: steps.filter.outputs.check == 'true'
         run: ./vendor/bin/psalm --output-format=github --report=psalm-results.sarif
       - name: Upload Security Analysis results to GitHub
+        if: steps.filter.outputs.check == 'true'
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: ${{ matrix.scan.path }}/psalm-results.sarif


### PR DESCRIPTION
## Purpose

_This has caused the path to live build to break so reverting until can fix_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
