### PR TITLE
LPAL-1262 Post builds in #opg-lpa-builds

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -318,7 +318,7 @@ jobs:
     - uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
       id: slack
       with:
-        channel-id: "C01BKBWGWTY"
+        channel-id: "CAMB46M6Y"
         payload: |
             {
               "icon_emoji": ":robot_face:",
@@ -468,7 +468,7 @@ jobs:
 
     - uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
       with:
-        channel-id: "C01BKBWGWTY"
+        channel-id: "CAMB46M6Y"
         update-ts: ${{ needs.post_deployment_slack_msg.outputs.ts }}
         payload: |
             {


### PR DESCRIPTION
## Purpose

Move builds from opg-lpa-live-builds to opg-lpa-builds.

Fixes LPAL-1262

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
