### PR TITLE
LPAL-1404 - major terraform aws provider upgrade

### DIFF
--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -2,38 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.100.0"
-  constraints = "~> 5.0"
+  version     = "6.9.0"
+  constraints = "6.9.0"
   hashes = [
-    "h1:+X3t1uVrM0z4K/lAYUV1SYmO7UBd9/Y4XC11zI9wcQQ=",
-    "h1:95JvzqH8cVlNqTBgqfg5UfMZXT2a8K+vygOQ9afj4mQ=",
-    "h1:FAfHhUISfZ2hS9itjVfBi71TltLVAHS2ZnQXlldUva0=",
-    "h1:FZ4tAR+rsfmMatrfK9BrB6k+EhvolUNR67pSlc8bacs=",
-    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
-    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
-    "h1:MLOPC8C1bKpbqPgtdkn26PSI/zYJZQc35vTLF4GNkXc=",
-    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
-    "h1:hVDEfiQis2sEFhiqQUL2MFc3YGyA3NNnk/vNz2J1nfI=",
-    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
-    "h1:jAEZ9zxrrwIdsPm0ycSiAX0HqnssEN7VdA6B8FC9NqI=",
-    "h1:lcDxx0Nx+ifFqTBpxz8Un27O0s+I7UNJAr/rUpSqlig=",
-    "h1:qvzqmkxybGRKK4ttHbp4+lvYMOwoDsZKNIT1nRyCEK8=",
-    "h1:wOhTPz6apLBuF7/FYZuCoXRK/MLgrNprZ3vXmq83g5k=",
-    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
-    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
-    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
-    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
-    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
-    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "h1:tYd0S1e8xSwAM3NtDrvu2e80pV9fvLEWAjhtDR4JP5o=",
+    "zh:0121aeca90856ba37d03cff9eed40321cc3ae1c0f77bef3329e17212c48f884a",
+    "zh:4f09e73f948d4545358eed978bc41fd1a825c65b530a532bfaf9aaba93ac6e55",
+    "zh:58604213402b5dba8360367e09b3d3762736980c80a72d6297be7cb71fe8dc8d",
+    "zh:5aa9fe54fc9aba0780cae11becfce698e5093ee002066590599277d5aa71e59e",
+    "zh:7e8546575a80d54b8db7edb53574c2d1f04afbdbafc599d0eb78da9e74e917f7",
+    "zh:846ce59c9f7ec3c92b33fe3a0d98386420bcbb971260da9ff869b219a1125df4",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
-    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
-    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
-    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
-    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
-    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
-    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
-    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+    "zh:9bd2cb527dcbd76977c18f3f6844638b6d5039f070accc41d064831f98aa7b40",
+    "zh:9df98266de85cf047c9a2e43b892c74479805e0936dbb3583aef314d2fa0f5fc",
+    "zh:a4fc8e9645b147902bcf36f10ea1891ca92661c4ee4135046cc79b8ce6fe1093",
+    "zh:afe3029760f7aa5484e26c80670f86b6b5054126776376ba6aec4aa8a41483ce",
+    "zh:c158cd1790422237ab2a2e10fc02e5522bd7bce39c067ffbc9edda1e6c9ebf3b",
+    "zh:f5408929d5df6f81fcb93a433e0dbc0432b748b400cc41910328b936a7590fd5",
+    "zh:f6331bb27134e288d8c324b2390c610fd924f71af1ec27f79070dfa26f4dd410",
+    "zh:f6b8b429d5fa71f186bda45468bbde230a1697a38480487f41d7172f1e374e2d",
   ]
 }
 
@@ -84,5 +71,18 @@ provider "registry.terraform.io/pagerduty/pagerduty" {
     "h1:sjlxoIrUqpxQSVQ0gWMGE5XQAWeeu87R4cMB2STy7BY=",
     "h1:ts1Qxq4GUVRWDtFR9dp3NmAAwebfagjLKeMF/spQHWI=",
     "h1:xAyfP7ymHVdbtlwjeXk2Dpr+2sKBVG8396F65j0rfa8=",
+    "zh:0d78102d65324ef363c7749994c8229d20d919e695d7196b6270ad0f286c3126",
+    "zh:122a7bbcc00e4c4274462b8a114d2e8a3a7022a0e575a79d2e19294a748eadc5",
+    "zh:342b77bbc1b02541502fce65403c1724a3c9fc317280d0d551984ff282842027",
+    "zh:366e090b960c77b74eaa3fd714c27881c8552c99caff93aa3cb05bd1d496e634",
+    "zh:3f7d0102c6bc03c4c56624352327201f87a033cc1cbeb31c0f5e4755215018c5",
+    "zh:6fd2247de6da2116790139d2d7348bfe90032e95b74d21d38230e156ddae28d0",
+    "zh:70243a6003d29dbbf2f6aa833c2e9b0485d599fe52ff3c2b475834291bc1f982",
+    "zh:850f544b9eaffd411202f7d1fbed3ff8c26d91f924dadd9be3d99ed45fe9d83c",
+    "zh:9f56d59b42078ffa873a230764bf3ceba735b4589cf584b28b96118a79ee136b",
+    "zh:a44a64c22f22a6d802e90039368ece661a81e69f4a4b460d7687810f05ec0351",
+    "zh:a8b8d604da6ac1ecaf2ec64337bfb7198cef78a4e1bc10951e8dfe7e2baf6cdb",
+    "zh:badeb50e166b4290b276472ca22c01db06e7a2e2b45b159c21d61192e7dd3fbe",
+    "zh:d8bc4d96d3c00add82dae1dc33c4afb3817c8d06898b2ea3f49ccd13650b1261",
   ]
 }

