### PR TITLE
LPAL-1321: only pass end_of_workflow when pipeline actually succeeds

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -1,4 +1,4 @@
-name: "[Workflow] PR"
+name: "[Workflow] PR Environment"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -517,26 +517,28 @@ jobs:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
 
-  end_of_pr_workflow:
-    name: End of PR Workflow
-    if: github.ref != 'refs/heads/main'
+  end_of_workflow:
+    name: End of Workflow
     runs-on: ubuntu-latest
     needs:
-      - cypress_tests_Remaining
-      - cypress_tests_SignupIncluded
-      - cypress_tests_Signup_StichedClone
-      - cypress_tests_Signup_StichedHW
-      - cypress_tests_Signup_StichedPF
       - terraform_outputs
       - workflow_variables
+      - post_tests_slack_msg
     environment:
       name: "dev_${{ needs.workflow_variables.outputs.safe_branch_name }}"
       url: "https://${{ env.FRONT_URL }}/home"
     env:
       FRONT_URL: ${{ needs.terraform_outputs.outputs.front_fqdn }}
     steps:
-      - name: End of PR Workflow
+      - name: End of Workflow
         run: |
-          echo "${{ needs.workflow_variables.outputs.safe_branch_name }} PR environment tested, built and deployed"
-          echo "Tag Deployed: ${{ needs.workflow_variables.outputs.short_sha }}"
-          echo "URL: https://${{ env.FRONT_URL }}/home"
+          if ${{ contains(needs.terraform_outputs.result, 'success') && contains(needs.post_tests_slack_msg.result, 'success') }}; then
+            echo "${{ needs.workflow_variables.outputs.safe_branch_name }} PR environment tested, built and deployed"
+            echo "Tag Deployed: ${{ needs.workflow_variables.outputs.short_sha }}"
+            echo "URL: https://${{ env.FRONT_URL }}/home"
+            exit 0
+          else
+            echo "Previous jobs in pipeline failed."
+            exit 1
+          fi
+    if: always()


### PR DESCRIPTION
## Purpose

Prevent the PR from being merged when the end_of_workflow job has been skipped.

Fixes LPAL-1321

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
