### PR TITLE
Update renovate config with ignore deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,9 @@
     "Renovate",
     "Dependencies"
   ],
+  "ignoreDeps": [
+        "github.com/ministryofjustice/opg-terraform-aws-moj-ip-allow-list"
+  ],
   "commitMessageAction": "Renovate update",
   "forkProcessing": "enabled",
   "lockFileMaintenance": {


### PR DESCRIPTION
## Purpose

Adds an ignore dependency block to Renovate config to ignore an error.

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
