### PR TITLE
LPAL-1284 Add SPF / DMARC records for public facing domains

### DIFF
--- a/terraform/environment/modules/dns/main.tf
+++ b/terraform/environment/modules/dns/main.tf
@@ -35,6 +35,64 @@ resource "aws_route53_record" "public_facing_lastingpowerofattorney_redirect" {
   }
 }
 
+resource "aws_route53_record" "spf_public_facing_lastingpowerofattorney" {
+  provider = aws.management
+  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  name     = "${local.dns_namespace_env_public}${local.dns_namespace_dev_prefix}${data.aws_route53_zone.live_service_lasting_power_of_attorney.name}"
+  type     = "TXT"
+  ttl      = "300"
+
+  records = [
+    "v=spf1 -all",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "spf_public_facing_lastingpowerofattorney_redirect" {
+  count    = var.environment_name == "production" ? 1 : 0
+  provider = aws.management
+  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  name     = data.aws_route53_zone.live_service_lasting_power_of_attorney.name
+  type     = "TXT"
+  ttl      = "300"
+
+  records = [
+    "v=spf1 -all",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "dmarc_public_facing_lastingpowerofattorney" {
+  provider = aws.management
+  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  name     = "_dmarc.${local.dns_namespace_env_public}${local.dns_namespace_dev_prefix}${data.aws_route53_zone.live_service_lasting_power_of_attorney.name}"
+  type     = "TXT"
+  ttl      = "300"
+
+  records = [
+    "v=DMARC1; p=reject; sp=reject; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk",
+  ]
+}
+
+resource "aws_route53_record" "dmarc_public_facing_lastingpowerofattorney_redirect" {
+  count    = var.environment_name == "production" ? 1 : 0
+  provider = aws.management
+  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  name     = "_dmarc.${data.aws_route53_zone.live_service_lasting_power_of_attorney.name}"
+  type     = "TXT"
+  ttl      = "300"
+
+  records = [
+    "v=DMARC1; p=reject; sp=reject; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk",
+  ]
+}
+
 //-------------------------------------------------------------
 // front
 
@@ -54,7 +112,6 @@ resource "aws_route53_record" "front" {
     create_before_destroy = true
   }
 }
-
 
 //-------------------------------------------------------------
 // admin


### PR DESCRIPTION
## Purpose

Add SPF / DMARC records for public-facing domain names.

Fixes LPAL-1284
## Approach

Create and populate SPF / DMARC records using `aws_route53_record` resources

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
