### PR TITLE
Rename abstract API Unit test classes to remove deprecations

### DIFF
--- a/service-api/module/Application/tests/Controller/Version2/Auth/AbstractAuthControllerTestCase.php
+++ b/service-api/module/Application/tests/Controller/Version2/Auth/AbstractAuthControllerTestCase.php
@@ -19,7 +19,7 @@ use Laminas\Mvc\Controller\Plugin\Params;
 use Laminas\Mvc\Controller\PluginManager;
 use Psr\Log\LoggerInterface;
 
-abstract class AbstractAuthControllerTest extends MockeryTestCase
+abstract class AbstractAuthControllerTestCase extends MockeryTestCase
 {
     /**
      * @var MockInterface|AuthenticationService

--- a/service-api/module/Application/tests/Controller/Version2/Auth/AuthenticateControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Auth/AuthenticateControllerTest.php
@@ -13,7 +13,7 @@ use Laminas\View\Model\JsonModel;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 
-class AuthenticateControllerTest extends AbstractAuthControllerTest
+class AuthenticateControllerTest extends AbstractAuthControllerTestCase
 {
     public function testAuthenticateActionWithToken()
     {

--- a/service-api/module/Application/tests/Controller/Version2/Auth/EmailControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Auth/EmailControllerTest.php
@@ -10,7 +10,7 @@ use Laminas\View\Model\JsonModel;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Mockery;
 
-class EmailControllerTest extends AbstractAuthControllerTest
+class EmailControllerTest extends AbstractAuthControllerTestCase
 {
     public function setUp(): void
     {

--- a/service-api/module/Application/tests/Controller/Version2/Auth/PasswordControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Auth/PasswordControllerTest.php
@@ -8,7 +8,7 @@ use Laminas\View\Model\JsonModel;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Mockery;
 
-class PasswordControllerTest extends AbstractAuthControllerTest
+class PasswordControllerTest extends AbstractAuthControllerTestCase
 {
     public function setUp() : void
     {

--- a/service-api/module/Application/tests/Controller/Version2/Auth/UsersControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Auth/UsersControllerTest.php
@@ -8,7 +8,7 @@ use Laminas\View\Model\JsonModel;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Mockery;
 
-class UsersControllerTest extends AbstractAuthControllerTest
+class UsersControllerTest extends AbstractAuthControllerTestCase
 {
     public function setUp() : void
     {

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/AbstractControllerTestCase.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/AbstractControllerTestCase.php
@@ -15,7 +15,7 @@ use Laminas\Router\Http\RouteMatch;
 use Laminas\Stdlib\ParametersInterface;
 use LmcRbacMvc\Service\AuthorizationService;
 
-abstract class AbstractControllerTest extends MockeryTestCase
+abstract class AbstractControllerTestCase extends MockeryTestCase
 {
     /**
      * @var int|null

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/AbstractLpaControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/AbstractLpaControllerTest.php
@@ -13,7 +13,7 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\Router\RouteMatch;
 use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 
-class AbstractLpaControllerTest extends AbstractControllerTest
+class AbstractLpaControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var AbstractService|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/ApplicationControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/ApplicationControllerTest.php
@@ -11,7 +11,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class ApplicationControllerTest extends AbstractControllerTest
+class ApplicationControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/CertificateProviderControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/CertificateProviderControllerTest.php
@@ -11,7 +11,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class CertificateProviderControllerTest extends AbstractControllerTest
+class CertificateProviderControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/CorrespondentControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/CorrespondentControllerTest.php
@@ -11,7 +11,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class CorrespondentControllerTest extends AbstractControllerTest
+class CorrespondentControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/DonorControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/DonorControllerTest.php
@@ -10,7 +10,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class DonorControllerTest extends AbstractControllerTest
+class DonorControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/InstructionControllerTests.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/InstructionControllerTests.php
@@ -10,7 +10,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class InstructionControllerTests extends AbstractControllerTest
+class InstructionControllerTests extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/LockControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/LockControllerTest.php
@@ -10,7 +10,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class LockControllerTest extends AbstractControllerTest
+class LockControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/NotifiedPeopleControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/NotifiedPeopleControllerTest.php
@@ -11,7 +11,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class NotifiedPeopleControllerTest extends AbstractControllerTest
+class NotifiedPeopleControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/PaymentControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/PaymentControllerTest.php
@@ -10,7 +10,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class PaymentControllerTest extends AbstractControllerTest
+class PaymentControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/PdfControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/PdfControllerTest.php
@@ -11,7 +11,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class PdfControllerTest extends AbstractControllerTest
+class PdfControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/PreferenceControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/PreferenceControllerTest.php
@@ -10,7 +10,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class PreferenceControllerTest extends AbstractControllerTest
+class PreferenceControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/PrimaryAttorneyControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/PrimaryAttorneyControllerTest.php
@@ -11,7 +11,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class PrimaryAttorneyControllerTest extends AbstractControllerTest
+class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/PrimaryAttorneyDecisionsControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/PrimaryAttorneyDecisionsControllerTest.php
@@ -10,7 +10,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class PrimaryAttorneyDecisionsControllerTest extends AbstractControllerTest
+class PrimaryAttorneyDecisionsControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/RepeatCaseNumberControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/RepeatCaseNumberControllerTest.php
@@ -11,7 +11,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class RepeatCaseNumberControllerTest extends AbstractControllerTest
+class RepeatCaseNumberControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/ReplacementAttorneyControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/ReplacementAttorneyControllerTest.php
@@ -11,7 +11,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class ReplacementAttorneyControllerTest extends AbstractControllerTest
+class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/ReplacementAttorneyDecisionsControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/ReplacementAttorneyDecisionsControllerTest.php
@@ -10,7 +10,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class ReplacementAttorneyDecisionsControllerTest extends AbstractControllerTest
+class ReplacementAttorneyDecisionsControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/SeedControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/SeedControllerTest.php
@@ -11,7 +11,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class SeedControllerTest extends AbstractControllerTest
+class SeedControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/StatusControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/StatusControllerTest.php
@@ -14,7 +14,7 @@ use Mockery\MockInterface;
 use MakeShared\DataModel\Lpa\Lpa;
 use Psr\Log\LoggerInterface;
 
-class StatusControllerTest extends AbstractControllerTest
+class StatusControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var $service ApplicationsService|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/TypeControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/TypeControllerTest.php
@@ -10,7 +10,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class TypeControllerTest extends AbstractControllerTest
+class TypeControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/UserControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/UserControllerTest.php
@@ -13,7 +13,7 @@ use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 use LmcRbacMvc\Service\AuthorizationService;
 
-class UserControllerTest extends AbstractControllerTest
+class UserControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/WhoAreYouControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/WhoAreYouControllerTest.php
@@ -10,7 +10,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class WhoAreYouControllerTest extends AbstractControllerTest
+class WhoAreYouControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/WhoIsRegisteringControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/WhoIsRegisteringControllerTest.php
@@ -10,7 +10,7 @@ use Mockery\MockInterface;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
-class WhoIsRegisteringControllerTest extends AbstractControllerTest
+class WhoIsRegisteringControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var Service|MockInterface

--- a/service-api/module/Application/tests/Model/Service/AbstractServiceTestCase.php
+++ b/service-api/module/Application/tests/Model/Service/AbstractServiceTestCase.php
@@ -9,7 +9,7 @@ use Mockery\MockInterface;
 use MakeShared\DataModel\Lpa\Lpa;
 use MakeShared\DataModel\User\User;
 
-abstract class AbstractServiceTest extends MockeryTestCase
+abstract class AbstractServiceTestCase extends MockeryTestCase
 {
     /**
      * Convenience function to get a pre-mocked ApiLpaCollection

--- a/service-api/module/Application/tests/Model/Service/AccountCleanup/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/AccountCleanup/ServiceTest.php
@@ -7,7 +7,7 @@ use Application\Model\DataAccess\Repository\Application\ApplicationRepositoryInt
 use Application\Model\DataAccess\Repository\User\UserRepositoryInterface;
 use Application\Model\DataAccess\Postgres\UserModel as User;
 use Application\Model\Service\Users\Service as UsersService;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use Alphagov\Notifications\Client as NotifyClient;
 use Alphagov\Notifications\Exception\NotifyException;
 use DateInterval;
@@ -17,7 +17,7 @@ use Mockery;
 use Mockery\MockInterface;
 use Psr\Log\LoggerInterface;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     /**
      * @var MockInterface|UserRepositoryInterface

--- a/service-api/module/Application/tests/Model/Service/Applications/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Applications/ServiceTest.php
@@ -8,7 +8,7 @@ use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Library\MillisecondDateTime;
 use Application\Model\Service\Applications\Collection;
 use Application\Model\Service\DataModelEntity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use EmptyIterator;
 use Mockery\MockInterface;
 use MakeShared\DataModel\Lpa\Document\Document;
@@ -18,7 +18,7 @@ use MakeShared\DataModel\User\User;
 use MakeSharedTest\DataModel\FixturesData;
 use Mockery;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     /**
      * @var MockInterface|ApplicationRepositoryInterface

--- a/service-api/module/Application/tests/Model/Service/AttorneyDecisionsPrimary/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/AttorneyDecisionsPrimary/ServiceTest.php
@@ -4,11 +4,11 @@ namespace ApplicationTest\Model\Service\AttorneyDecisionsPrimary;
 
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\DataModelEntity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\Decisions\PrimaryAttorneyDecisions;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {

--- a/service-api/module/Application/tests/Model/Service/AttorneyDecisionsReplacement/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/AttorneyDecisionsReplacement/ServiceTest.php
@@ -4,11 +4,11 @@ namespace ApplicationTest\Model\Service\AttorneyDecisionsReplacement;
 
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\DataModelEntity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\Decisions\ReplacementAttorneyDecisions;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {

--- a/service-api/module/Application/tests/Model/Service/AttorneysPrimary/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/AttorneysPrimary/ServiceTest.php
@@ -5,11 +5,11 @@ namespace ApplicationTest\Model\Service\AttorneysPrimary;
 use Application\Library\ApiProblem\ApiProblem;
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\DataModelEntity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\Attorneys\Human;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testCreateInvalidType()
     {

--- a/service-api/module/Application/tests/Model/Service/AttorneysReplacement/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/AttorneysReplacement/ServiceTest.php
@@ -5,11 +5,11 @@ namespace ApplicationTest\Model\Service\AttorneysReplacement;
 use Application\Library\ApiProblem\ApiProblem;
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\DataModelEntity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\Attorneys\Human;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testCreateInvalidType()
     {

--- a/service-api/module/Application/tests/Model/Service/Authentication/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Authentication/ServiceTest.php
@@ -5,13 +5,13 @@ namespace ApplicationTest\Model\Service\Authentication;
 use Application\Model\DataAccess\Repository\User\UserRepositoryInterface;
 use Application\Model\DataAccess\Postgres\UserModel as User;
 use Application\Model\Service\Authentication\Service as AuthenticationService;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use DateInterval;
 use DateTime;
 use Mockery;
 use Mockery\MockInterface;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     const TIME_FORMAT = 'Y-m-d\TH:i:s.uO';
 

--- a/service-api/module/Application/tests/Model/Service/CertificateProvider/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/CertificateProvider/ServiceTest.php
@@ -4,11 +4,11 @@ namespace ApplicationTest\Model\Service\CertificateProvider;
 
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\DataModelEntity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\CertificateProvider;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {

--- a/service-api/module/Application/tests/Model/Service/Correspondent/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Correspondent/ServiceTest.php
@@ -4,11 +4,11 @@ namespace ApplicationTest\Model\Service\Correspondent;
 
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\DataModelEntity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\Correspondence;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {

--- a/service-api/module/Application/tests/Model/Service/Donor/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Donor/ServiceTest.php
@@ -4,11 +4,11 @@ namespace ApplicationTest\Model\Service\Donor;
 
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\DataModelEntity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\Donor;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {

--- a/service-api/module/Application/tests/Model/Service/Email/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Email/ServiceTest.php
@@ -6,12 +6,12 @@ use Application\Model\DataAccess\Repository\User\UserRepositoryInterface;
 use Application\Model\DataAccess\Repository\User\UpdateEmailUsingTokenResponse;
 use Application\Model\DataAccess\Postgres\UserModel as User;
 use Application\Model\Service\Email\Service as EmailUpdateService;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use DateTime;
 use Mockery;
 use Mockery\MockInterface;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     /**
      * @var MockInterface|UserRepositoryInterface

--- a/service-api/module/Application/tests/Model/Service/Feedback/FeedbackServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Feedback/FeedbackServiceTest.php
@@ -6,11 +6,11 @@ use Application\Model\DataAccess\Repository\Feedback\FeedbackRepositoryInterface
 use Application\Model\Service\Feedback\FeedbackValidator;
 use Application\Model\Service\Feedback\Service as FeedbackService;
 use ApplicationTest\Model\Service\Feedback\FeedbackServiceBuilder;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use DateTime;
 use Mockery;
 
-class FeedbackServiceTest extends AbstractServiceTest
+class FeedbackServiceTest extends AbstractServiceTestCase
 {
     // feedback service under test
     private FeedbackService $sut;

--- a/service-api/module/Application/tests/Model/Service/Instruction/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Instruction/ServiceTest.php
@@ -4,10 +4,10 @@ namespace ApplicationTest\Model\Service\Instruction;
 
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\Instruction\Entity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {

--- a/service-api/module/Application/tests/Model/Service/Lock/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Lock/ServiceTest.php
@@ -4,11 +4,11 @@ namespace ApplicationTest\Model\Service\Lock;
 
 use Application\Library\ApiProblem\ApiProblem;
 use Application\Model\Service\Lock\Entity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeSharedTest\DataModel\FixturesData;
 use DateTime;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testCreateAlreadyLocked()
     {

--- a/service-api/module/Application/tests/Model/Service/NotifiedPeople/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/NotifiedPeople/ServiceTest.php
@@ -5,11 +5,11 @@ namespace ApplicationTest\Model\Service\NotifiedPeople;
 use Application\Library\ApiProblem\ApiProblem;
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\DataModelEntity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\NotifiedPerson;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testCreateValidationFailed()
     {

--- a/service-api/module/Application/tests/Model/Service/Password/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Password/ServiceTest.php
@@ -6,14 +6,14 @@ use Application\Model\DataAccess\Repository\User\UpdatePasswordUsingTokenError;
 use Application\Model\DataAccess\Repository\User\UserRepositoryInterface;
 use Application\Model\Service\Authentication\Service as AuthenticationService;
 use Application\Model\Service\Password\Service as PasswordService;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use Application\Model\DataAccess\Postgres\UserModel as User;
 use ApplicationTest\Model\Service\Password\ServiceBuilder;
 use DateTime;
 use Mockery;
 use Mockery\MockInterface;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     /**
      * @var MockInterface|UserRepositoryInterface

--- a/service-api/module/Application/tests/Model/Service/Payment/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Payment/ServiceTest.php
@@ -4,11 +4,11 @@ namespace ApplicationTest\Model\Service\Payment;
 
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\DataModelEntity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Payment\Payment;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {

--- a/service-api/module/Application/tests/Model/Service/Pdfs/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Pdfs/ServiceTest.php
@@ -6,7 +6,7 @@ use Application\Library\ApiProblem\ApiProblem;
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Library\Http\Response\File as FileResponse;
 use Application\Model\Service\Pdfs\Service;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use Aws\Command;
 use Aws\Result;
 use Aws\S3\Exception\S3Exception;
@@ -18,7 +18,7 @@ use Laminas\Crypt\BlockCipher;
 use Laminas\Crypt\Symmetric\Exception\InvalidArgumentException as CryptInvalidArgumentException;
 use hash;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     private $config = [
         'pdf' => [

--- a/service-api/module/Application/tests/Model/Service/Preference/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Preference/ServiceTest.php
@@ -4,10 +4,10 @@ namespace ApplicationTest\Model\Service\Preference;
 
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\Preference\Entity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {

--- a/service-api/module/Application/tests/Model/Service/RepeatCaseNumber/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/RepeatCaseNumber/ServiceTest.php
@@ -4,10 +4,10 @@ namespace ApplicationTest\Model\Service\RepeatCaseNumber;
 
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\RepeatCaseNumber\Entity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {

--- a/service-api/module/Application/tests/Model/Service/Seed/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Seed/ServiceTest.php
@@ -5,13 +5,13 @@ namespace ApplicationTest\Model\Service\Seed;
 use Application\Library\ApiProblem\ApiProblem;
 use Application\Model\DataAccess\Repository\Application\ApplicationRepositoryInterface;
 use Application\Model\Service\Seed\Entity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use ApplicationTest\Model\Service\Applications\ServiceBuilder as ApplicationsServiceBuilder;
 use MakeShared\DataModel\Lpa\Lpa;
 use MakeSharedTest\DataModel\FixturesData;
 use Mockery;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testFetchSeedNotFound()
     {

--- a/service-api/module/Application/tests/Model/Service/Stats/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Stats/ServiceTest.php
@@ -4,11 +4,11 @@ namespace ApplicationTest\Model\Service\Stats;
 
 use Application\Model\DataAccess\Repository\Stats\StatsRepositoryInterface;
 use Application\Model\DataAccess\Repository\User\UserRepositoryInterface;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use DateTime;
 use Mockery;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testFetch()
     {

--- a/service-api/module/Application/tests/Model/Service/System/StatsTest.php
+++ b/service-api/module/Application/tests/Model/Service/System/StatsTest.php
@@ -5,10 +5,10 @@ namespace ApplicationTest\Model\Service\System;
 use Application\Model\DataAccess\Repository\Application\ApplicationRepositoryInterface;
 use Application\Model\DataAccess\Repository\Application\WhoRepositoryInterface;
 use Application\Model\DataAccess\Repository\Stats\StatsRepositoryInterface;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use Mockery;
 
-class StatsTest extends AbstractServiceTest
+class StatsTest extends AbstractServiceTestCase
 {
     public function testGenerate()
     {

--- a/service-api/module/Application/tests/Model/Service/Type/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Type/ServiceTest.php
@@ -4,10 +4,10 @@ namespace ApplicationTest\Model\Service\Type;
 
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\Type\Entity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {

--- a/service-api/module/Application/tests/Model/Service/Users/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Users/ServiceTest.php
@@ -12,7 +12,7 @@ use Application\Model\Service\Applications\Service as ApplicationsService;
 use Application\Model\Service\Users\Service as UsersService;
 use Application\Model\Service\DataModelEntity;
 use ApplicationTest\Helpers;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use ApplicationTest\Model\Service\Users\ServiceBuilder;
 use Mockery;
 use Mockery\MockInterface;
@@ -21,7 +21,7 @@ use MakeSharedTest\DataModel\FixturesData;
 use ArrayObject;
 use DateTime;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     /**
      * @var MockInterface|ApplicationsService

--- a/service-api/module/Application/tests/Model/Service/WhoAreYou/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/WhoAreYou/ServiceTest.php
@@ -6,12 +6,12 @@ use Application\Library\ApiProblem\ApiProblem;
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\DataAccess\Repository\Application\WhoRepositoryInterface;
 use Application\Model\Service\WhoAreYou\Entity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use Mockery;
 use MakeShared\DataModel\WhoAreYou\WhoAreYou;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateAlreadyAnswered()
     {

--- a/service-api/module/Application/tests/Model/Service/WhoIsRegistering/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/WhoIsRegistering/ServiceTest.php
@@ -4,10 +4,10 @@ namespace ApplicationTest\Model\Service\WhoIsRegistering;
 
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\WhoIsRegistering\Entity;
-use ApplicationTest\Model\Service\AbstractServiceTest;
+use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTest
+class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {


### PR DESCRIPTION
## Purpose

This fixes many deprecations that will become breking issues when upgrading to PHP Unit 10

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
