### PR TITLE
update healthcheck url in response to deprecation warning (url is

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/localstack:/tmp/localstack
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:4566/health?reload"]
+      test: ["CMD", "curl", "http://localhost:4566/_localstack/health?reload"]
 
   local-config:
     container_name: lpa-local-config


### PR DESCRIPTION
changing)

## Purpose

_update healthcheck url in response to deprecation warning_

## Approach

_update in docker compose file_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
