### PR TITLE
LPAL-1276 fix locally running of cypress pdf tests and fix xdebug for admin, pdf, api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -451,6 +451,10 @@ services:
       AWS_ACCESS_KEY_ID: "devkey"
       AWS_SECRET_ACCESS_KEY: "secretdevkey"
 
+      # XDEBUG mode and session need setting for this to run when xdebug mode above is enabled
+      XDEBUG_MODE: debug
+      XDEBUG_SESSION: 1
+
       OPG_LPA_COMMON_S3_ENDPOINT: http://localstack:4566
       OPG_LPA_COMMON_PDF_QUEUE_URL: http://sqs.eu-west-1.localhost.localstack.cloud:4566/000000000000/pdf-queue.fifo
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
 
   localstack:
     container_name: lpa-localstack
-    image: localstack/localstack:0.14.5
+    image: localstack/localstack:3.0.2
     privileged: true
     ports:
       - 4568:4566
@@ -91,7 +91,10 @@ services:
       - LAMBDA_DOCKER_NETWORK=malpadev
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /tmp/localstack:/tmp/localstack
+    networks:
+      default:
+        aliases:
+          - sqs.eu-west-1.localhost.localstack.cloud
     healthcheck:
       test: ["CMD", "curl", "http://localhost:4566/_localstack/health?reload"]
 
@@ -437,6 +440,8 @@ services:
       - /tmp/
     build:
       context: ./
+      args:
+        ENABLE_XDEBUG: 0
       dockerfile: service-pdf/docker/app/Dockerfile
 # Other containers are built with debug on. Lines could be put here to build pdf with debug, but not doing as default due to pdf being slow already
     environment:
@@ -447,8 +452,9 @@ services:
       AWS_SECRET_ACCESS_KEY: "secretdevkey"
 
       OPG_LPA_COMMON_S3_ENDPOINT: http://localstack:4566
-      OPG_LPA_COMMON_PDF_QUEUE_URL: http://localstack:4566/000000000000/pdf-queue.fifo
+      OPG_LPA_COMMON_PDF_QUEUE_URL: http://sqs.eu-west-1.localhost.localstack.cloud:4566/000000000000/pdf-queue.fifo
 
+      PHP_IDE_CONFIG: serverName=lpa-pdf-app
   # ---------------------------
   # Seeding
   seeding:

--- a/local-config/start.sh
+++ b/local-config/start.sh
@@ -54,4 +54,5 @@ aws sqs create-queue \
 aws s3api create-bucket \
 --endpoint=http://${OPG_LPA_COMMON_S3_ENDPOINT} \
 --region=${DEFAULT_REGION} \
---bucket=${OPG_LPA_COMMON_PDF_CACHE_S3_BUCKET}
+--bucket=${OPG_LPA_COMMON_PDF_CACHE_S3_BUCKET} \
+--create-bucket-configuration LocationConstraint=eu-west-1

--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -12,19 +12,6 @@ RUN apk add --no-cache icu fcgi \
     && docker-php-ext-install intl \
     && docker-php-ext-install bcmath
 
-# Enable debug if needed. Should only be used locally
-ARG ENABLE_XDEBUG=0
-RUN if [ "$ENABLE_XDEBUG" = 1 ] ; then \
-      pecl install xdebug ; \
-      echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      docker-php-ext-enable xdebug ; \
-    fi ;
-
 # Install composer dependencies
 COPY --chown=root:root service-admin/composer.json /app/composer.json
 COPY --chown=root:root service-admin/composer.lock /app/composer.lock
@@ -34,8 +21,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
     && rm /app/composer.json \
     && rm /usr/bin/composer
 
-# Clean up build dependencies, but only after everything else we need has been installed
-RUN apk del .build-dependencies
 
 COPY --chown=root:root service-admin/config /app/config
 COPY --chown=root:root service-admin/public /app/public
@@ -52,6 +37,22 @@ COPY --chown=root:root scripts/containers/health-check.sh /usr/local/bin/health-
 RUN chmod +x /usr/local/bin/health-check.sh
 
 WORKDIR /app
+
+# Enable debug if needed. Should only be used locally
+ARG ENABLE_XDEBUG=0
+RUN if [ "$ENABLE_XDEBUG" = 1 ] ; then \
+      pecl install xdebug ; \
+      echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      docker-php-ext-enable xdebug ; \
+    fi ;
+
+# Clean up build dependencies, but only after everything else we need has been installed
+RUN apk del .build-dependencies
 
 USER appuser
 

