### PR TITLE
LPAL-1279 Remove TF code duplicate checks

### DIFF
--- a/.github/workflows/analysis-trivy.yml
+++ b/.github/workflows/analysis-trivy.yml
@@ -12,10 +12,6 @@ on:
       - "shared/**"
       - "tests/**"
       - "cypress/**"
-      - "terraform/environment/**"
-      - "terraform/account/**"
-      - "local-ssl/**"
-      - "node-build-assets/**"
 
 jobs:
   filter-and-scan:
@@ -26,69 +22,36 @@ jobs:
         scan:
           - name: service-api
             path: "./service-api"
-            code-scan: true
           - name: service-admin
             path: "./service-admin"
-            code-scan: true
           - name: service-front
             path: "./service-front"
-            code-scan: true
           - name: service-pdf
             path: "./service-pdf"
-            code-scan: true
           - name: shared
             path: "./shared"
-            code-scan: true
           - name: tests
             path: "./tests"
-            code-scan: true
           - name: cypress
             path: "./cypress"
-            code-scan: true
-          - name: terraform/account
-            path: "./terraform/account"
-            code-scan: false
-          - name: terraform/environment
-            path: './terraform/environment'
-            code-scan: false
-          - name: local-ssl
-            path: "./local-ssl"
-            code-scan: false
-          - name: node-build-assets
-            path: "./node-build-assets"
-            code-scan: false
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Filter paths
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             check: '${{ matrix.scan.path }}/**'
 
-      - name: Run Trivy vulnerability scanner for IaC
-        if: steps.filter.outputs.check == 'true'
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: "config"
-          ignore-unfixed: true
-          format: "template"
-          template: "@/contrib/sarif.tpl"
-          output: "${{ matrix.scan.name }}/trivy-results-config.sarif"
-          scan-ref: ${{ matrix.scan.path }}
-          hide-progress: false
-
       - name: Run Trivy vulnerability scanner for Code
-        if: steps.filter.outputs.check == 'true' && matrix.scan.code-scan == true
+        if: steps.filter.outputs.check == 'true'
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: "fs"
           ignore-unfixed: true
           hide-progress: false
-          format: "template"
-          template: "@/contrib/sarif.tpl"
+          format: "sarif"
           output: "${{ matrix.scan.name }}/trivy-results-code.sarif"
           scan-ref: ${{ matrix.scan.path }}
 

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -482,7 +482,7 @@ jobs:
         JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
     - name: Find in commit messages
-      uses: atlassian/gajira-find-issue-key@master
+      uses: atlassian/gajira-find-issue-key@7d11fdc500b3b69d3edd797e9f1d619b89f8dafc # tag=3.0.1
       id: jira_ticket
       continue-on-error: true
       with:


### PR DESCRIPTION
## Purpose

Remove duplicated dfsec/tfsec checks from Trivy.

Fixes LPAL-1279

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
