### PR TITLE
LPAL-1333 upgrade upload- and download- artifact to specific version

### DIFF
--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -57,7 +57,7 @@ jobs:
           pip install -r scripts/pipeline/ci_ingress/requirements.txt
 
       - name: Download Terraform Task definition
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # tag=v3.0.2
+        uses: actions/download-artifact@v4.1.8
         with:
           name: terraform-artifact
           path: /tmp/
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload Screenshot Artifact
         if: failure()
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3.2.1
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: cypress-screenshots
           path: cypress/screenshots/

--- a/.github/workflows/locust_tests.yml
+++ b/.github/workflows/locust_tests.yml
@@ -49,7 +49,7 @@ jobs:
           pip install -r scripts/pipeline/ci_ingress/requirements.txt
 
       - name: Download Terraform Task definition
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # tag=v3.0.2
+        uses: actions/download-artifact@v4.1.8
         with:
           name: terraform-artifact
           path: /tmp/

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Check coverage
         run: php ../scripts/pipeline/php_coverage/check_coverage.php ./coverage-xml/index.xml ${{ matrix.scan.minCoverage }}
       - name: Upload Coverage Artifacts
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3.2.1
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: coverage-html
           path: ${{ matrix.scan.path }}/coverage-html/
@@ -104,7 +104,7 @@ jobs:
       - name: Check coverage
         run: php ../scripts/pipeline/php_coverage/check_coverage.php ./coverage-xml/index.xml ${{ matrix.scan.minCoverage }}
       - name: Upload Coverage Artifacts
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3.2.1
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: coverage-html
           path: ${{ matrix.scan.path }}/coverage-html/

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -166,7 +166,7 @@ jobs:
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Download Terraform Task definition
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # tag=v3.0.2
+      uses: actions/download-artifact@v4.1.8
       with:
         name: terraform-artifact
         path: /tmp/
@@ -395,7 +395,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Download Terraform Task definition
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # tag=v3.0.2
+        uses: actions/download-artifact@v4.1.8
         with:
           name: terraform-artifact
           path: /tmp/

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -275,7 +275,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Download Terraform Task definition
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # tag=v3.0.2
+        uses: actions/download-artifact@v4.1.8
         with:
           name: terraform-artifact
           path: /tmp/

--- a/.github/workflows/workflow_start_task.yml
+++ b/.github/workflows/workflow_start_task.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Download Terraform Task definition
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # tag=v3.0.2
+        uses: actions/download-artifact@v4.1.8
         with:
           name: terraform-artifact
           path: /tmp/

--- a/.github/workflows/workflow_weekly_refresh.yml
+++ b/.github/workflows/workflow_weekly_refresh.yml
@@ -200,7 +200,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Download Terraform Task definition
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # tag=v3.0.2
+        uses: actions/download-artifact@v4.1.8
         with:
           name: terraform-artifact
           path: /tmp/

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ run-front-composer:
 
 .PHONY: run-pdf-composer
 run-pdf-composer:
-	@docker run --rm -v `pwd`/service-pdf/:/app/ composer:${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
+	@docker run --rm -v `pwd`/service-pdf/:/app/ composer:${COMPOSER_VERSION} composer update tecnickcom/tcpdf --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
 
 .PHONY: run-api-composer
 run-api-composer:
@@ -42,7 +42,7 @@ run-api-composer:
 
 .PHONY: run-admin-composer
 run-admin-composer:
-	@docker run --rm -v `pwd`/service-admin/:/app/ composer:${COMPOSER_VERSION} composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
+	@docker run --rm -v `pwd`/service-admin/:/app/ composer:${COMPOSER_VERSION} composer update tecnickcom/tcpdf --prefer-dist --no-interaction --no-scripts --ignore-platform-reqs
 
 .PHONY: run-shared-composer
 run-shared-composer:

--- a/service-admin/composer.lock
+++ b/service-admin/composer.lock
@@ -9212,5 +9212,5 @@
         "php": ">=8.2 <8.3.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
## Purpose

_Current version of upload and download artifact github actions in build are deprecated so builds are blocked. Fix this_


## Approach

_Upgrade version. Use specific version no instead of sha so renovate picks this up in future_


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