--- a/service-admin/docker/app/Dockerfile
+++ b/service-admin/docker/app/Dockerfile
@@ -14,15 +14,15 @@ RUN apk add --no-cache icu fcgi \
 
 # Enable debug if needed. Should only be used locally
 ARG ENABLE_XDEBUG=0
-RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
+RUN if [ "$ENABLE_XDEBUG" = 1 ] ; then \
       pecl install xdebug ; \
-      docker-php-ext-enable xdebug ; \
       echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
       echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
       echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
       echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
       echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
       echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      docker-php-ext-enable xdebug ; \
     fi ;
 
 # Install composer dependencies

--- a/service-api/config/autoload/global.php
+++ b/service-api/config/autoload/global.php
@@ -77,6 +77,7 @@ return [
                     'url' => getenv('OPG_LPA_COMMON_PDF_QUEUE_URL') ?: null,
                 ],
                 'client' => [
+                    'endpoint' => getenv('OPG_LPA_COMMON_PDF_QUEUE_URL') ?: null,
                     'region' => getenv('AWS_REGION') ?: 'eu-west-1',
                     'version' => '2012-11-05',
                 ],

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -20,15 +20,15 @@ ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
 
 # Enable debug if needed. Should only be used locally
 ARG ENABLE_XDEBUG=0
-RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
+RUN if [ "$ENABLE_XDEBUG" = "1" ] ; then \
       pecl install xdebug ; \
-      docker-php-ext-enable xdebug ; \
       echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
       echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
       echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
       echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
       echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
       echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      docker-php-ext-enable xdebug ; \
     fi ;
 
 # Install composer dependencies

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -18,19 +18,6 @@ RUN apk add --no-cache postgresql-libs icu fcgi \
 # Default for AWS. Should be set to 1 for local development.
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0"
 
-# Enable debug if needed. Should only be used locally
-ARG ENABLE_XDEBUG=0
-RUN if [ "$ENABLE_XDEBUG" = "1" ] ; then \
-      pecl install xdebug ; \
-      echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-      docker-php-ext-enable xdebug ; \
-    fi ;
-
 # Install composer dependencies
 COPY --chown=root:root service-api/composer.json /app/composer.json
 COPY --chown=root:root service-api/composer.lock /app/composer.lock
@@ -43,8 +30,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 ARG OPG_LPA_COMMON_APP_VERSION
 ENV OPG_LPA_COMMON_APP_VERSION=${OPG_LPA_COMMON_APP_VERSION}
 
-# Clean up build dependencies, but only after everything else we need has been installed
-RUN apk del .build-dependencies
 
 # Core files for the application
 COPY --chown=root:root service-api/db/migrations /app/db/migrations
@@ -68,6 +53,23 @@ COPY --chown=root:root scripts/containers/health-check.sh /usr/local/bin/health-
 RUN chmod +x /app/db-migrations.sh /usr/local/bin/health-check.sh
 
 WORKDIR /app
+
+# Enable debug if needed. Should only be used locally
+ARG ENABLE_XDEBUG=0
+RUN if [ "$ENABLE_XDEBUG" = "1" ] ; then \
+      pecl install xdebug ; \
+      echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+      docker-php-ext-enable xdebug ; \
+    fi ;
+
+
+# Clean up build dependencies, but only after everything else we need has been installed
+RUN apk del .build-dependencies
 
 USER appuser
 

--- a/service-pdf/bin/start.sh
+++ b/service-pdf/bin/start.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 while : ; do
     php /app/bin/sqs.php
 done

--- a/service-pdf/config/global.php
+++ b/service-pdf/config/global.php
@@ -16,6 +16,7 @@ return [
                 'url' => getenv('OPG_LPA_COMMON_PDF_QUEUE_URL') ?: null,
             ],
             'client' => [
+                'endpoint' => getenv('OPG_LPA_COMMON_PDF_QUEUE_URL') ?: null,
                 'region' => getenv('AWS_REGION') ?: 'eu-west-1',
                 'version' => '2012-11-05',
             ],

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --upgrade --no-cache apk-tools
 RUN apk upgrade --no-cache
 
 RUN apk update \
