### PR TITLE
LPAL-1037 longer password

### DIFF
--- a/cypress/e2e/AdminUserAccount.feature
+++ b/cypress/e2e/AdminUserAccount.feature
@@ -3,7 +3,7 @@ Feature: AdminUserAccount
 
   Scenario: Delete user from user-facing site
     # Sign up new user on user-facing site
-    Given I sign up "SignupAndDeleteUser" test user with password "Pass1234"
+    Given I sign up "SignupAndDeleteUser" test user with password "Pass12345678"
     When I use activation email for "SignupAndDeleteUser" to visit the link
     Then I see "Account activated" in the title
 

--- a/cypress/e2e/DashboardDeleteLpa.feature
+++ b/cypress/e2e/DashboardDeleteLpa.feature
@@ -7,7 +7,7 @@ Feature: DashboardDeleteLpa
         Given I ignore application exceptions
 
     Scenario: Sign up with new user, create LPA, delete LPA (LPAL-840)
-        Given I sign up "DashboardDeleteLpaUser" test user with password "Pass1234"
+        Given I sign up "DashboardDeleteLpaUser" test user with password "Pass12345678"
         When I use activation email for "DashboardDeleteLpaUser" to visit the link
         Then I see "Account activated" in the title
 

--- a/cypress/e2e/PasswordReset.feature
+++ b/cypress/e2e/PasswordReset.feature
@@ -4,7 +4,7 @@ Feature: PasswordReset
     I want to be able to reset my password
 
     Scenario: Sign up with new user, reset password (LPAL-797)
-      Given I sign up "PasswordResetUser" test user with password "Pass1234"
+      Given I sign up "PasswordResetUser" test user with password "Pass12345678"
       When I use activation email for "PasswordResetUser" to visit the link
       Then I see "Account activated" in the title
 

--- a/cypress/e2e/ReusedDonorKeepsAllDetails.feature
+++ b/cypress/e2e/ReusedDonorKeepsAllDetails.feature
@@ -8,7 +8,7 @@ Feature: ReusedDonorKeepsAllDetails
 
     Scenario: Create LPA with donor who can't sign; on reuse, donor "can't sign" checkbox is ticked
         # Sign up with automatically generated test username and password
-        Given I sign up "ReusedDonorKeepsAllDetailsUser" test user with password "Pass1234"
+        Given I sign up "ReusedDonorKeepsAllDetailsUser" test user with password "Pass12345678"
         When I use activation email for "ReusedDonorKeepsAllDetailsUser" to visit the link
         Then I see "Account activated" in the title
 

--- a/cypress/e2e/SignOut.feature
+++ b/cypress/e2e/SignOut.feature
@@ -8,7 +8,7 @@ Feature: SignOut
 
     @focus
     Scenario: On sign out, user is redirected to feedback page
-        Given I sign up "SignupAndSignoutTestUser" test user with password "Pass1234"
+        Given I sign up "SignupAndSignoutTestUser" test user with password "Pass12345678"
         And I use activation email for "SignupAndSignoutTestUser" to visit the link
         When I log in as "SignupAndSignoutTestUser" test user
         Then a simulated click on the "sign-out" link causes a 302 redirect to "https://www.gov.uk/done/lasting-power-of-attorney"

--- a/cypress/e2e/SignUpWithFixtures.feature
+++ b/cypress/e2e/SignUpWithFixtures.feature
@@ -8,7 +8,7 @@ Feature: SignUpWithFixtures
 
     @focus @CleanupFixtures
     Scenario: Sign up with an email address already belonging to a user account (LPAL-485)
-        When I sign up with email "initially_inactive_seeded_test_user3@digital.justice.gov.uk" and password "Pass1234"
+        When I sign up with email "initially_inactive_seeded_test_user3@digital.justice.gov.uk" and password "Pass12345678"
         Then I do not see "api-problem" in the page text
         And I do not see "There is a problem" in the page text
         And I see "Please check your email" in the page text

