### PR TITLE
LPAL-1254 Update CA certificate for RDS

### DIFF
--- a/terraform/environment/modules/environment/modules/aurora/main.tf
+++ b/terraform/environment/modules/environment/modules/aurora/main.tf
@@ -34,6 +34,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   auto_minor_version_upgrade      = var.auto_minor_version_upgrade
   db_subnet_group_name            = var.db_subnet_group_name
   depends_on                      = [aws_rds_cluster.cluster]
+  ca_cert_identifier              = var.ca_cert_identifier
   cluster_identifier              = "${var.cluster_identifier}-${var.environment}"
   copy_tags_to_snapshot           = var.copy_tags_to_snapshot
   engine                          = var.engine
@@ -95,6 +96,7 @@ resource "aws_rds_cluster_instance" "serverless_instances" {
   auto_minor_version_upgrade      = var.auto_minor_version_upgrade
   db_subnet_group_name            = var.db_subnet_group_name
   depends_on                      = [aws_rds_cluster.cluster_serverless]
+  ca_cert_identifier              = var.ca_cert_identifier
   cluster_identifier              = "${var.cluster_identifier}-${var.environment}"
   engine                          = var.engine
   engine_version                  = var.engine_version

--- a/terraform/environment/modules/environment/modules/aurora/variables.tf
+++ b/terraform/environment/modules/environment/modules/aurora/variables.tf
@@ -28,3 +28,4 @@ variable "replication_source_identifier" {}
 variable "copy_tags_to_snapshot" { default = true }
 variable "iam_database_authentication_enabled" { default = true }
 variable "psql_aurora_parameter_group_family" { default = "aurora-postgresql13" }
+variable "ca_cert_identifier" { default = "rds-ca-rsa2048-g1" }


### PR DESCRIPTION
## Purpose

Update CA certificate for RDS instance

Fixes LPAL-1254

## Approach

Update the certificate used by RDS for TLS. No updates to the client necessary.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
