### PR TITLE
LPAL-1342: pipeline stop on failure

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -151,6 +151,8 @@ jobs:
       task_name: "seeding"
     needs:
       - terraform_environment_preproduction
+      - terraform_region_preproduction
+      - terraform_account_preproduction
     secrets: inherit
 
   preprod_terraform_outputs:

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -259,8 +259,6 @@ jobs:
       task_name: "seeding"
     needs:
       - terraform_environment_development
-      - terraform_account_preproduction
-      - terraform_region_preproduction
     secrets: inherit
 
   terraform_outputs:

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -259,6 +259,8 @@ jobs:
       task_name: "seeding"
     needs:
       - terraform_environment_development
+      - terraform_account_preproduction
+      - terraform_region_preproduction
     secrets: inherit
 
   terraform_outputs:


### PR DESCRIPTION
## Purpose

Adds the account and region Terraform to be required to continue the pipeline into the seeding tasks

Fixes LPAL-1342

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