--- a/cypress/e2e/SignupAndChangeDetails.feature
+++ b/cypress/e2e/SignupAndChangeDetails.feature
@@ -7,7 +7,7 @@ Feature: SignupAndChangeDetails
         Given I ignore application exceptions
 
     Scenario: Sign up with automatically generated test username and password
-        Given I sign up "SignupAndChangeDetailsUser" test user with password "Pass1234"
+        Given I sign up "SignupAndChangeDetailsUser" test user with password "Pass12345678"
         When I use activation email for "SignupAndChangeDetailsUser" to visit the link
         Then I see "Account activated" in the title
 

--- a/service-front/module/Application/src/Form/User/SetPassword.php
+++ b/service-front/module/Application/src/Form/User/SetPassword.php
@@ -55,7 +55,7 @@ class SetPassword extends AbstractCsrfForm
                     'name'    => 'StringLength',
                     'options' => [
                         'encoding' => 'UTF-8',
-                        'min'      => 8,
+                        'min'      => 12,
                         'messages' => [
                             StringLength::TOO_SHORT => 'min-length-%min%',
                         ],

--- a/service-front/module/Application/tests/Form/User/ChangePasswordTest.php
+++ b/service-front/module/Application/tests/Form/User/ChangePasswordTest.php
@@ -50,9 +50,9 @@ class ChangePasswordTest extends MockeryTestCase
     public function testValidateByModelOK()
     {
         $this->form->setData(array_merge([
-            'password_current'      => 'P@55word',
-            'password'              => 'P@55word',
-            'password_confirm'      => 'P@55word',
+            'password_current'      => 'P@55wordword',
+            'password'              => 'P@55wordword',
+            'password_confirm'      => 'P@55wordword',
             'skip_confirm_password' => '0',
         ], $this->getCsrfData()));
 
@@ -64,9 +64,9 @@ class ChangePasswordTest extends MockeryTestCase
     public function testValidateByModelOKWithHTMLTags()
     {
         $this->form->setData(array_merge([
-            'password_current'      => 'P@55word',
-            'password'              => '<>P@55word',
-            'password_confirm'      => '<>P@55word',
+            'password_current'      => 'P@55wordword',
+            'password'              => '<>P@55wordword',
+            'password_confirm'      => '<>P@55wordword',
             'skip_confirm_password' => '0',
         ], $this->getCsrfData()));
 

--- a/service-front/module/Application/tests/Form/User/RegistrationTest.php
+++ b/service-front/module/Application/tests/Form/User/RegistrationTest.php
@@ -60,8 +60,8 @@ class RegistrationTest extends MockeryTestCase
             'email'                 => 'a@b.com',
             'email_confirm'         => 'a@b.com',
             'terms'                 => '1',
-            'password'              => '<>P@55word',
-            'password_confirm'      => '<>P@55word',
+            'password'              => '<>P@55wordword',
+            'password_confirm'      => '<>P@55wordword',
             'skip_confirm_password' => '0',
         ], $this->getCsrfData()));
 
@@ -92,7 +92,7 @@ class RegistrationTest extends MockeryTestCase
             'email'                 => 'a@b.com',
             'email_confirm'         => 'a@b.com',
             'terms'                 => '1',
-            'password'              => '<>P@55word',
+            'password'              => '<>P@55wordword',
             'password_confirm'      => '',
             'skip_confirm_password' => '1',
         ], $this->getCsrfData()));

--- a/service-front/module/Application/tests/Form/User/RegistrationTest.php
+++ b/service-front/module/Application/tests/Form/User/RegistrationTest.php
@@ -44,8 +44,8 @@ class RegistrationTest extends MockeryTestCase
             'email'                 => 'a@b.com',
             'email_confirm'         => 'a@b.com',
             'terms'                 => '1',
-            'password'              => 'P@55word',
-            'password_confirm'      => 'P@55word',
+            'password'              => 'P@55wordword',
+            'password_confirm'      => 'P@55wordword',
             'skip_confirm_password' => '0',
         ], $this->getCsrfData()));
 

