### PR TITLE
LPAL-1294 Remove Jira actions

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -323,21 +323,6 @@ jobs:
       FRONT_URL: ${{ needs.terraform_outputs.outputs.front_fqdn }}
       ADMIN_URL: ${{ needs.terraform_outputs.outputs.admin_fqdn }}
     steps:
-    - name: Login to Jira
-      uses: atlassian/gajira-login@45fd029b9f1d6d8926c6f04175aa80c0e42c9026 # tag=3.0.1
-      continue-on-error: true
-      env:
-        JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-        JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-
-    - name: Find in commit messages
-      uses: atlassian/gajira-find-issue-key@7d11fdc500b3b69d3edd797e9f1d619b89f8dafc # tag=3.0.1
-      continue-on-error: true
-      id: jira_ticket
-      with:
-        string: ${{ github.event.pull_request.title }}
-
     - uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
       id: slack
       with:
@@ -387,7 +372,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Front URL:* https://${{ env.FRONT_URL }}/home\n*Admin URL:* https://${{ env.ADMIN_URL }}\n*Jira Ticket:* https://opgtransform.atlassian.net/browse/${{ steps.jira_ticket.outputs.issue }}"
+                    "text": "*Front URL:* https://${{ env.FRONT_URL }}/home\n*Admin URL:* https://${{ env.ADMIN_URL }}"
                   }
                 }
 
@@ -474,20 +459,6 @@ jobs:
       FRONT_URL: ${{ needs.terraform_outputs.outputs.front_fqdn }}
       ADMIN_URL: ${{ needs.terraform_outputs.outputs.admin_fqdn }}
     steps:
-    - name: Login to Jira
-      uses: atlassian/gajira-login@45fd029b9f1d6d8926c6f04175aa80c0e42c9026 # tag=3.0.1
-      continue-on-error: true
-      env:
-        JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-        JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-
-    - name: Find in commit messages
-      uses: atlassian/gajira-find-issue-key@7d11fdc500b3b69d3edd797e9f1d619b89f8dafc # tag=3.0.1
-      id: jira_ticket
-      continue-on-error: true
-      with:
-        string: ${{ github.event.pull_request.title }}
 
     - uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
       with:
@@ -538,7 +509,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                     "text": "*Front URL:* https://${{ env.FRONT_URL }}/home\n*Admin URL:* https://${{ env.ADMIN_URL }}\n*Jira Ticket:* https://opgtransform.atlassian.net/browse/${{ steps.jira_ticket.outputs.issue }}"
+                     "text": "*Front URL:* https://${{ env.FRONT_URL }}/home\n*Admin URL:* https://${{ env.ADMIN_URL }}"
                   }
                 }
 


### PR DESCRIPTION
## Purpose

Remove Jira actions from Github Workflows 
Fixes LPAL-1294

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
