### PR TITLE
LPAL-1290 Delay triggering PDF alarms

### DIFF
--- a/terraform/environment/modules/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/modules/environment/cloudwatch_alarms.tf
@@ -46,9 +46,9 @@ resource "aws_cloudwatch_metric_alarm" "admin_5xx_errors" {
 
 resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
   actions_enabled     = true
-  alarm_name          = "${var.environment_name} pdf messages awaiting processing"
+  alarm_name          = "${var.environment_name}-pdf-queue-excess-items"
   alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
-  alarm_description   = "number of pdf requests in queue"
+  alarm_description   = "ApproximateNumberOfMessagesVisible >= 10 for 5 minutes in pdf queue"
   namespace           = "AWS/SQS"
   metric_name         = "ApproximateNumberOfMessagesVisible"
   comparison_operator = "GreaterThanThreshold"
@@ -58,12 +58,34 @@ resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
   ok_actions          = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
   period              = 60
   evaluation_periods  = 1
-  datapoints_to_alarm = 1
+  datapoints_to_alarm = 5
   statistic           = "Sum"
   tags                = local.pdf_component_tag
-  threshold           = 6
+  threshold           = 10
   treat_missing_data  = "notBreaching"
 }
+
+resource "aws_cloudwatch_metric_alarm" "pdf_queue_oldest_message" {
+  actions_enabled     = true
+  alarm_name          = "${var.environment_name}-pdf-queue-oldest-message"
+  alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
+  alarm_description   = "ApproximateAgeOfOldestMessage >= 60 seconds for 5 minutes in pdf queue"
+  namespace           = "AWS/SQS"
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  comparison_operator = "GreaterThanThreshold"
+  dimensions = {
+    QueueName = aws_sqs_queue.pdf_fifo_queue.name
+  }
+  ok_actions          = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  statistic           = "Maximum"
+  tags                = local.pdf_component_tag
+  threshold           = 60
+  treat_missing_data  = "notBreaching"
+}
+
 
 resource "aws_cloudwatch_metric_alarm" "front_ddos_attack_external" {
   alarm_name          = "${var.environment_name}-FrontDDoSDetected"

--- a/terraform/environment/modules/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/modules/environment/cloudwatch_alarms.tf
@@ -65,27 +65,6 @@ resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
   treat_missing_data  = "notBreaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "pdf_queue_oldest_message" {
-  actions_enabled     = true
-  alarm_name          = "${var.environment_name}-pdf-queue-oldest-message"
-  alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
-  alarm_description   = "ApproximateAgeOfOldestMessage >= 60 seconds for 5 minutes in pdf queue"
-  namespace           = "AWS/SQS"
-  metric_name         = "ApproximateAgeOfOldestMessage"
-  comparison_operator = "GreaterThanThreshold"
-  dimensions = {
-    QueueName = aws_sqs_queue.pdf_fifo_queue.name
-  }
-  ok_actions          = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
-  period              = 300
-  evaluation_periods  = 1
-  datapoints_to_alarm = 1
-  statistic           = "Maximum"
-  tags                = local.pdf_component_tag
-  threshold           = 60
-  treat_missing_data  = "notBreaching"
-}
-
 
 resource "aws_cloudwatch_metric_alarm" "front_ddos_attack_external" {
   alarm_name          = "${var.environment_name}-FrontDDoSDetected"

--- a/terraform/environment/modules/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/modules/environment/cloudwatch_alarms.tf
@@ -57,7 +57,7 @@ resource "aws_cloudwatch_metric_alarm" "pdf_queue_excess_items" {
   }
   ok_actions          = [aws_sns_topic.cloudwatch_to_pagerduty_ops.arn]
   period              = 60
-  evaluation_periods  = 1
+  evaluation_periods  = 5
   datapoints_to_alarm = 5
   statistic           = "Sum"
   tags                = local.pdf_component_tag


### PR DESCRIPTION
## Purpose

We currently trigger an alarm when we have =>6 messages in the queue for 1 minute. This is unnecessary as the `service-pdf` can easily scale to handle this so this alarm is currently a proxy for "service-pdf is scaling by +1". This PR will change the alarm to only trigger if the `ApproximateNumberOfMessagesVisible` is >=10 for 5 minutes to reduce the amount of alarms we get in Slack as this would suggest that messages are not being consumed from the queue.

Fixes LPAL-1290

## Approach

Change alarms in Terraform.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
