### PR TITLE
LPAL-1260 Add request num autoscale for front ECS

### DIFF
--- a/terraform/environment/modules/environment/autoscaling.tf
+++ b/terraform/environment/modules/environment/autoscaling.tf
@@ -8,6 +8,7 @@ module "front_ecs_autoscaling" {
   ecs_task_autoscaling_maximum                  = var.account.autoscaling.front.maximum
   autoscaling_metric_track_request_count_target = 360 # Set to 360 to allow for 25% headroom based on max request count of 480 requests per minute
   request_count_scale_out_cooldown              = 30
+  aws_request_count_metric_resource_label       = "${aws_lb.front.arn_suffix}/${aws_lb_target_group.front.arn_suffix}"
   tags                                          = local.front_component_tag
 }
 

--- a/terraform/environment/modules/environment/autoscaling.tf
+++ b/terraform/environment/modules/environment/autoscaling.tf
@@ -1,23 +1,26 @@
 module "front_ecs_autoscaling" {
-  source                           = "./modules/ecs_autoscaling"
-  environment                      = var.environment_name
-  aws_ecs_cluster_name             = aws_ecs_cluster.online-lpa.name
-  aws_ecs_service_name             = aws_ecs_service.front.name
-  ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn
-  ecs_task_autoscaling_minimum     = var.account.autoscaling.front.minimum
-  ecs_task_autoscaling_maximum     = var.account.autoscaling.front.maximum
-  tags                             = local.front_component_tag
+  source                                        = "./modules/ecs_autoscaling"
+  environment                                   = var.environment_name
+  aws_ecs_cluster_name                          = aws_ecs_cluster.online-lpa.name
+  aws_ecs_service_name                          = aws_ecs_service.front.name
+  ecs_autoscaling_service_role_arn              = data.aws_iam_role.ecs_autoscaling_service_role.arn
+  ecs_task_autoscaling_minimum                  = var.account.autoscaling.front.minimum
+  ecs_task_autoscaling_maximum                  = var.account.autoscaling.front.maximum
+  autoscaling_metric_track_request_count_target = 360 # Set to 360 to allow for 25% headroom based on max request count of 480 requests per minute
+  request_count_scale_out_cooldown              = 30
+  tags                                          = local.front_component_tag
 }
 
 module "api_ecs_autoscaling" {
-  source                           = "./modules/ecs_autoscaling"
-  environment                      = var.environment_name
-  aws_ecs_cluster_name             = aws_ecs_cluster.online-lpa.name
-  aws_ecs_service_name             = aws_ecs_service.api.name
-  ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn
-  ecs_task_autoscaling_minimum     = var.account.autoscaling.api.minimum
-  ecs_task_autoscaling_maximum     = var.account.autoscaling.api.maximum
-  tags                             = local.api_component_tag
+  source                              = "./modules/ecs_autoscaling"
+  environment                         = var.environment_name
+  aws_ecs_cluster_name                = aws_ecs_cluster.online-lpa.name
+  aws_ecs_service_name                = aws_ecs_service.api.name
+  ecs_autoscaling_service_role_arn    = data.aws_iam_role.ecs_autoscaling_service_role.arn
+  ecs_task_autoscaling_minimum        = var.account.autoscaling.api.minimum
+  ecs_task_autoscaling_maximum        = var.account.autoscaling.api.maximum
+  autoscaling_metric_track_cpu_target = 45
+  tags                                = local.api_component_tag
 }
 
 module "pdf_ecs_autoscaling" {

--- a/terraform/environment/modules/environment/modules/ecs_autoscaling/main.tf
+++ b/terraform/environment/modules/environment/modules/ecs_autoscaling/main.tf
@@ -43,6 +43,25 @@ resource "aws_appautoscaling_policy" "memory_track_metric" {
   }
 }
 
+resource "aws_appautoscaling_policy" "request_count" {
+  count              = var.autoscaling_metric_track_request_count_target > 0 ? 1 : 0
+  name               = "${var.environment}-${var.aws_ecs_service_name}-request-count"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs_service.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_service.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_service.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value       = var.autoscaling_metric_track_request_count_target
+    scale_in_cooldown  = var.request_count_scale_in_cooldown
+    scale_out_cooldown = var.request_count_scale_out_cooldown
+
+    predefined_metric_specification {
+      predefined_metric_type = "ALBRequestCountPerTarget"
+    }
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "max_scaling_reached" {
   alarm_name                = "${var.environment}-${var.aws_ecs_service_name}-max-scaling-reached"
   comparison_operator       = "GreaterThanOrEqualToThreshold"

--- a/terraform/environment/modules/environment/modules/ecs_autoscaling/main.tf
+++ b/terraform/environment/modules/environment/modules/ecs_autoscaling/main.tf
@@ -58,6 +58,7 @@ resource "aws_appautoscaling_policy" "request_count" {
 
     predefined_metric_specification {
       predefined_metric_type = "ALBRequestCountPerTarget"
+      resource_label         = var.aws_request_count_metric_resource_label
     }
   }
 }

--- a/terraform/environment/modules/environment/modules/ecs_autoscaling/variables.tf
+++ b/terraform/environment/modules/environment/modules/ecs_autoscaling/variables.tf
@@ -88,6 +88,11 @@ variable "autoscaling_metric_track_request_count_target" {
   default     = 0
 }
 
+variable "aws_request_count_metric_resource_label" {
+  description = "Identifies the ALB resource associated with the metric ALBRequestCountPerTarget. Format is app/<load-balancer-name>/<load-balancer-id>/targetgroup/<target-group-name>/<target-group-id>"
+  type        = string
+}
+
 output "appautoscaling_target" {
   description = "returns the autoscaling target for other scaling operations to use"
   value = {

--- a/terraform/environment/modules/environment/modules/ecs_autoscaling/variables.tf
+++ b/terraform/environment/modules/environment/modules/ecs_autoscaling/variables.tf
@@ -91,6 +91,7 @@ variable "autoscaling_metric_track_request_count_target" {
 variable "aws_request_count_metric_resource_label" {
   description = "Identifies the ALB resource associated with the metric ALBRequestCountPerTarget. Format is app/<load-balancer-name>/<load-balancer-id>/targetgroup/<target-group-name>/<target-group-id>"
   type        = string
+  default     = ""
 }
 
 output "appautoscaling_target" {

--- a/terraform/environment/modules/environment/modules/ecs_autoscaling/variables.tf
+++ b/terraform/environment/modules/environment/modules/ecs_autoscaling/variables.tf
@@ -70,6 +70,24 @@ variable "tags" {
   type        = map(any)
 }
 
+variable "request_count_scale_in_cooldown" {
+  description = "The amount of time, in seconds, after a scale in activity completes before another scale in activity can start."
+  type        = number
+  default     = 60
+}
+
+variable "request_count_scale_out_cooldown" {
+  description = "The amount of time, in seconds, after a scale out activity completes before another scale out activity can start."
+  type        = number
+  default     = 60
+}
+
+variable "autoscaling_metric_track_request_count_target" {
+  description = "Average Application Load Balancer request count per target per minutes. This is the metric that will be used to scale the service."
+  type        = number
+  default     = 0
+}
+
 output "appautoscaling_target" {
   description = "returns the autoscaling target for other scaling operations to use"
   value = {


### PR DESCRIPTION
## Purpose

Make the service quicker to autoscale in the event of a sudden increase in traffic.

Fixes LPAL-1260

## Approach

Scale front ECS containers based on ALB requests per minute and scale API based on lower average CPU.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