--- a/service-front/module/Application/tests/Form/User/SetPasswordTest.php
+++ b/service-front/module/Application/tests/Form/User/SetPasswordTest.php
@@ -36,8 +36,8 @@ class SetPasswordTest extends MockeryTestCase
     public function testValidateByModelOK()
     {
         $this->form->setData(array_merge([
-            'password'              => 'P@55word',
-            'password_confirm'      => 'P@55word',
+            'password'              => 'P@55wordword',
+            'password_confirm'      => 'P@55wordword',
             'skip_confirm_password' => '0',
         ], $this->getCsrfData()));
 

--- a/service-front/module/Application/view/application/authenticated/change-password/partials/index-error-summary.twig
+++ b/service-front/module/Application/view/application/authenticated/change-password/partials/index-error-summary.twig
@@ -7,7 +7,7 @@
     },
     'password' : {
         'cannot-be-empty' : 'Enter your new password',
-        'min-length-8' : 'Choose a new password that is at least eight characters long',
+        'min-length-12' : 'Choose a new password that is at least twelve characters long',
         'must-include-digit' : 'Choose a new password that includes at least one digit (0-9)',
         'must-include-lower-case' : 'Choose a new password that includes at least one lower case letter (a-z)',
         'must-include-upper-case' : 'Choose a new password that includes at least one capital letter (A-Z)',

--- a/service-front/module/Application/view/application/general/forgot-password/partials/reset-password-error-summary.twig
+++ b/service-front/module/Application/view/application/general/forgot-password/partials/reset-password-error-summary.twig
@@ -3,7 +3,7 @@
 {% set form = formErrorTextExchange(form,  {
     'password' : {
         'cannot-be-empty' : 'Enter your password',
-        'min-length-8' : 'Your password must be at least eight characters long',
+        'min-length-12' : 'Your password must be at least twelve characters long',
         'must-include-digit' : 'Your password must include at least one digit (0-9)',
         'must-include-lower-case' : 'Your password must include at least one lower case letter (a-z)',
         'must-include-upper-case' : 'Your password must include at least one capital letter (A-Z)',

--- a/service-front/module/Application/view/application/general/register/partials/index-error-summary.twig
+++ b/service-front/module/Application/view/application/general/register/partials/index-error-summary.twig
@@ -10,7 +10,7 @@
     },
     'password' : {
         'cannot-be-empty' : 'Enter your password',
-        'min-length-8' : 'Your password must be at least eight characters long',
+        'min-length-12' : 'Your password must be at least twelve characters long',
         'must-include-digit' : 'Your password must include at least one digit (0-9)',
         'must-include-lower-case' : 'Your password must include at least one lower case letter (a-z)',
         'must-include-upper-case' : 'Your password must include at least one capital letter (A-Z)',

--- a/service-front/module/Application/view/application/partials/password-rules.twig
+++ b/service-front/module/Application/view/application/partials/password-rules.twig
@@ -1,7 +1,7 @@
 <div class="text">
     <p>Your password needs to have:</p>
     <ul class="list list-bullet">
-        <li>at least 8 characters</li>
+        <li>at least 12 characters</li>
         <li>at least one lower-case and one capital letter</li>
         <li>at least one number</li>
     </ul>

--- a/service-pdf/src/Opg/Lpa/Pdf/AbstractIndividualPdf.php
+++ b/service-pdf/src/Opg/Lpa/Pdf/AbstractIndividualPdf.php
@@ -241,7 +241,7 @@ abstract class AbstractIndividualPdf extends AbstractPdf
      */
     public function generate($protect = false)
     {
-        $this->fillForm($this->data)
+        $this->fillForm($this->data, 'UTF-8', true, 'fdf')
              ->needAppearances()
              ->flatten()
              ->saveAs($this->pdfFile);


### PR DESCRIPTION
## Purpose

_Increase password length to 12 chars_

## Approach

_Change validators and tests to be 12 chars instead of 8_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
