### PR TITLE
Reverting data protection policy to default plus email address identi…

### DIFF
--- a/terraform/environment/modules/environment/cloudwatch_data_protection_policy.tf
+++ b/terraform/environment/modules/environment/cloudwatch_data_protection_policy.tf
@@ -10,8 +10,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
       {
         "Sid" : "audit-policy",
         "DataIdentifier" : [
-          "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
-          "HTTPGetEmailAddress"
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
         ],
         "Operation" : {
           "Audit" : {
@@ -22,8 +21,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
       {
         "Sid" : "redact-policy",
         "DataIdentifier" : [
-          "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
-          "HTTPGetEmailAddress"
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
         ],
         "Operation" : {
           "Deidentify" : {
@@ -31,14 +29,6 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
           }
         }
       }
-    ],
-    "Configuration" : {
-      "CustomDataIdentifier" : [
-        {
-          "Name" : "HTTPGetEmailAddress",
-          "Regex" : "\\/create-account-success\\?email=[\\w-\\.]+%40([\\w-]+\\.)+[\\w-]{2,4}&resend=true"
-        }
-      ]
-    }
+    ]
   })
 }


### PR DESCRIPTION
## Purpose

Reverting the data protection policies back to the default, including the email address identifier

Fixes LPAL-1308

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
