### PR TITLE
allow concurrent PRs by renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,9 +19,9 @@
     "prCreation": "immediate",
     "prPriority": 5
   },
-  "prConcurrentLimit": 1,
+  "prConcurrentLimit": 3,
   "prHourlyLimit": 1,
-  "branchConcurrentLimit": 1,
+  "branchConcurrentLimit": 5,
   "enabledManagers": [
     "dockerfile",
     "docker-compose",


### PR DESCRIPTION
## Purpose

_Due to some open PRs that cannot be merged swiftly, renovate has not been creating new ones. It is possible to trigger new renovate PRs by hand to get updates through, however its not obvious which are mature enough, so better to let renovate decide when to create a PR. Allowing more concurrency allows this_

## Approach

_Edit renovate.json_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
