### PR TITLE
reduce concurrent PRs as they tend to break each other

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
     "prCreation": "immediate",
     "prPriority": 5
   },
-  "prConcurrentLimit": 3,
+  "prConcurrentLimit": 1,
   "prHourlyLimit": 1,
   "branchConcurrentLimit": 5,
   "enabledManagers": [


### PR DESCRIPTION
## Purpose

_Renovate is currently creating PRs in parallel. These tend to trample on each other with terraform locks, especially when they auto-rebuild when main gets updated. For now we should only allow 1 at a time until we have a better way_

## Approach

_Update renovate config_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
