### PR TITLE
LPAL-1284 Correct DNS zones used to create SPF / DMARC records

### DIFF
--- a/terraform/environment/modules/dns/main.tf
+++ b/terraform/environment/modules/dns/main.tf
@@ -37,7 +37,7 @@ resource "aws_route53_record" "public_facing_lastingpowerofattorney_redirect" {
 
 resource "aws_route53_record" "spf_public_facing_lastingpowerofattorney" {
   provider = aws.management
-  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  zone_id  = data.aws_route53_zone.live_service_lasting_power_of_attorney.zone_id
   name     = "${local.dns_namespace_env_public}${local.dns_namespace_dev_prefix}${data.aws_route53_zone.live_service_lasting_power_of_attorney.name}"
   type     = "TXT"
   ttl      = "300"
@@ -54,7 +54,7 @@ resource "aws_route53_record" "spf_public_facing_lastingpowerofattorney" {
 resource "aws_route53_record" "spf_public_facing_lastingpowerofattorney_redirect" {
   count    = var.environment_name == "production" ? 1 : 0
   provider = aws.management
-  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  zone_id  = data.aws_route53_zone.live_service_lasting_power_of_attorney.zone_id
   name     = data.aws_route53_zone.live_service_lasting_power_of_attorney.name
   type     = "TXT"
   ttl      = "300"
@@ -70,7 +70,7 @@ resource "aws_route53_record" "spf_public_facing_lastingpowerofattorney_redirect
 
 resource "aws_route53_record" "dmarc_public_facing_lastingpowerofattorney" {
   provider = aws.management
-  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  zone_id  = data.aws_route53_zone.live_service_lasting_power_of_attorney.zone_id
   name     = "_dmarc.${local.dns_namespace_env_public}${local.dns_namespace_dev_prefix}${data.aws_route53_zone.live_service_lasting_power_of_attorney.name}"
   type     = "TXT"
   ttl      = "300"
@@ -83,7 +83,7 @@ resource "aws_route53_record" "dmarc_public_facing_lastingpowerofattorney" {
 resource "aws_route53_record" "dmarc_public_facing_lastingpowerofattorney_redirect" {
   count    = var.environment_name == "production" ? 1 : 0
   provider = aws.management
-  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  zone_id  = data.aws_route53_zone.live_service_lasting_power_of_attorney.zone_id
   name     = "_dmarc.${data.aws_route53_zone.live_service_lasting_power_of_attorney.name}"
   type     = "TXT"
   ttl      = "300"


### PR DESCRIPTION
## Purpose

Correct DNS zones used to create SPF / DMARC records.

Fixes LPAL-1284

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
