### PR TITLE
LPAL-1259: Expire Redis items after 3 hours

### DIFF
--- a/service-front/module/Application/src/Model/Service/Redis/RedisClient.php
+++ b/service-front/module/Application/src/Model/Service/Redis/RedisClient.php
@@ -54,7 +54,8 @@ class RedisClient
             $this->redisPort = intval($urlParts['port']);
         }
 
-        $this->ttl = $ttlMs;
+        # Redis' setEx expects TTL in seconds, but this is passed to the constructor in milliseconds
+        $this->ttl = $ttlMs / 1000;
 
         if (is_null($redis)) {
             $redis = new Redis();


### PR DESCRIPTION
## Purpose

Adjust the expiry time of Redis items from 3000 hours to 3 hours.

Fixes LPAL-1259

## Approach

Change the _construct method to divide the amount of milliseconds by 1000 before passing it to the setEx method.

## Learning

https://github.com/phpredis/phpredis#setex-psetex

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
