### PR TITLE
LPAL-1282 Re-add non-www DNS record

### DIFF
--- a/terraform/environment/modules/dns/main.tf
+++ b/terraform/environment/modules/dns/main.tf
@@ -16,6 +16,24 @@ resource "aws_route53_record" "public_facing_lastingpowerofattorney" {
   }
 }
 
+# URL for the LPA Service without the www. subdomain. Redirected to the www. subdomain on front LB.
+resource "aws_route53_record" "public_facing_lastingpowerofattorney_redirect" {
+  count           = var.environment_name == "production" ? 1 : 0
+  provider        = aws.management
+  zone_id         = data.aws_route53_zone.live_service_lasting_power_of_attorney.zone_id
+  name            = data.aws_route53_zone.live_service_lasting_power_of_attorney.name
+  type            = "A"
+  allow_overwrite = true
+  alias {
+    evaluate_target_health = false
+    name                   = var.front_dns_name
+    zone_id                = var.front_zone_id
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
 
 //-------------------------------------------------------------
 // front


### PR DESCRIPTION
## Purpose

Re-add the non-www DNS record for production. This will be redirected to www. by the front ALB.

Fixes LPAL-1282

## Approach

Add a new `aws_route53_record` to the DNS module which is only created in production.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
