### PR TITLE
LPAL-1251 attempt to replace laminas-log with monolog

### DIFF
--- a/service-admin/composer.json
+++ b/service-admin/composer.json
@@ -23,7 +23,7 @@
         "laminas/laminas-config-aggregator": "^1.7",
         "laminas/laminas-diactoros": "^2.8.0",
         "laminas/laminas-form": "^3.0.1",
-        "laminas/laminas-log": "^2.13",
+        "monolog/monolog": "^3.4",
         "laminas/laminas-math": "^3.4",
         "laminas/laminas-permissions-rbac": "^3.2.0",
         "laminas/laminas-router": "^3.7",

--- a/service-admin/composer.lock
+++ b/service-admin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89dfedca9e082c32099217116af67129",
+    "content-hash": "eb602f0f316b7504d4efda074a877895",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1835,94 +1835,6 @@
             "time": "2022-10-16T12:50:49+00:00"
         },
         {
-            "name": "laminas/laminas-log",
-            "version": "2.16.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-log.git",
-                "reference": "a9c16bb161311553238b8989aa587bed4b518a7e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-log/zipball/a9c16bb161311553238b8989aa587bed4b518a7e",
-                "reference": "a9c16bb161311553238b8989aa587bed4b518a7e",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-servicemanager": "^3.3.0",
-                "laminas/laminas-stdlib": "^3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-                "psr/log": "^1.1.2"
-            },
-            "conflict": {
-                "zendframework/zend-log": "*"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-xml": "*",
-                "firephp/firephp-core": "^0.5.3",
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-db": "^2.6",
-                "laminas/laminas-escaper": "^2.5",
-                "laminas/laminas-filter": "^2.5",
-                "laminas/laminas-mail": "^2.6.1",
-                "laminas/laminas-validator": "^2.10.1",
-                "mikey179/vfsstream": "^1.6.7",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.10"
-            },
-            "suggest": {
-                "ext-mongo": "mongo extension to use Mongo writer",
-                "ext-mongodb": "mongodb extension to use MongoDB writer",
-                "laminas/laminas-db": "Laminas\\Db component to use the database log writer",
-                "laminas/laminas-escaper": "Laminas\\Escaper component, for use in the XML log formatter",
-                "laminas/laminas-mail": "Laminas\\Mail component to use the email log writer",
-                "laminas/laminas-validator": "Laminas\\Validator component to block invalid log messages"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Log",
-                    "config-provider": "Laminas\\Log\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Log\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Robust, composite logger with filtering, formatting, and PSR-3 support",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "log",
-                "logging"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-log/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-log/issues",
-                "rss": "https://github.com/laminas/laminas-log/releases.atom",
-                "source": "https://github.com/laminas/laminas-log"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2022-12-19T16:38:15+00:00"
-        },
-        {
             "name": "laminas/laminas-math",
             "version": "3.6.0",
             "source": {
@@ -3117,6 +3029,107 @@
             "time": "2022-12-01T11:42:00+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e2392369686d420ca32df3803de28b5d6f76867d",
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.1",
+                "predis/predis": "^1.1 || ^2",
+                "ruflin/elastica": "^7",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-21T08:46:11+00:00"
+        },
+        {
             "name": "mtdowling/jmespath.php",
             "version": "2.7.0",
             "source": {
@@ -3934,30 +3947,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3978,9 +3991,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -9063,5 +9076,5 @@
         "php": ">=8.2 <8.3.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/service-admin/src/App/src/Logging/LoggerTrait.php
+++ b/service-admin/src/App/src/Logging/LoggerTrait.php
@@ -2,8 +2,10 @@
 
 namespace App\Logging;
 
-use Laminas\Log\Logger as LaminasLogger;
-use Laminas\Log\Writer\Stream as StreamWriter;
+use Monolog\Level;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
 
 /**
  * Trait LoggerTrait
@@ -12,18 +14,18 @@ use Laminas\Log\Writer\Stream as StreamWriter;
 trait LoggerTrait
 {
     /**
-     * @var LaminasLogger
+     * @var Logger
      */
     private $logger;
 
     /**
-     * @return LaminasLogger $logger
+     * @return Logger $logger
      */
     public function getLogger()
     {
-        if (!$this->logger instanceof LaminasLogger) {
-            $this->logger = new LaminasLogger();
-            $this->logger->addWriter(new StreamWriter('php://stderr'));
+        if (!$this->logger instanceof Logger) {
+            $this->logger = new Logger('logger');
+            $this->logger->pushHandler(new StreamHandler('php://stderr', Level::Warning));
         }
 
         return $this->logger;

--- a/service-admin/src/App/src/Logging/LoggingErrorListener.php
+++ b/service-admin/src/App/src/Logging/LoggingErrorListener.php
@@ -23,7 +23,7 @@ class LoggingErrorListener
      */
     public function __invoke(Throwable $error, ServerRequestInterface $_1, ResponseInterface $_2)
     {
-        $this->getLogger()->err(sprintf(
+        $this->getLogger()->error(sprintf(
             '%s in %s on line %s - %s',
             $error->getMessage(),
             $error->getFile(),

--- a/service-admin/src/App/src/Middleware/Session/JwtMiddleware.php
+++ b/service-admin/src/App/src/Middleware/Session/JwtMiddleware.php
@@ -180,7 +180,7 @@ final class JwtMiddleware implements MiddlewareInterface
         };
 
         /* If everything fails log and throw. */
-        $this->getLogger()->warn("Token not found");
+        $this->getLogger()->warning("Token not found");
         throw new RuntimeException("Token not found.");
     }
 
@@ -198,7 +198,7 @@ final class JwtMiddleware implements MiddlewareInterface
             );
             return (array) $decoded;
         } catch (Exception $exception) {
-            $this->getLogger()->warn($exception->getMessage(), [$token]);
+            $this->getLogger()->warning($exception->getMessage(), [$token]);
             throw $exception;
         }
     }

--- a/service-api/composer.json
+++ b/service-api/composer.json
@@ -14,7 +14,7 @@
         "laminas/laminas-cache-storage-adapter-memory": "2.2.0",
         "laminas/laminas-crypt": "^3.4",
         "laminas/laminas-filter": "^2.12.0",
-        "laminas/laminas-log": "^2.13",
+        "monolog/monolog": "^3.4",
         "laminas/laminas-math": "^3.4",
         "laminas/laminas-mvc": "^3.2",
         "laminas/laminas-mvc-i18n": "^2.0",

--- a/service-api/composer.lock
+++ b/service-api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "761ccd5359884480d22d492895e16c37",
+    "content-hash": "1b46c34719acc97d5f1a2845996aef04",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -2474,94 +2474,6 @@
             "time": "2022-10-16T12:50:49+00:00"
         },
         {
-            "name": "laminas/laminas-log",
-            "version": "2.16.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-log.git",
-                "reference": "a9c16bb161311553238b8989aa587bed4b518a7e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-log/zipball/a9c16bb161311553238b8989aa587bed4b518a7e",
-                "reference": "a9c16bb161311553238b8989aa587bed4b518a7e",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-servicemanager": "^3.3.0",
-                "laminas/laminas-stdlib": "^3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-                "psr/log": "^1.1.2"
-            },
-            "conflict": {
-                "zendframework/zend-log": "*"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-xml": "*",
-                "firephp/firephp-core": "^0.5.3",
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-db": "^2.6",
-                "laminas/laminas-escaper": "^2.5",
-                "laminas/laminas-filter": "^2.5",
-                "laminas/laminas-mail": "^2.6.1",
-                "laminas/laminas-validator": "^2.10.1",
-                "mikey179/vfsstream": "^1.6.7",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.10"
-            },
-            "suggest": {
-                "ext-mongo": "mongo extension to use Mongo writer",
-                "ext-mongodb": "mongodb extension to use MongoDB writer",
-                "laminas/laminas-db": "Laminas\\Db component to use the database log writer",
-                "laminas/laminas-escaper": "Laminas\\Escaper component, for use in the XML log formatter",
-                "laminas/laminas-mail": "Laminas\\Mail component to use the email log writer",
-                "laminas/laminas-validator": "Laminas\\Validator component to block invalid log messages"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Log",
-                    "config-provider": "Laminas\\Log\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Log\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Robust, composite logger with filtering, formatting, and PSR-3 support",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "log",
-                "logging"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-log/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-log/issues",
-                "rss": "https://github.com/laminas/laminas-log/releases.atom",
-                "source": "https://github.com/laminas/laminas-log"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2022-12-19T16:38:15+00:00"
-        },
-        {
             "name": "laminas/laminas-math",
             "version": "3.6.0",
             "source": {
@@ -3549,6 +3461,107 @@
             "time": "2023-03-09T17:58:48+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e2392369686d420ca32df3803de28b5d6f76867d",
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.1",
+                "predis/predis": "^1.1 || ^2",
+                "ruflin/elastica": "^7",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-21T08:46:11+00:00"
+        },
+        {
             "name": "mtdowling/jmespath.php",
             "version": "2.7.0",
             "source": {
@@ -4203,30 +4216,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4247,9 +4260,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/2.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:41:46+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -8671,5 +8684,5 @@
         "php": "^8.2.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/service-api/module/Application/src/Controller/FeedbackController.php
+++ b/service-api/module/Application/src/Controller/FeedbackController.php
@@ -91,7 +91,7 @@ class FeedbackController extends AbstractRestfulController
         $result = $this->service->add($data);
 
         if ($result === false) {
-            $this->getLogger()->err('Data required for database insert was missing');
+            $this->getLogger()->error('Data required for database insert was missing');
 
             return new ApiProblemResponse(
                 new ApiProblem(400, 'Unable to save feedback. Ensure at least one valid field is sent.')

--- a/service-api/module/Application/src/Controller/PingController.php
+++ b/service-api/module/Application/src/Controller/PingController.php
@@ -10,7 +10,6 @@ use GuzzleHttp\Psr7\Uri;
 use Http\Client\HttpClient;
 use MakeShared\Constants;
 use MakeShared\Logging\LoggerTrait;
-use Laminas\Log\Logger as LaminasLogger;
 use Laminas\Mvc\Controller\AbstractRestfulController;
 use Laminas\View\Model\JsonModel;
 use Exception;
@@ -144,7 +143,7 @@ class PingController extends AbstractRestfulController
 
             $queueOk = ($count < 50);
         } catch (Exception $e) {
-            $this->getLogger()->err('SQS queue is not available to API: ' . $e->getMessage());
+            $this->getLogger()->error('SQS queue is not available to API: ' . $e->getMessage());
         }
 
         // Main database
@@ -152,7 +151,7 @@ class PingController extends AbstractRestfulController
             $this->database->getDriver()->getConnection()->connect();
             $dbOk = true;
         } catch (Exception $e) {
-            $this->getLogger()->err('Database is not available to API: ' . $e->getMessage());
+            $this->getLogger()->error('Database is not available to API: ' . $e->getMessage());
         }
 
         // OPG Gateway
@@ -174,7 +173,7 @@ class PingController extends AbstractRestfulController
                 $opgGatewayOk = true;
             }
         } catch (Exception $e) {
-            $this->getLogger()->err(
+            $this->getLogger()->error(
                 "Sirius gateway not available to API at $url: " . $e->getMessage()
             );
         }

--- a/service-api/module/Application/src/Library/Authentication/Adapter/LpaAuth.php
+++ b/service-api/module/Application/src/Library/Authentication/Adapter/LpaAuth.php
@@ -53,7 +53,7 @@ class LpaAuth implements AdapterInterface
         try {
             $data = $this->authenticationService->withToken($this->token, true);
         } catch (LaminasExceptionInterface $ex) {
-            $this->getLogger()->err(
+            $this->getLogger()->error(
                 'Unable to get user with token; possible database issue; message: ' . $ex->getMessage()
             );
             return new Result(Result::FAILURE, null);

--- a/service-api/module/Application/src/Model/DataAccess/Postgres/FeedbackData.php
+++ b/service-api/module/Application/src/Model/DataAccess/Postgres/FeedbackData.php
@@ -45,9 +45,9 @@ class FeedbackData extends AbstractBase implements FeedbackRepository\FeedbackRe
         try {
             $sql->execute();
         } catch (\Laminas\Db\Adapter\Exception\InvalidQueryException $e) {
-            $this->getLogger()->err('Error running insert query for feedback');
-            $this->getLogger()->err($e->getMessage());
-            $this->getLogger()->err($e->getTraceAsString());
+            $this->getLogger()->error('Error running insert query for feedback');
+            $this->getLogger()->error($e->getMessage());
+            $this->getLogger()->error($e->getTraceAsString());
             return false;
         }
 

--- a/service-api/module/Application/src/Model/Service/AccountCleanup/Service.php
+++ b/service-api/module/Application/src/Model/Service/AccountCleanup/Service.php
@@ -157,7 +157,7 @@ class Service extends AbstractService
                 echo "NotifyException: " . $e->getMessage() . "\n";
 
                 // Notify exceptions aren't too bad, we will just retry tomorrow.
-                $this->getLogger()->warn('Unable to send account expiry notification', [
+                $this->getLogger()->warning('Unable to send account expiry notification', [
                     'exception' => $e->getMessage()
                 ]);
             } catch (Exception $e) {

--- a/service-api/module/Application/src/Model/Service/Feedback/Service.php
+++ b/service-api/module/Application/src/Model/Service/Feedback/Service.php
@@ -37,19 +37,19 @@ class Service extends AbstractService
 
         // Feedback cannot be empty
         if (empty($feedback)) {
-            $this->getLogger()->err('Required fields for saving feedback not present');
+            $this->getLogger()->error('Required fields for saving feedback not present');
             return false;
         }
 
         // validator only checks the validity of fields which can be saved as feedback
         if (!$this->feedbackValidator->isValid($feedback)) {
-            $this->getLogger()->err('Feedback data failed validation');
+            $this->getLogger()->error('Feedback data failed validation');
             return false;
         }
 
         $dbInsertResult = $this->getFeedbackRepository()->insert($feedback);
         if (!$dbInsertResult) {
-            $this->getLogger()->err('Error inserting feedback into database: invalid query');
+            $this->getLogger()->error('Error inserting feedback into database: invalid query');
         }
 
         return $dbInsertResult;

--- a/service-api/module/Application/src/Model/Service/Pdfs/Service.php
+++ b/service-api/module/Application/src/Model/Service/Pdfs/Service.php
@@ -166,7 +166,7 @@ class Service extends AbstractService
             // If we get here it exists in the bucket...
             return self::STATUS_READY;
         } catch (\Aws\S3\Exception\S3Exception $ignore) {
-            $this->getLogger()->err('Exception while attempting to get PDF info from S3');
+            $this->getLogger()->error('Exception while attempting to get PDF info from S3');
         }
 
         /*

--- a/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
+++ b/service-api/module/Application/src/Model/Service/ProcessingStatus/Service.php
@@ -149,7 +149,7 @@ class Service extends AbstractService
 
                 case 500:
                 case 503:
-                    $this->getLogger()->err(
+                    $this->getLogger()->error(
                         'Bad ' . $statusCode . ' response from Sirius gateway: ' .
                         (string)$result->getBody()
                     );
@@ -157,7 +157,7 @@ class Service extends AbstractService
                     throw new ApiProblemException('Bad response from Sirius gateway: ' . $statusCode);
 
                 default:
-                    $this->getLogger()->err(
+                    $this->getLogger()->error(
                         'Unexpected response from Sirius gateway: ' . $statusCode .
                         '; ' . (string)$result->getBody()
                     );

--- a/service-api/module/Application/src/Model/Service/System/Stats.php
+++ b/service-api/module/Application/src/Model/Service/System/Stats.php
@@ -42,7 +42,7 @@ class Stats extends AbstractService
             $stats['lpas'] = $this->getLpaStats();
             $this->getLogger()->info("Successfully generated lpas stats");
         } catch (Exception $ex) {
-            $this->getLogger()->err("Failed to generate lpas stats due to {$ex->getMessage()}", [$ex]);
+            $this->getLogger()->error("Failed to generate lpas stats due to {$ex->getMessage()}", [$ex]);
             $stats['lpas'] = ['generated' => false];
         }
 
@@ -55,7 +55,7 @@ class Stats extends AbstractService
 
             $this->getLogger()->info("Successfully generated lpasPerUser stats");
         } catch (Exception $ex) {
-            $this->getLogger()->err("Failed to generate lpasPerUser stats due to {$ex->getMessage()}", [$ex]);
+            $this->getLogger()->error("Failed to generate lpasPerUser stats due to {$ex->getMessage()}", [$ex]);
             $stats['lpasPerUser'] = ['generated' => false];
         }
 
@@ -63,7 +63,7 @@ class Stats extends AbstractService
             $stats['who'] = $this->getWhoAreYou();
             $this->getLogger()->info("Successfully generated who stats");
         } catch (Exception $ex) {
-            $this->getLogger()->err("Failed to generate who stats due to {$ex->getMessage()}", [$ex]);
+            $this->getLogger()->error("Failed to generate who stats due to {$ex->getMessage()}", [$ex]);
             $stats['who'] = ['generated' => false];
         }
 
@@ -71,7 +71,7 @@ class Stats extends AbstractService
             $stats['correspondence'] = $this->getCorrespondenceStats();
             $this->getLogger()->info("Successfully generated correspondence stats");
         } catch (Exception $ex) {
-            $this->getLogger()->err("Failed to generate correspondence stats due to {$ex->getMessage()}", [$ex]);
+            $this->getLogger()->error("Failed to generate correspondence stats due to {$ex->getMessage()}", [$ex]);
             $stats['correspondence'] = ['generated' => false];
         }
 
@@ -79,7 +79,7 @@ class Stats extends AbstractService
             $stats['preferencesInstructions'] = $this->getPreferencesInstructionsStats();
             $this->getLogger()->info("Successfully generated preferencesInstructions stats");
         } catch (Exception $ex) {
-            $this->getLogger()->err(
+            $this->getLogger()->error(
                 "Failed to generate preferencesInstructions stats due to {$ex->getMessage()}",
                 [$ex]
             );
@@ -90,7 +90,7 @@ class Stats extends AbstractService
             $stats['options'] = $this->getOptionsStats();
             $this->getLogger()->info("Successfully generated options stats");
         } catch (Exception $ex) {
-            $this->getLogger()->err("Failed to generate options stats due to {$ex->getMessage()}", [$ex]);
+            $this->getLogger()->error("Failed to generate options stats due to {$ex->getMessage()}", [$ex]);
             $stats['options'] = ['generated' => false];
         }
 

--- a/service-front/composer.json
+++ b/service-front/composer.json
@@ -25,7 +25,7 @@
         "kokspflanze/zfc-twig": "^4.0.1",
         "laminas/laminas-mvc-i18n": "^2.0",
         "laminas/laminas-mail": "^2.15.1",
-        "laminas/laminas-log": "^2.13",
+        "monolog/monolog": "^3.4",
         "guzzlehttp/psr7": "^2.4",
         "alphagov/notifications-php-client": "^5.0.0",
         "symfony/validator": "^4.2",

--- a/service-front/composer.lock
+++ b/service-front/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "795141bcc8cea99765e28b5c0f3d9e39",
+    "content-hash": "814e6c423692b04c07b2fabaa482b891",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -1884,94 +1884,6 @@
             "time": "2022-10-16T12:50:49+00:00"
         },
         {
-            "name": "laminas/laminas-log",
-            "version": "2.16.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-log.git",
-                "reference": "a9c16bb161311553238b8989aa587bed4b518a7e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-log/zipball/a9c16bb161311553238b8989aa587bed4b518a7e",
-                "reference": "a9c16bb161311553238b8989aa587bed4b518a7e",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-servicemanager": "^3.3.0",
-                "laminas/laminas-stdlib": "^3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-                "psr/log": "^1.1.2"
-            },
-            "conflict": {
-                "zendframework/zend-log": "*"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-xml": "*",
-                "firephp/firephp-core": "^0.5.3",
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-db": "^2.6",
-                "laminas/laminas-escaper": "^2.5",
-                "laminas/laminas-filter": "^2.5",
-                "laminas/laminas-mail": "^2.6.1",
-                "laminas/laminas-validator": "^2.10.1",
-                "mikey179/vfsstream": "^1.6.7",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.10"
-            },
-            "suggest": {
-                "ext-mongo": "mongo extension to use Mongo writer",
-                "ext-mongodb": "mongodb extension to use MongoDB writer",
-                "laminas/laminas-db": "Laminas\\Db component to use the database log writer",
-                "laminas/laminas-escaper": "Laminas\\Escaper component, for use in the XML log formatter",
-                "laminas/laminas-mail": "Laminas\\Mail component to use the email log writer",
-                "laminas/laminas-validator": "Laminas\\Validator component to block invalid log messages"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Log",
-                    "config-provider": "Laminas\\Log\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Log\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Robust, composite logger with filtering, formatting, and PSR-3 support",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "log",
-                "logging"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-log/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-log/issues",
-                "rss": "https://github.com/laminas/laminas-log/releases.atom",
-                "source": "https://github.com/laminas/laminas-log"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2022-12-19T16:38:15+00:00"
-        },
-        {
             "name": "laminas/laminas-mail",
             "version": "2.23.0",
             "source": {
@@ -3074,6 +2986,107 @@
             "time": "2021-11-24T02:52:38+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e2392369686d420ca32df3803de28b5d6f76867d",
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.1",
+                "predis/predis": "^1.1 || ^2",
+                "ruflin/elastica": "^7",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-21T08:46:11+00:00"
+        },
+        {
             "name": "mtdowling/jmespath.php",
             "version": "2.6.1",
             "source": {
@@ -3673,30 +3686,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3717,9 +3730,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "psr/simple-cache",

--- a/service-front/module/Application/src/Controller/Authenticated/PostcodeController.php
+++ b/service-front/module/Application/src/Controller/Authenticated/PostcodeController.php
@@ -33,7 +33,7 @@ class PostcodeController extends AbstractAuthenticatedController
         try {
             $addresses = $this->addressLookup->lookupPostcode($postcode);
         }catch (\RuntimeException $e) {
-            $this->getLogger()->warn("Exception from postcode lookup: ".$e->getMessage());
+            $this->getLogger()->warning("Exception from postcode lookup: ".$e->getMessage());
         }
 
 

--- a/service-front/module/Application/src/Form/Validator/Csrf.php
+++ b/service-front/module/Application/src/Form/Validator/Csrf.php
@@ -46,7 +46,7 @@ class Csrf extends LaminasCsrfValidator
         $hash = $this->getHash(true);
 
         if ($value !== $hash) {
-            $this->getLogger()->err(sprintf(
+            $this->getLogger()->error(sprintf(
                 "Mismatched CSRF provided; expected %s received %s",
                 $this->getHash(),
                 $value,

--- a/service-front/module/Application/src/Model/Service/ApiClient/Client.php
+++ b/service-front/module/Application/src/Model/Service/ApiClient/Client.php
@@ -294,7 +294,7 @@ class Client
     private function handleErrorResponse(ResponseInterface $response)
     {
         $exception = new Exception\ApiException($response);
-        $this->getLogger()->err($exception->getMessage(), ['headers' => $this->defaultHeaders]);
+        $this->getLogger()->error($exception->getMessage(), ['headers' => $this->defaultHeaders]);
         throw $exception;
     }
 }

--- a/service-front/module/Application/src/Model/Service/Feedback/Feedback.php
+++ b/service-front/module/Application/src/Model/Service/Feedback/Feedback.php
@@ -61,10 +61,10 @@ class Feedback extends AbstractEmailService implements ApiClientAwareInterface
 
             return true;
         } catch (ApiException $ex) {
-            $this->getLogger()->err("API exception while adding feedback from Feedback service\n" .
+            $this->getLogger()->error("API exception while adding feedback from Feedback service\n" .
                 $ex->getMessage() . "\n" . $ex->getTraceAsString());
         } catch (InvalidArgumentException $ex) {
-            $this->getLogger()->err("Mail exception while adding feedback from Feedback service\n" .
+            $this->getLogger()->error("Mail exception while adding feedback from Feedback service\n" .
                 $ex->getMessage() . "\n" . $ex->getTraceAsString());
         }
 

--- a/service-front/module/Application/src/Model/Service/Lpa/Application.php
+++ b/service-front/module/Application/src/Model/Service/Lpa/Application.php
@@ -48,7 +48,7 @@ class Application extends AbstractService implements ApiClientAwareInterface
             $result = $this->apiClient->httpGet($target);
             return new Lpa($result);
         } catch (ApiException $ex) {
-            $this->getLogger()->err($ex->getMessage());
+            $this->getLogger->error($ex->getMessage());
         }
 
         return false;
@@ -61,7 +61,7 @@ class Application extends AbstractService implements ApiClientAwareInterface
         try {
             $result = $this->apiClient->httpGet($target);
         } catch (ApiException $ex) {
-            $this->getLogger()->err($ex->getMessage());
+            $this->getLogger->error($ex->getMessage());
             $result = null;
         }
 
@@ -94,7 +94,7 @@ class Application extends AbstractService implements ApiClientAwareInterface
                 $this->apiClient->httpPost(sprintf('/v2/user/%s/applications', $this->getUserId()))
             );
         } catch (ApiException $ex) {
-            $this->getLogger()->err('ApiException thrown when creating LPA application');
+            $this->getLogger->error('ApiException thrown when creating LPA application');
         }
 
         return false;
@@ -114,7 +114,7 @@ class Application extends AbstractService implements ApiClientAwareInterface
         try {
             return new Lpa($this->apiClient->httpPatch($target, $data));
         } catch (ApiException $ex) {
-            $this->getLogger()->err('ApiException thrown when updating LPA application');
+            $this->getLogger->error('ApiException thrown when updating LPA application');
         }
 
         return false;
@@ -171,7 +171,7 @@ class Application extends AbstractService implements ApiClientAwareInterface
                 $result = $response;
             }
         } catch (ApiException $ex) {
-            $this->getLogger()->err('ApiException thrown when fetching LPA application summaries');
+            $this->getLogger->error('ApiException thrown when fetching LPA application summaries');
         }
 
         $trackFromDate = new DateTime($this->getConfig()['processing-status']['track-from-date']);
@@ -292,7 +292,7 @@ class Application extends AbstractService implements ApiClientAwareInterface
                 sprintf('/v2/user/%s/applications/%s/pdfs/%s', $this->getUserId(), $lpaId, $pdfType),
             );
         } catch (ApiException $ex) {
-            $this->getLogger()->err('Error connecting to API while fetching PDF: ' . $ex->getMessage());
+            $this->getLogger->error('Error connecting to API while fetching PDF: ' . $ex->getMessage());
             return false;
         }
 

--- a/service-front/module/Application/src/Model/Service/Lpa/Communication.php
+++ b/service-front/module/Application/src/Model/Service/Lpa/Communication.php
@@ -77,7 +77,7 @@ class Communication extends AbstractEmailService
             $mailParameters = new MailParameters($to, $this->emailTemplateRef, $this->data);
             $this->getMailTransport()->send($mailParameters);
         } catch (ExceptionInterface $ex) {
-            $this->getLogger()->err($ex->getMessage());
+            $this->getLogger()->error($ex->getMessage());
             return "failed-sending-email";
         }
 

--- a/service-front/module/Application/src/Model/Service/Mail/Transport/NotifyMailTransport.php
+++ b/service-front/module/Application/src/Model/Service/Mail/Transport/NotifyMailTransport.php
@@ -108,7 +108,7 @@ class NotifyMailTransport implements MailTransportInterface
             try {
                 $this->client->sendEmail($toAddress, $notifyTemplateId, $data);
             } catch (NotifyException $ex) {
-                $this->getLogger()->err(
+                $this->getLogger()->error(
                     'Failed sending email via Notify: ' . $ex->getMessage() . '\n' . $ex->getTraceAsString()
                 );
 
@@ -152,7 +152,7 @@ class NotifyMailTransport implements MailTransportInterface
                 $data,
             );
         } catch (NotifyException $ex) {
-            $this->getLogger()->err('Healthcheck on Notify failed: ' . $ex->getMessage());
+            $this->getLogger()->error('Healthcheck on Notify failed: ' . $ex->getMessage());
 
             $result['ok'] = false;
             $result['status'] = Constants::STATUS_FAIL;

--- a/service-front/module/Application/src/Model/Service/Redis/RedisClient.php
+++ b/service-front/module/Application/src/Model/Service/Redis/RedisClient.php
@@ -72,12 +72,12 @@ class RedisClient
             // domain name cannot be resolved (in this case, an exception is still thrown)
             $result = @$this->redisClient->connect($this->redisHost, $this->redisPort);
         } catch (RedisException $e) {
-            $this->getLogger()->err(sprintf(
+            $this->getLogger()->error(sprintf(
                 'Unable to connect to Redis server at %s:%s',
                 $this->redisHost,
                 $this->redisPort
             ));
-            $this->getLogger()->err($e->getMessage());
+            $this->getLogger()->error($e->getMessage());
             $result = false;
         }
 

--- a/service-front/module/Application/src/Model/Service/User/Details.php
+++ b/service-front/module/Application/src/Model/Service/User/Details.php
@@ -38,7 +38,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
         try {
             return new User($this->apiClient->httpGet('/v2/user/' . $this->getUserId()));
         } catch (ApiException $ex) {
-            $this->getLogger()->err($ex->getMessage());
+            $this->getLogger()->error($ex->getMessage());
         }
 
         return false;
@@ -117,7 +117,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
                 try {
                     $this->getMailTransport()->send($mailParameters);
                 } catch (ExceptionInterface $ex1) {
-                    $logger->err($ex1->getMessage());
+                    $logger->error($ex1->getMessage());
                 }
 
                 // Send the new email address an email with link to verify that
@@ -137,14 +137,14 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
                 try {
                     $this->getMailTransport()->send($mailParameters);
                 } catch (ExceptionInterface $ex2) {
-                    $logger->err($ex2->getMessage());
+                    $logger->error($ex2->getMessage());
                     return 'failed-sending-email';
                 }
 
                 return true;
             }
         } catch (ApiException $ex3) {
-            $logger->err($ex3->getMessage());
+            $logger->error($ex3->getMessage());
 
             //  Get the real error out of the exception details
             switch ($ex3->getMessage()) {
@@ -171,7 +171,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
 
             return true;
         } catch (ApiException $ex) {
-            $logger->err($ex->getMessage());
+            $logger->error($ex->getMessage());
         }
 
         return false;
@@ -216,7 +216,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
                 try {
                     $this->getMailTransport()->send($mailParameters);
                 } catch (ExceptionInterface $ex) {
-                    $logger->err($ex->getMessage());
+                    $logger->error($ex->getMessage());
                 }
 
                 // Update the identity with the new token to avoid being
@@ -228,7 +228,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
                 return true;
             }
         } catch (ApiException $ex) {
-            $logger->err($ex->getMessage());
+            $logger->error($ex->getMessage());
         }
 
         return 'unknown-error';
@@ -253,7 +253,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
             }
             $failureCode = null;
         } catch (ApiException $ex) {
-            $this->getLogger()->err($ex->getMessage());
+            $this->getLogger()->error($ex->getMessage());
 
             $success = false;
             $expiresIn = null;
@@ -284,7 +284,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
         try {
             $this->apiClient->httpDelete('/v2/user/' . $this->getUserId());
         } catch (ApiException $ex) {
-            $logger->err($ex->getMessage());
+            $logger->error($ex->getMessage());
             return false;
         }
 
@@ -330,7 +330,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
                     try {
                         $this->getMailTransport()->send($mailParameters);
                     } catch (ExceptionInterface $ex) {
-                        $logger->err($ex->getMessage());
+                        $logger->error($ex->getMessage());
                         return "failed-sending-email";
                     }
 
@@ -355,7 +355,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
                 try {
                     $this->getMailTransport()->send($mailParameters);
                 } catch (ExceptionInterface $ex) {
-                    $logger->err($ex->getMessage());
+                    $logger->error($ex->getMessage());
                     return "failed-sending-email";
                 }
 
@@ -390,7 +390,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
         try {
             $this->getMailTransport()->send($mailParameters);
         } catch (ExceptionInterface $ex) {
-            $this->getLogger()->err($ex->getMessage());
+            $this->getLogger()->error($ex->getMessage());
             return 'failed-sending-email';
         }
 
@@ -420,7 +420,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
             }
         } catch (ApiException $ex) {
             $msg = $ex->getMessage();
-            $logger->err($msg);
+            $logger->error($msg);
 
             if ($msg === 'Invalid passwordToken') {
                 return 'invalid-token';
@@ -469,7 +469,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
                 try {
                     $this->getMailTransport()->send($mailParameters);
                 } catch (ExceptionInterface $ex1) {
-                    $logger->err($ex1->getMessage());
+                    $logger->error($ex1->getMessage());
                     return 'failed-sending-email';
                 }
 
@@ -485,7 +485,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
                 try {
                     $this->getMailTransport()->send($mailParameters);
                 } catch (ExceptionInterface $ex3) {
-                    $logger->err($ex3->getMessage());
+                    $logger->error($ex3->getMessage());
                     return 'failed-sending-warning-email';
                 }
                 return 'address-already-registered';
@@ -516,7 +516,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
                 return $this->sendAccountActivateEmail($email, $result['activation_token']);
             }
         } catch (ApiException $ex) {
-            $this->getLogger()->err($ex->getMessage());
+            $this->getLogger()->error($ex->getMessage());
         }
 
         //  If a proper reset token was returned, or the exception thrown was NOT account-not-activated then
@@ -544,7 +544,7 @@ class Details extends AbstractEmailService implements ApiClientAwareInterface
 
             return true;
         } catch (ApiException $ex) {
-            $logger->err($ex->getMessage());
+            $logger->error($ex->getMessage());
         }
 
         $logger->info('Account activation attempt with token failed, or was already activated');

--- a/service-front/module/Application/tests/Logging/ErrorEventListenerTest.php
+++ b/service-front/module/Application/tests/Logging/ErrorEventListenerTest.php
@@ -20,11 +20,11 @@ class ErrorEventListenerTest extends MockeryTestCase
 
         $logger = Mockery::mock(Logger::class);
 
-        $logger->shouldReceive('err')
+        $logger->shouldReceive('error')
                ->with(MvcEvent::EVENT_DISPATCH_ERROR, Mockery::type('array'))
                ->times(1);
 
-        $logger->shouldReceive('err')
+        $logger->shouldReceive('error')
                ->with(MvcEvent::EVENT_RENDER_ERROR, Mockery::type('array'))
                ->times(1);
 
@@ -33,7 +33,7 @@ class ErrorEventListenerTest extends MockeryTestCase
         $eventLogger->attach($eventManager);
 
         // dispatch events from the event manager and check that the logger
-        // has err() called
+        // has error() called
         $eventManager->trigger(MvcEvent::EVENT_DISPATCH_ERROR);
         $eventManager->trigger(MvcEvent::EVENT_RENDER_ERROR);
     }

--- a/service-pdf/composer.json
+++ b/service-pdf/composer.json
@@ -16,7 +16,7 @@
         "tecnickcom/tcpdf": "6.4.1",
         "setasign/fpdi-tcpdf": "^2.0",
         "laminas/laminas-zendframework-bridge": "^1.1.1",
-        "laminas/laminas-log": "^2.13",
+        "monolog/monolog": "^3.4",
         "symfony/validator": "^4.2",
         "egulias/email-validator": "~1.2"
     },

--- a/service-pdf/composer.lock
+++ b/service-pdf/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fea45fe30ffde578db1a9a96a7cc88e4",
+    "content-hash": "6b7f9e60f3122d96962bce75cb92bdef",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -811,94 +811,6 @@
             "time": "2023-05-16T23:25:05+00:00"
         },
         {
-            "name": "laminas/laminas-log",
-            "version": "2.16.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-log.git",
-                "reference": "a9c16bb161311553238b8989aa587bed4b518a7e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-log/zipball/a9c16bb161311553238b8989aa587bed4b518a7e",
-                "reference": "a9c16bb161311553238b8989aa587bed4b518a7e",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-servicemanager": "^3.3.0",
-                "laminas/laminas-stdlib": "^3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-                "psr/log": "^1.1.2"
-            },
-            "conflict": {
-                "zendframework/zend-log": "*"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-xml": "*",
-                "firephp/firephp-core": "^0.5.3",
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-db": "^2.6",
-                "laminas/laminas-escaper": "^2.5",
-                "laminas/laminas-filter": "^2.5",
-                "laminas/laminas-mail": "^2.6.1",
-                "laminas/laminas-validator": "^2.10.1",
-                "mikey179/vfsstream": "^1.6.7",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.10"
-            },
-            "suggest": {
-                "ext-mongo": "mongo extension to use Mongo writer",
-                "ext-mongodb": "mongodb extension to use MongoDB writer",
-                "laminas/laminas-db": "Laminas\\Db component to use the database log writer",
-                "laminas/laminas-escaper": "Laminas\\Escaper component, for use in the XML log formatter",
-                "laminas/laminas-mail": "Laminas\\Mail component to use the email log writer",
-                "laminas/laminas-validator": "Laminas\\Validator component to block invalid log messages"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Log",
-                    "config-provider": "Laminas\\Log\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Log\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Robust, composite logger with filtering, formatting, and PSR-3 support",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "log",
-                "logging"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-log/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-log/issues",
-                "rss": "https://github.com/laminas/laminas-log/releases.atom",
-                "source": "https://github.com/laminas/laminas-log"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2022-12-19T16:38:15+00:00"
-        },
-        {
             "name": "laminas/laminas-math",
             "version": "3.6.0",
             "source": {
@@ -1398,6 +1310,107 @@
             "time": "2014-07-09T11:08:51+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e2392369686d420ca32df3803de28b5d6f76867d",
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.1",
+                "predis/predis": "^1.1 || ^2",
+                "ruflin/elastica": "^7",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-21T08:46:11+00:00"
+        },
+        {
             "name": "mtdowling/jmespath.php",
             "version": "2.7.0",
             "source": {
@@ -1673,30 +1686,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1717,9 +1730,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -5948,10 +5961,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1 <8.2.0"
+        "php": ">=8.1"
     },
     "platform-dev": {
         "ext-json": "*"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/service-pdf/src/Opg/Lpa/Pdf/PdfRenderer.php
+++ b/service-pdf/src/Opg/Lpa/Pdf/PdfRenderer.php
@@ -81,12 +81,12 @@ class PdfRenderer
         }
 
         if (!isset($assetsConfig['source_template_path'])) {
-            $this->getLogger()->err('source_template_path not set in config');
+            $this->getLogger()->error('source_template_path not set in config');
             return false;
         }
 
         if (!isset($assetsConfig['template_path_on_ram_disk'])) {
-            $this->getLogger()->err('template_path_on_ram_disk not set in config');
+            $this->getLogger()->error('template_path_on_ram_disk not set in config');
             return false;
         }
 
@@ -215,7 +215,7 @@ class PdfRenderer
         $message = $docId . ': ' . $message;
 
         if ($isError) {
-            $this->getLogger()->err($message, $loggingParams);
+            $this->getLogger()->error($message, $loggingParams);
         } else {
             $this->getLogger()->info($message, $loggingParams);
         }

--- a/service-pdf/src/Opg/Lpa/Pdf/Worker/Response/S3Response.php
+++ b/service-pdf/src/Opg/Lpa/Pdf/Worker/Response/S3Response.php
@@ -56,7 +56,7 @@ class S3Response
 
             $s3->putObject($file);
         } catch (S3Exception $e) {
-            $this->getLogger()->emerg('ERROR: Failed to save to S3 in ' . $workerSettingsConfig['Bucket']);
+            $this->getLogger()->error('ERROR: Failed to save to S3 in ' . $workerSettingsConfig['Bucket']);
             throw $e;
         }
 

--- a/service-pdf/src/Opg/Lpa/Pdf/Worker/SqsWorker.php
+++ b/service-pdf/src/Opg/Lpa/Pdf/Worker/SqsWorker.php
@@ -35,7 +35,7 @@ class SqsWorker
         $pdfFilePath = $pdf['filepath'];
 
         if (is_null($pdfFilePath)) {
-            $this->getLogger()->err('null path returned for generated PDF');
+            $this->getLogger()->error('null path returned for generated PDF');
             return null;
         }
 
@@ -108,7 +108,7 @@ class SqsWorker
                         (microtime(true) - $startTime) .
                         " seconds to make PDF for LPA " . $lpaId);
                 } catch (\Exception $e) {
-                    $this->getLogger()->err("Error generating PDF", [
+                    $this->getLogger()->error("Error generating PDF", [
                         'jobId' => $lpaMessage['jobId'],
                         'lpaId' => $lpaMessage['lpaId'],
                     ]);
@@ -125,7 +125,7 @@ class SqsWorker
                 $this->getLogger()->debug("No message found in queue for this poll, finishing thread.");
             }
         } catch (\Exception $e) {
-            $this->getLogger()->emerg("Exception in SqsWorker: " . $e->getMessage());
+            $this->getLogger()->error("Exception in SqsWorker: " . $e->getMessage());
             sleep(5);
         }
     }

--- a/shared/composer.json
+++ b/shared/composer.json
@@ -14,7 +14,7 @@
         "egulias/email-validator": "~1.2",
         "laminas/laminas-diactoros": "^2.23",
         "laminas/laminas-eventmanager": "^3.5",
-        "laminas/laminas-log": "^2.13",
+        "monolog/monolog": "^3.4",
         "laminas/laminas-mvc": "^3.5",
         "symfony/validator": "^4.2"
     },

--- a/shared/composer.lock
+++ b/shared/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e01ea1d54e1e5beda941e7f0d446031",
+    "content-hash": "1e0b134882df73d10d277787079ed67a",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -661,94 +661,6 @@
             "time": "2022-10-16T12:50:49+00:00"
         },
         {
-            "name": "laminas/laminas-log",
-            "version": "2.16.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-log.git",
-                "reference": "a9c16bb161311553238b8989aa587bed4b518a7e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-log/zipball/a9c16bb161311553238b8989aa587bed4b518a7e",
-                "reference": "a9c16bb161311553238b8989aa587bed4b518a7e",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-servicemanager": "^3.3.0",
-                "laminas/laminas-stdlib": "^3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-                "psr/log": "^1.1.2"
-            },
-            "conflict": {
-                "zendframework/zend-log": "*"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-xml": "*",
-                "firephp/firephp-core": "^0.5.3",
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-db": "^2.6",
-                "laminas/laminas-escaper": "^2.5",
-                "laminas/laminas-filter": "^2.5",
-                "laminas/laminas-mail": "^2.6.1",
-                "laminas/laminas-validator": "^2.10.1",
-                "mikey179/vfsstream": "^1.6.7",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.10"
-            },
-            "suggest": {
-                "ext-mongo": "mongo extension to use Mongo writer",
-                "ext-mongodb": "mongodb extension to use MongoDB writer",
-                "laminas/laminas-db": "Laminas\\Db component to use the database log writer",
-                "laminas/laminas-escaper": "Laminas\\Escaper component, for use in the XML log formatter",
-                "laminas/laminas-mail": "Laminas\\Mail component to use the email log writer",
-                "laminas/laminas-validator": "Laminas\\Validator component to block invalid log messages"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Log",
-                    "config-provider": "Laminas\\Log\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Log\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Robust, composite logger with filtering, formatting, and PSR-3 support",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "log",
-                "logging"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-log/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-log/issues",
-                "rss": "https://github.com/laminas/laminas-log/releases.atom",
-                "source": "https://github.com/laminas/laminas-log"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2022-12-19T16:38:15+00:00"
-        },
-        {
             "name": "laminas/laminas-modulemanager",
             "version": "2.14.0",
             "source": {
@@ -1365,6 +1277,107 @@
             "time": "2023-02-09T16:07:15+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e2392369686d420ca32df3803de28b5d6f76867d",
+                "reference": "e2392369686d420ca32df3803de28b5d6f76867d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.1",
+                "predis/predis": "^1.1 || ^2",
+                "ruflin/elastica": "^7",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-21T08:46:11+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v4.17.1",
             "source": {
@@ -1578,30 +1591,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1622,9 +1635,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -5621,5 +5634,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/shared/module/MakeShared/src/Logging/HeadersProcessor.php
+++ b/shared/module/MakeShared/src/Logging/HeadersProcessor.php
@@ -2,7 +2,7 @@
 
 namespace MakeShared\Logging;
 
-use Laminas\Log\Processor\ProcessorInterface;
+use Monolog\Processor\ProcessorInterface;
 
 /**
  * Process any headers array in the $extra field, stripping sensitive
@@ -49,7 +49,7 @@ class HeadersProcessor implements ProcessorInterface
 
     public const HEADERS_TO_STRIP = ['cookie', 'authorization', '_ga', '_gid', 'token'];
 
-    public function process(array $event): array
+    public function __invoke(array $event): array
     {
         // early return if there's no "headers" in $extra
         if (!isset($event['extra'][self::HEADERS_FIELD_NAME])) {

--- a/shared/module/MakeShared/src/Logging/LoggerTrait.php
+++ b/shared/module/MakeShared/src/Logging/LoggerTrait.php
@@ -2,7 +2,7 @@
 
 namespace MakeShared\Logging;
 
-use Laminas\Log\Logger as LaminasLogger;
+use Monolog\Logger as MonologLogger;
 use MakeShared\Logging\Logger;
 
 /**
@@ -12,26 +12,26 @@ use MakeShared\Logging\Logger;
 trait LoggerTrait
 {
     /**
-     * @var LaminasLogger
+     * @var MonologLogger
      */
     private $logger;
 
     /**
-     * @param LaminasLogger $logger
+     * @param MonologLogger $logger
      * @return $this
      */
-    public function setLogger(LaminasLogger $logger)
+    public function setLogger(MonologLogger $logger)
     {
         $this->logger = $logger;
         return $this;
     }
 
     /**
-     * @return LaminasLogger $logger
+     * @return MonologLogger $logger
      */
     public function getLogger()
     {
-        if (!$this->logger instanceof LaminasLogger) {
+        if (!$this->logger instanceof MonologLogger) {
             $this->logger = new Logger();
         }
 

--- a/shared/module/MakeShared/src/Logging/MvcEventProcessor.php
+++ b/shared/module/MakeShared/src/Logging/MvcEventProcessor.php
@@ -3,7 +3,7 @@
 namespace MakeShared\Logging;
 
 use Laminas\Mvc\MvcEvent;
-use Laminas\Log\Processor\ProcessorInterface;
+use Monolog\Processor\ProcessorInterface;
 
 /**
  * Recognise MVC events sent to the logger and convert them to arrays.
@@ -24,7 +24,7 @@ class MvcEventProcessor implements ProcessorInterface
      */
     public const EVENT_FIELD_NAME = 'event';
 
-    public function process(array $event): array
+    public function __invoke(array $event): array
     {
         // early return if there's no "event" in $extra
         if (

--- a/shared/module/MakeShared/src/Logging/SimpleLogger.php
+++ b/shared/module/MakeShared/src/Logging/SimpleLogger.php
@@ -2,14 +2,14 @@
 
 namespace MakeShared\Logging;
 
-use Laminas\Log\Logger as LaminasLogger;
-use Laminas\Log\Writer\Stream as StreamWriter;
+use Monolog\Logger as MonologLogger;
+use Monolog\Handler\StreamHandler;
 
-class SimpleLogger extends LaminasLogger
+class SimpleLogger extends MonologLogger
 {
     public function __construct()
     {
         parent::__construct();
-        $this->addWriter(new StreamWriter('php://stderr'));
+        $this->pushHandler(new StreamHandler('php://stderr', Level::Warning));
     }
 }

--- a/shared/module/MakeShared/src/Logging/SimpleLoggerTrait.php
+++ b/shared/module/MakeShared/src/Logging/SimpleLoggerTrait.php
@@ -2,7 +2,7 @@
 
 namespace MakeShared\Logging;
 
-use Laminas\Log\Logger as LaminasLogger;
+use Monolog\Logger as MonologLogger;
 use MakeShared\Logging\SimpleLogger;
 
 /**
@@ -12,16 +12,16 @@ use MakeShared\Logging\SimpleLogger;
 trait SimpleLoggerTrait
 {
     /**
-     * @var LaminasLogger
+     * @var MonologLogger
      */
     private $logger;
 
     /**
-     * @return LaminasLogger $logger
+     * @return MonologLogger $logger
      */
     public function getLogger()
     {
-        if (!$this->logger instanceof LaminasLogger) {
+        if (!$this->logger instanceof MonologLogger) {
             $this->logger = new SimpleLogger();
         }
 

--- a/shared/module/MakeShared/src/Logging/TraceIdProcessor.php
+++ b/shared/module/MakeShared/src/Logging/TraceIdProcessor.php
@@ -2,7 +2,7 @@
 
 namespace MakeShared\Logging;
 
-use Laminas\Log\Processor\ProcessorInterface;
+use Monolog\Processor\ProcessorInterface;
 
 /**
  * If a non-null trace_id property is in the $extra field for the log event,
@@ -16,7 +16,7 @@ class TraceIdProcessor implements ProcessorInterface
      */
     public const TRACE_ID_FIELD_NAME = 'trace_id';
 
-    public function process(array $event): array
+    public function __invoke(array $event): array
     {
         // early return if there's no "trace_id" in $extra
         if (!array_key_exists(self::TRACE_ID_FIELD_NAME, $event['extra'])) {


### PR DESCRIPTION
## Purpose

_Replace laminas-log , which is becoming abandonware, with monolog_

## Approach

_Update composer.json and lock files, modify lots of code to use Monolog instead of Laminas-log.  in Monolog, warn() function is called warning() instead, and err() method is called error() instead_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
