### PR TITLE
LPAL-1255 Add DNS health check for Make

### DIFF
--- a/terraform/environment/main.tf
+++ b/terraform/environment/main.tf
@@ -56,6 +56,7 @@ module "environment_dns" {
   source = "./modules/dns"
   providers = {
     aws            = aws
+    aws.us_east_1  = aws.us_east_1
     aws.management = aws.management
   }
   account_name     = local.account_name

--- a/terraform/environment/modules/dns/main.tf
+++ b/terraform/environment/modules/dns/main.tf
@@ -58,3 +58,34 @@ resource "aws_route53_record" "admin" {
   }
 }
 
+resource "aws_route53_health_check" "public_facing_lastingpowerofattorney" {
+  fqdn              = aws_route53_record.public_facing_lastingpowerofattorney.fqdn
+  reference_name    = "${substr(var.environment_name, 0, 20)}-lpapub"
+  port              = 443
+  type              = "HTTPS"
+  failure_threshold = 1
+  request_interval  = 30
+  measure_latency   = true
+  regions           = ["us-east-1", "us-west-1", "us-west-2", "eu-west-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "sa-east-1"]
+
+  provider = aws.us_east_1
+}
+
+resource "aws_cloudwatch_metric_alarm" "public_facing_lastingpowerofattorney" {
+  alarm_description   = "${var.environment_name} LPA health check"
+  alarm_name          = "${var.environment_name}-lpa-healthcheck-alarm"
+  actions_enabled     = false
+  comparison_operator = "LessThanThreshold"
+  datapoints_to_alarm = 1
+  evaluation_periods  = 1
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = 60
+  statistic           = "Minimum"
+  threshold           = 1
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.public_facing_lastingpowerofattorney.id
+  }
+
+  provider = aws.us_east_1
+}

--- a/terraform/environment/modules/dns/terraform.tf
+++ b/terraform/environment/modules/dns/terraform.tf
@@ -3,7 +3,8 @@ terraform {
     aws = {
       source = "hashicorp/aws"
       configuration_aliases = [
-        aws.management
+        aws.management,
+        aws.us_east_1
       ]
     }
     pagerduty = {

--- a/terraform/environment/modules/environment/load_balancer_front.tf
+++ b/terraform/environment/modules/environment/load_balancer_front.tf
@@ -28,6 +28,7 @@ resource "aws_lb" "front" {
 
   security_groups = [
     aws_security_group.front_loadbalancer.id,
+    aws_security_group.front_loadbalancer_route53.id,
   ]
   enable_deletion_protection = var.account_name == "development" ? false : true
   access_logs {
@@ -49,6 +50,28 @@ resource "aws_lb_listener" "front_loadbalancer" {
     target_group_arn = aws_lb_target_group.front.arn
     type             = "forward"
   }
+}
+
+
+resource "aws_security_group" "front_loadbalancer_route53" {
+  name_prefix = "${var.environment_name}-actor-loadbalancer-route53"
+  description = "Allow Route53 healthchecks"
+  vpc_id      = data.aws_vpc.default.id
+}
+
+resource "aws_security_group_rule" "actor_loadbalancer_ingress_route53_healthchecks" {
+  description       = "Loadbalancer ingresss from Route53 healthchecks"
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = "443"
+  to_port           = "443"
+  cidr_blocks       = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
+  security_group_id = aws_security_group.front_loadbalancer_route53.id
+}
+
+data "aws_ip_ranges" "route53_healthchecks" {
+  regions = ["eu-west-1", "eu-west-2"]
+  services = ["ROUTE53_HEALTHCHECKS"]
 }
 
 #tfsec:ignore:aws-ec2-add-description-to-security-group - Adding description is destructive change needing downtime. to be revisited
@@ -183,3 +206,4 @@ resource "aws_lb_listener_rule" "www_redirect" {
     }
   }
 }
+

--- a/terraform/environment/modules/environment/load_balancer_front.tf
+++ b/terraform/environment/modules/environment/load_balancer_front.tf
@@ -70,7 +70,7 @@ resource "aws_security_group_rule" "actor_loadbalancer_ingress_route53_healthche
 }
 
 data "aws_ip_ranges" "route53_healthchecks" {
-  regions = ["eu-west-1", "eu-west-2"]
+  regions  = ["eu-west-1", "eu-west-2"]
   services = ["ROUTE53_HEALTHCHECKS"]
 }
 


### PR DESCRIPTION
## Purpose

Add DNS health check for Make an LPA public front end.

Fixes LPAL-1255

## Approach

Create health check resource and change loadbalancer to allow HTTPS connections from AWS health check IP addresses.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
