### PR TITLE
Shrink the slack notifications on build

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -437,44 +437,31 @@ jobs:
         update-ts: ${{ needs.slack_msg_production_deploy_begin.outputs.ts }}
         payload: |
             {
-              "icon_emoji": ":robot_face:",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Production Deployment",
+                    "text": "Make - production release",
                     "emoji": true
                   }
                 },
                 {
-                  "type": "section",
-                  "fields": [
+                  "type": "context",
+                  "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Status:*\nComplete :white_check_mark:"
+                      "text": ":white_check_mark: <https://github.com/${{ github.payload.repository.full_name }}/actions/runs/${{ github.runId }}|Success>"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Started by:*\n ${{ github.triggering_actor }}"
-                    }
-                  ]
-                },
-                {
-                  "type": "section",
-                  "fields": [
+                      "text": ":astronaut: ${{ github.triggering_actor }}"
+                    },
                     {
                       "type": "mrkdwn",
-                      "text": "*Commit:*\n <https://github.com/ministryofjustice/opg-lpa/commit/${{ github.sha }}|${{ needs.set_variables.outputs.short_sha }}>"
+                      "text": ":floppy_disk: <https://github.com/ministryofjustice/opg-lpa/commit/${{ github.sha }}|Commit>"
                     }
                   ]
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "<https://github.com/ministryofjustice/opg-lpa/actions/runs/${{github.run_id}}|View workflow>"
-                  }
                 }
               ]
             }
@@ -488,44 +475,31 @@ jobs:
         update-ts: ${{ needs.slack_msg_production_deploy_begin.outputs.ts }}
         payload: |
             {
-              "icon_emoji": ":robot_face:",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Production Deployment",
+                    "text": "Make - production release",
                     "emoji": true
                   }
                 },
                 {
-                  "type": "section",
-                  "fields": [
+                  "type": "context",
+                  "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Status:*\nFailed! :x:"
+                      "text": ":cross-red: <https://github.com/${{ github.payload.repository.full_name }}/actions/runs/${{ github.runId }}|Failed>"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Started by:*\n ${{ github.triggering_actor }}"
-                    }
-                  ]
-                },
-                {
-                  "type": "section",
-                  "fields": [
+                      "text": ":astronaut: ${{ github.triggering_actor }}"
+                    },
                     {
                       "type": "mrkdwn",
-                      "text": "*Commit:*\n <https://github.com/ministryofjustice/opg-lpa/commit/${{ github.sha }}|${{ needs.set_variables.outputs.short_sha }}>"
+                      "text": ":floppy_disk: <https://github.com/ministryofjustice/opg-lpa/commit/${{ github.sha }}|Commit>"
                     }
                   ]
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "<https://github.com/ministryofjustice/opg-lpa/actions/runs/${{github.run_id}}|View workflow>"
-                  }
                 }
               ]
             }
@@ -538,7 +512,6 @@ jobs:
         channel-id: "C9PNCT2KS"
         payload: |
             {
-              "icon_emoji": ":warning:",
               "blocks": [
                 {
                   "type": "section",

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -466,53 +466,39 @@ jobs:
         update-ts: ${{ needs.post_deployment_slack_msg.outputs.ts }}
         payload: |
             {
-              "icon_emoji": ":robot_face:",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Development Environment Deployment",
+                    "text": "Make - development deployment",
                     "emoji": true
                   }
                 },
                 {
                   "type": "section",
-                  "fields": [
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Front URL:* https://${{ env.FRONT_URL }}/home\n*Admin URL:* https://${{ env.ADMIN_URL }}"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Status:*\nDeployed (Tests have passed!)"
+                      "text": ":white_check_mark: <https://github.com/${{ github.payload.repository.full_name }}/actions/runs/${{ github.runId }}|Success>"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Started by:*\n ${{ github.triggering_actor }}"
-                    }
-                  ]
-                },
-                {
-                  "type": "section",
-                  "fields": [
+                      "text": ":astronaut: ${{ github.triggering_actor }}"
+                    },
                     {
                       "type": "mrkdwn",
-                      "text": "*Commit:*\n <https://github.com/ministryofjustice/opg-lpa/commit/${{ github.sha }}|${{ needs.workflow_variables.outputs.short_sha }}>"
+                      "text": ":floppy_disk: <https://github.com/ministryofjustice/opg-lpa/commit/${{ github.sha }}|Commit>"
                     }
                   ]
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "<https://github.com/ministryofjustice/opg-lpa/actions/runs/${{github.run_id}}|View workflow>"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                     "text": "*Front URL:* https://${{ env.FRONT_URL }}/home\n*Admin URL:* https://${{ env.ADMIN_URL }}"
-                  }
                 }
-
               ]
             }
       env:


### PR DESCRIPTION
## Purpose

Shrink the height of slack success and failed notifications in an effort to reduce channel spam fatigue

## Checklist

* [x] I have performed a self-review of my own code
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added mandatory tags to terraformed resources, where possible
* If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* The product team have tested these changes