-    && apk add --no-cache openjdk8-jre bash libpng \
+    && apk add --no-cache openjdk8-jre libpng \
     && apk add --no-cache --virtual .build-dependencies $PHPIZE_DEPS autoconf gcc make musl-dev pkgconfig zlib-dev libpng-dev linux-headers\
     && docker-php-ext-install gd
 

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -7,20 +7,20 @@ RUN apk upgrade --no-cache
 
 RUN apk update \
     && apk add --no-cache openjdk8-jre bash libpng \
-    && apk add --no-cache --virtual .build-dependencies autoconf gcc make musl-dev pkgconfig zlib-dev libpng-dev \
+    && apk add --no-cache --virtual .build-dependencies $PHPIZE_DEPS autoconf gcc make musl-dev pkgconfig zlib-dev libpng-dev linux-headers\
     && docker-php-ext-install gd
 
 # Enable debug if needed. Should only be used locally.
 ARG ENABLE_XDEBUG=0
-RUN if [[ $ENABLE_XDEBUG = 1 ]] ; then \
+RUN if [ "$ENABLE_XDEBUG" = "1" ] ; then \
         pecl install xdebug ; \
-        docker-php-ext-enable xdebug ; \
         echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
         echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
         echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
         echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
         echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
         echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+        docker-php-ext-enable xdebug ; \
     fi
 
 # Install composer dependencies

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -10,19 +10,6 @@ RUN apk update \
     && apk add --no-cache --virtual .build-dependencies $PHPIZE_DEPS autoconf gcc make musl-dev pkgconfig zlib-dev libpng-dev linux-headers\
     && docker-php-ext-install gd
 
-# Enable debug if needed. Should only be used locally.
-ARG ENABLE_XDEBUG=0
-RUN if [ "$ENABLE_XDEBUG" = "1" ] ; then \
-        pecl install xdebug ; \
-        echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-        echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-        echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-        echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-        echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-        echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-        docker-php-ext-enable xdebug ; \
-    fi
-
 # Install composer dependencies
 COPY --chown=root:root service-pdf/composer.json /app/composer.json
 COPY --chown=root:root service-pdf/composer.lock /app/composer.lock
@@ -32,8 +19,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
     && rm /app/composer.json \
     && rm /usr/bin/composer
 
-# Clean up build dependencies, but only after everything else we need has been installed
-RUN apk del .build-dependencies
 
 # This is version 3.2.1 of this tool, we will need to check this regularly.
 # PDFTK does have a community based docker container, but the version is not up to date.
@@ -47,6 +32,22 @@ COPY --chown=root:root service-pdf /app
 COPY --chown=root:root shared/docker/app/app-php.ini /usr/local/etc/php/conf.d/
 
 WORKDIR /app
+
+# Enable debug if needed. Should only be used locally.
+ARG ENABLE_XDEBUG=0
+RUN if [ "$ENABLE_XDEBUG" = "1" ] ; then \
+        pecl install xdebug ; \
+        echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+        echo "xdebug.discover_client_host = true" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+        echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+        echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+        echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+        echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
+        docker-php-ext-enable xdebug ; \
+    fi
+
+# Clean up build dependencies, but only after everything else we need has been installed
+RUN apk del .build-dependencies
 
 USER appuser
 


### PR DESCRIPTION
## Purpose

_PDF tests were broken locally because service-pdf and service-api could not talk to sqs. Fix this, and fix debugging for local services with xdebug/phpstorm_

## Approach

- service-front was already working with debugger. Rejig other services dockerfiles to be like service-front's 
- Upgrade localstack in docker-compose. Add endpoint parameter to config for service-pdf and service-api, which appears to now be needed by AWS SDK.
- Change style of address for sqs queue to be more as expected by AWS (Greg's suggestion)
-  service_pdf needed a couple of XDEBUG related vars setting in docker-compose , to switch on debugger as that is a script not a full app (full app the debugger switches on anyway without such a nudge)
- changed service-pdf-bin/start.sh to not require bash to run - no need for this and just meant bash was being unnecessarily installed on alpine image
- localconfig start.sh needed another parameter for creating s3 bucket, due to localstack upgrade

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