--- a/terraform/environment/modules/dns/versions.tf
+++ b/terraform/environment/modules/dns/versions.tf
@@ -6,7 +6,7 @@ terraform {
         aws.management,
         aws.us_east_1
       ]
-      version = "~> 5.0"
+      version = "6.9.0"
     }
     pagerduty = {
       source  = "PagerDuty/pagerduty"

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -52,9 +52,7 @@ resource "aws_service_discovery_service" "api" {
     routing_policy = "MULTIVALUE"
   }
 
-  health_check_custom_config {
-    failure_threshold = 1
-  }
+  health_check_custom_config {}
 }
 
 resource "aws_service_discovery_service" "api_canonical" {
@@ -71,9 +69,7 @@ resource "aws_service_discovery_service" "api_canonical" {
     routing_policy = "MULTIVALUE"
   }
 
-  health_check_custom_config {
-    failure_threshold = 1
-  }
+  health_check_custom_config {}
 }
 locals {
 

--- a/terraform/environment/modules/environment/locals.tf
+++ b/terraform/environment/modules/environment/locals.tf
@@ -10,8 +10,8 @@ locals {
   front_dns                   = "front.lpa"
   admin_dns                   = "admin.lpa"
   pager_duty_ops_service_name = "Make a Lasting Power of Attorney Ops Monitoring"
-  region_name                 = var.account.regions[data.aws_region.current.name].region
-  is_primary_region           = var.account.regions[data.aws_region.current.name].is_primary
+  region_name                 = var.account.regions[data.aws_region.current.region].region
+  is_primary_region           = var.account.regions[data.aws_region.current.region].is_primary
 
   shared_component_tag = {
     component = "shared"

--- a/terraform/environment/modules/environment/modules/aurora/versions.tf
+++ b/terraform/environment/modules/environment/modules/aurora/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "6.9.0"
     }
   }
   required_version = "1.12.2"

--- a/terraform/environment/modules/environment/modules/ecs_autoscaling/versions.tf
+++ b/terraform/environment/modules/environment/modules/ecs_autoscaling/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "6.9.0"
     }
   }
   required_version = "1.12.2"

--- a/terraform/environment/modules/environment/modules/ecs_scheduled_scaling/versions.tf
+++ b/terraform/environment/modules/environment/modules/ecs_scheduled_scaling/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "6.9.0"
     }
   }
   required_version = "1.12.2"

--- a/terraform/environment/modules/environment/versions.tf
+++ b/terraform/environment/modules/environment/versions.tf
@@ -5,7 +5,7 @@ terraform {
       configuration_aliases = [
         aws.management
       ]
-      version = "~> 5.0"
+      version = "6.9.0"
     }
     pagerduty = {
       source  = "PagerDuty/pagerduty"

--- a/terraform/environment/modules/rds_cross_region_backup/iam.tf
+++ b/terraform/environment/modules/rds_cross_region_backup/iam.tf
@@ -15,7 +15,7 @@ data "aws_kms_key" "destination_rds_snapshot_key" {
 }
 
 data "aws_kms_key" "source_rds_snapshot_key" {
-  key_id = "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/${var.key_alias}"
+  key_id = "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:alias/${var.key_alias}"
 }
 
 data "aws_iam_policy_document" "aurora_backup_role" {

--- a/terraform/environment/modules/rds_cross_region_backup/main.tf
+++ b/terraform/environment/modules/rds_cross_region_backup/main.tf
@@ -29,13 +29,13 @@ resource "aws_backup_plan" "main" {
 }
 
 resource "aws_backup_vault" "main" {
-  name        = "${var.environment_name}_${data.aws_region.current.name}_aurora_backup_vault"
+  name        = "${var.environment_name}_${data.aws_region.current.region}_aurora_backup_vault"
   kms_key_arn = data.aws_kms_key.source_rds_snapshot_key.arn
 }
 
 resource "aws_backup_vault" "secondary" {
   provider    = aws.destination
-  name        = "${var.environment_name}_${data.aws_region.secondary.name}_aurora_backup_vault"
+  name        = "${var.environment_name}_${data.aws_region.secondary.region}_aurora_backup_vault"
   kms_key_arn = data.aws_kms_key.destination_rds_snapshot_key.arn
 }
 

--- a/terraform/environment/modules/rds_cross_region_backup/sns.tf
+++ b/terraform/environment/modules/rds_cross_region_backup/sns.tf
@@ -1,5 +1,5 @@
 data "aws_sns_topic" "rds_events" {
-  name = "${var.account_name}-${data.aws_region.current.name}-rds-events"
+  name = "${var.account_name}-${data.aws_region.current.region}-rds-events"
 }
 
 resource "aws_backup_vault_notifications" "aws_backup_failures" {

--- a/terraform/environment/modules/rds_cross_region_backup/versions.tf
+++ b/terraform/environment/modules/rds_cross_region_backup/versions.tf
@@ -5,7 +5,7 @@ terraform {
       configuration_aliases = [
         aws.destination
       ]
-      version = "~> 5.0"
+      version = "6.9.0"
     }
     pagerduty = {
       source  = "PagerDuty/pagerduty"

--- a/terraform/environment/versions.tf
+++ b/terraform/environment/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "6.9.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## Purpose

Upgrade to the new major version of the AWS provider for terraform, 6.9.0

Fixes LPAL-1404

## Approach

Instead of ranges, I will be pinning terraform to a specific version.

environment
- upgrade provider version
- resolve validation warnings and issues

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade

