### PR TITLE
Finalize frontend unit test cases

### DIFF
--- a/service-front/module/Application/tests/Adapter/DynamoDbKeyValueStoreTest.php
+++ b/service-front/module/Application/tests/Adapter/DynamoDbKeyValueStoreTest.php
@@ -9,7 +9,7 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
 
-class DynamoDbKeyValueStoreTest extends MockeryTestCase
+final class DynamoDbKeyValueStoreTest extends MockeryTestCase
 {
     /**
      * @var DynamoDbKeyValueStore

--- a/service-front/module/Application/tests/Controller/AbstractLpaActorControllerTest.php
+++ b/service-front/module/Application/tests/Controller/AbstractLpaActorControllerTest.php
@@ -8,7 +8,7 @@ use MakeShared\DataModel\Lpa\Document\Correspondence;
 use MakeSharedTest\DataModel\FixturesData;
 use RuntimeException;
 
-class AbstractLpaActorControllerTest extends AbstractControllerTestCase
+final class AbstractLpaActorControllerTest extends AbstractControllerTestCase
 {
     public function testReuseActorDetailsHttpOneOption()
     {

--- a/service-front/module/Application/tests/Controller/AbstractLpaControllerTest.php
+++ b/service-front/module/Application/tests/Controller/AbstractLpaControllerTest.php
@@ -10,7 +10,7 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\Router\RouteMatch;
 use Laminas\View\Model\ViewModel;
 
-class AbstractLpaControllerTest extends AbstractControllerTestCase
+final class AbstractLpaControllerTest extends AbstractControllerTestCase
 {
     public function testOnDispatchNotAuthenticated()
     {

--- a/service-front/module/Application/tests/Controller/Authenticated/AboutYouControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/AboutYouControllerTest.php
@@ -13,7 +13,7 @@ use MakeShared\DataModel\User\User;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class AboutYouControllerTest extends AbstractControllerTestCase
+final class AboutYouControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|AboutYou

--- a/service-front/module/Application/tests/Controller/Authenticated/ChangeEmailAddressControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/ChangeEmailAddressControllerTest.php
@@ -9,7 +9,7 @@ use Mockery;
 use Mockery\MockInterface;
 use Laminas\View\Model\ViewModel;
 
-class ChangeEmailAddressControllerTest extends AbstractControllerTestCase
+final class ChangeEmailAddressControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|ChangeEmailAddress

--- a/service-front/module/Application/tests/Controller/Authenticated/ChangePasswordControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/ChangePasswordControllerTest.php
@@ -10,7 +10,7 @@ use Mockery\MockInterface;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class ChangePasswordControllerTest extends AbstractControllerTestCase
+final class ChangePasswordControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|ChangePassword

--- a/service-front/module/Application/tests/Controller/Authenticated/DashboardControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/DashboardControllerTest.php
@@ -13,7 +13,7 @@ use Laminas\View\Model\ViewModel;
 use MakeSharedTest\DataModel\FixturesData;
 use Mockery;
 
-class DashboardControllerTest extends AbstractControllerTestCase
+final class DashboardControllerTest extends AbstractControllerTestCase
 {
     public function testIndexActionZeroLpas()
     {

--- a/service-front/module/Application/tests/Controller/Authenticated/DeleteControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/DeleteControllerTest.php
@@ -8,7 +8,7 @@ use Laminas\Http\Response;
 use Laminas\Session\Container;
 use Laminas\View\Model\ViewModel;
 
-class DeleteControllerTest extends AbstractControllerTestCase
+final class DeleteControllerTest extends AbstractControllerTestCase
 {
     public function testIndexAction()
     {

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/ApplicantControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/ApplicantControllerTest.php
@@ -13,7 +13,7 @@ use RuntimeException;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class ApplicantControllerTest extends AbstractControllerTestCase
+final class ApplicantControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|ApplicantForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/CertificateProviderControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/CertificateProviderControllerTest.php
@@ -15,7 +15,7 @@ use RuntimeException;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class CertificateProviderControllerTest extends AbstractControllerTestCase
+final class CertificateProviderControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|BlankMainFlowForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/CheckoutControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/CheckoutControllerTest.php
@@ -17,7 +17,7 @@ use Laminas\View\Model\ViewModel;
 use Alphagov\Pay\Client as GovPayClient;
 use Alphagov\Pay\Response\Payment as GovPayPayment;
 
-class CheckoutControllerTest extends AbstractControllerTestCase
+final class CheckoutControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|Communication

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/CompleteControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/CompleteControllerTest.php
@@ -7,7 +7,7 @@ use ApplicationTest\Controller\AbstractControllerTestCase;
 use MakeShared\DataModel\Lpa\Document\NotifiedPerson;
 use Laminas\View\Model\ViewModel;
 
-class CompleteControllerTest extends AbstractControllerTestCase
+final class CompleteControllerTest extends AbstractControllerTestCase
 {
     public function testIndexActionGetNotLocked()
     {

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/CorrespondentControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/CorrespondentControllerTest.php
@@ -17,7 +17,7 @@ use Laminas\Http\Response;
 use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
 
-class CorrespondentControllerTest extends AbstractControllerTestCase
+final class CorrespondentControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|CorrespondentForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/DateCheckControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/DateCheckControllerTest.php
@@ -9,7 +9,7 @@ use Mockery;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class DateCheckControllerTest extends AbstractControllerTestCase
+final class DateCheckControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|DateCheckForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/DonorControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/DonorControllerTest.php
@@ -17,7 +17,7 @@ use Laminas\Http\Response;
 use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
 
-class DonorControllerTest extends AbstractControllerTestCase
+final class DonorControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|DonorForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/DownloadControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/DownloadControllerTest.php
@@ -11,7 +11,7 @@ use Laminas\View\Model\ViewModel;
 use MakeShared\DataModel\Lpa\Document\NotifiedPerson;
 use Mockery;
 
-class DownloadControllerTest extends AbstractControllerTestCase
+final class DownloadControllerTest extends AbstractControllerTestCase
 {
     public function testIndexActionNoPdfAvailable()
     {

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/FeeReductionControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/FeeReductionControllerTest.php
@@ -12,7 +12,7 @@ use Laminas\Form\Element\Select;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class FeeReductionControllerTest extends AbstractControllerTestCase
+final class FeeReductionControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|FeeReductionForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/HowPrimaryAttorneysMakeDecisionControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/HowPrimaryAttorneysMakeDecisionControllerTest.php
@@ -13,7 +13,7 @@ use RuntimeException;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class HowPrimaryAttorneysMakeDecisionControllerTest extends AbstractControllerTestCase
+final class HowPrimaryAttorneysMakeDecisionControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|HowAttorneysMakeDecisionForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/HowReplacementAttorneysMakeDecisionControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/HowReplacementAttorneysMakeDecisionControllerTest.php
@@ -12,7 +12,7 @@ use RuntimeException;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class HowReplacementAttorneysMakeDecisionControllerTest extends AbstractControllerTestCase
+final class HowReplacementAttorneysMakeDecisionControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|HowAttorneysMakeDecisionForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/IndexControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/IndexControllerTest.php
@@ -7,7 +7,7 @@ use ApplicationTest\Controller\AbstractControllerTestCase;
 use MakeSharedTest\DataModel\FixturesData;
 use Laminas\Http\Response;
 
-class IndexControllerTest extends AbstractControllerTestCase
+final class IndexControllerTest extends AbstractControllerTestCase
 {
     public function testIndexActionNoSeed()
     {

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/InstructionsControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/InstructionsControllerTest.php
@@ -11,7 +11,7 @@ use RuntimeException;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class InstructionsControllerTest extends AbstractControllerTestCase
+final class InstructionsControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|InstructionsAndPreferencesForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/LifeSustainingControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/LifeSustainingControllerTest.php
@@ -11,7 +11,7 @@ use RuntimeException;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class LifeSustainingControllerTest extends AbstractControllerTestCase
+final class LifeSustainingControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|LifeSustainingForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/MoreInfoRequiredControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/MoreInfoRequiredControllerTest.php
@@ -6,7 +6,7 @@ use Application\Controller\Authenticated\Lpa\MoreInfoRequiredController;
 use ApplicationTest\Controller\AbstractControllerTestCase;
 use Laminas\View\Model\ViewModel;
 
-class MoreInfoRequiredControllerTest extends AbstractControllerTestCase
+final class MoreInfoRequiredControllerTest extends AbstractControllerTestCase
 {
     public function testIndexAction()
     {

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/PeopleToNotifyControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/PeopleToNotifyControllerTest.php
@@ -19,7 +19,7 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
 
-class PeopleToNotifyControllerTest extends AbstractControllerTestCase
+final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|BlankMainFlowForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/PrimaryAttorneyControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/PrimaryAttorneyControllerTest.php
@@ -22,7 +22,7 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
 
-class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
+final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|AttorneyForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/RepeatApplicationControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/RepeatApplicationControllerTest.php
@@ -12,7 +12,7 @@ use RuntimeException;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class RepeatApplicationControllerTest extends AbstractControllerTestCase
+final class RepeatApplicationControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|RepeatApplicationForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/ReplacementAttorneyControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/ReplacementAttorneyControllerTest.php
@@ -20,7 +20,7 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
 
-class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
+final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|BlankMainFlowForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/ReuseDetailsControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/ReuseDetailsControllerTest.php
@@ -12,7 +12,7 @@ use Laminas\Http\Response;
 use Laminas\Router\RouteMatch;
 use Laminas\View\Model\ViewModel;
 
-class ReuseDetailsControllerTest extends AbstractControllerTestCase
+final class ReuseDetailsControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|ReuseDetailsForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/StatusControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/StatusControllerTest.php
@@ -10,7 +10,7 @@ use Laminas\Session\Container;
 use Laminas\View\Model\ViewModel;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class StatusControllerTest extends AbstractControllerTestCase
+final class StatusControllerTest extends AbstractControllerTestCase
 {
     public function testIndexAction()
     {

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/SummaryControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/SummaryControllerTest.php
@@ -6,7 +6,7 @@ use Application\Controller\Authenticated\Lpa\SummaryController;
 use ApplicationTest\Controller\AbstractControllerTestCase;
 use Laminas\View\Model\ViewModel;
 
-class SummaryControllerTest extends AbstractControllerTestCase
+final class SummaryControllerTest extends AbstractControllerTestCase
 {
     public function testIndexAction()
     {

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/TypeControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/TypeControllerTest.php
@@ -12,7 +12,7 @@ use RuntimeException;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class TypeControllerTest extends AbstractControllerTestCase
+final class TypeControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|TypeForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/WhenLpaStartsControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/WhenLpaStartsControllerTest.php
@@ -12,7 +12,7 @@ use RuntimeException;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class WhenLpaStartsControllerTest extends AbstractControllerTestCase
+final class WhenLpaStartsControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|WhenLpaStartsForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/WhenReplacementAttorneyStepInControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/WhenReplacementAttorneyStepInControllerTest.php
@@ -12,7 +12,7 @@ use RuntimeException;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class WhenReplacementAttorneyStepInControllerTest extends AbstractControllerTestCase
+final class WhenReplacementAttorneyStepInControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|WhenReplacementAttorneyStepInForm

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/WhoAreYouControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/WhoAreYouControllerTest.php
@@ -12,7 +12,7 @@ use Laminas\View\Model\ViewModel;
 use Mockery;
 use Mockery\MockInterface;
 
-class WhoAreYouControllerTest extends AbstractControllerTestCase
+final class WhoAreYouControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|WhoAreYouForm

--- a/service-front/module/Application/tests/Controller/Authenticated/PostcodeControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/PostcodeControllerTest.php
@@ -13,7 +13,7 @@ use Laminas\View\Model\ViewModel;
 use Mockery;
 use Mockery\MockInterface;
 
-class PostcodeControllerTest extends AbstractControllerTestCase
+final class PostcodeControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|MvcEvent

--- a/service-front/module/Application/tests/Controller/Authenticated/SessionKeepAliveControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/SessionKeepAliveControllerTest.php
@@ -7,7 +7,7 @@ use ApplicationTest\Controller\AbstractControllerTestCase;
 use Laminas\View\Model\JsonModel;
 use Laminas\Http\Response;
 
-class SessionKeepAliveControllerTest extends AbstractControllerTestCase
+final class SessionKeepAliveControllerTest extends AbstractControllerTestCase
 {
     public function setUp() : void
     {

--- a/service-front/module/Application/tests/Controller/Authenticated/TypeControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/TypeControllerTest.php
@@ -13,7 +13,7 @@ use Mockery;
 use Mockery\MockInterface;
 use RuntimeException;
 
-class TypeControllerTest extends AbstractControllerTestCase
+final class TypeControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|TypeForm

--- a/service-front/module/Application/tests/Controller/General/AuthControllerCookieTest.php
+++ b/service-front/module/Application/tests/Controller/General/AuthControllerCookieTest.php
@@ -10,7 +10,7 @@ use Laminas\Http\Header\Cookie;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class AuthControllerCookieTest extends AbstractControllerTestCase
+final class AuthControllerCookieTest extends AbstractControllerTestCase
 {
     public function testIndexActionAlreadySignedIn()
     {

--- a/service-front/module/Application/tests/Controller/General/AuthControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/AuthControllerTest.php
@@ -17,7 +17,7 @@ use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
 use DateTime;
 
-class AuthControllerTest extends AbstractControllerTestCase
+final class AuthControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|Login

--- a/service-front/module/Application/tests/Controller/General/FeedbackControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/FeedbackControllerTest.php
@@ -14,7 +14,7 @@ use Laminas\Http\Response;
 use Laminas\Uri\Uri;
 use Laminas\View\Model\ViewModel;
 
-class FeedbackControllerTest extends AbstractControllerTestCase
+final class FeedbackControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|FeedbackForm

--- a/service-front/module/Application/tests/Controller/General/ForgotPasswordControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/ForgotPasswordControllerTest.php
@@ -12,7 +12,7 @@ use Mockery\MockInterface;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class ForgotPasswordControllerTest extends AbstractControllerTestCase
+final class ForgotPasswordControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|ConfirmEmail

--- a/service-front/module/Application/tests/Controller/General/GuidanceControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/GuidanceControllerTest.php
@@ -9,7 +9,7 @@ use Mockery;
 use Mockery\MockInterface;
 use Laminas\View\Model\ViewModel;
 
-class GuidanceControllerTest extends AbstractControllerTestCase
+final class GuidanceControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|Guidance

--- a/service-front/module/Application/tests/Controller/General/HomeControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/HomeControllerTest.php
@@ -6,7 +6,7 @@ use Application\Controller\General\HomeController;
 use ApplicationTest\Controller\AbstractControllerTestCase;
 use Laminas\View\Model\ViewModel;
 
-class HomeControllerTest extends AbstractControllerTestCase
+final class HomeControllerTest extends AbstractControllerTestCase
 {
     public function testIndexAction()
     {

--- a/service-front/module/Application/tests/Controller/General/PingControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/PingControllerTest.php
@@ -12,7 +12,7 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
 
-class PingControllerTest extends MockeryTestCase
+final class PingControllerTest extends MockeryTestCase
 {
     /**
      * @var MockInterface|Status

--- a/service-front/module/Application/tests/Controller/General/RegisterControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/RegisterControllerTest.php
@@ -17,7 +17,7 @@ use Laminas\View\Model\ViewModel;
 use Mockery;
 use Mockery\MockInterface;
 
-class RegisterControllerTest extends AbstractControllerTestCase
+final class RegisterControllerTest extends AbstractControllerTestCase
 {
     public const GA = 987654321987654321;
     /**

--- a/service-front/module/Application/tests/Controller/General/StatsControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/StatsControllerTest.php
@@ -10,7 +10,7 @@ use Laminas\View\Model\ViewModel;
 use Mockery;
 use Mockery\MockInterface;
 
-class StatsControllerTest extends AbstractControllerTestCase
+final class StatsControllerTest extends AbstractControllerTestCase
 {
     /**
      * @var MockInterface|StatsService

--- a/service-front/module/Application/tests/Controller/General/VerifyEmailAddressControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/VerifyEmailAddressControllerTest.php
@@ -7,7 +7,7 @@ use ApplicationTest\Controller\AbstractControllerTestCase;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 
-class VerifyEmailAddressControllerTest extends AbstractControllerTestCase
+final class VerifyEmailAddressControllerTest extends AbstractControllerTestCase
 {
     protected function getController(string $controllerName)
     {

--- a/service-front/module/Application/tests/ControllerFactory/ControllerAbstractFactoryTest.php
+++ b/service-front/module/Application/tests/ControllerFactory/ControllerAbstractFactoryTest.php
@@ -14,7 +14,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
 use Laminas\ServiceManager\AbstractPluginManager;
 
-class ControllerAbstractFactoryTest extends MockeryTestCase
+final class ControllerAbstractFactoryTest extends MockeryTestCase
 {
     /**
      * @var ControllerAbstractFactory

--- a/service-front/module/Application/tests/Form/Fieldset/CorrespondenceTest.php
+++ b/service-front/module/Application/tests/Form/Fieldset/CorrespondenceTest.php
@@ -5,7 +5,7 @@ namespace ApplicationTest\Form\FieldSet;
 use Application\Form\Fieldset\Correspondence;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class CorrespondenceTest extends MockeryTestCase
+final class CorrespondenceTest extends MockeryTestCase
 {
     public function testNameAndInstance()
     {

--- a/service-front/module/Application/tests/Form/Fieldset/DobTest.php
+++ b/service-front/module/Application/tests/Form/Fieldset/DobTest.php
@@ -5,7 +5,7 @@ namespace ApplicationTest\Form\Lpa;
 use Application\Form\Fieldset\Dob as DobFieldset;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class DobTest extends MockeryTestCase
+final class DobTest extends MockeryTestCase
 {
     public function testNameAndInstance()
     {

--- a/service-front/module/Application/tests/Form/General/FeedbackFormTest.php
+++ b/service-front/module/Application/tests/Form/General/FeedbackFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\General\FeedbackForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class FeedbackFormTest extends MockeryTestCase
+final class FeedbackFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/ApplicantFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/ApplicantFormTest.php
@@ -7,7 +7,7 @@ use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use MakeShared\DataModel\Lpa\Lpa;
 
-class ApplicantFormTest extends MockeryTestCase
+final class ApplicantFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/AttorneyFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/AttorneyFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\AttorneyForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class AttorneyFormTest extends MockeryTestCase
+final class AttorneyFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/BlankMainFlowFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/BlankMainFlowFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\BlankMainFlowForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class BlankMainFlowFormTest extends MockeryTestCase
+final class BlankMainFlowFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/CertificateProviderFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/CertificateProviderFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\CertificateProviderForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class CertificateProviderFormTest extends MockeryTestCase
+final class CertificateProviderFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/CorrespondenceFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/CorrespondenceFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\CorrespondenceForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class CorrespondenceFormTest extends MockeryTestCase
+final class CorrespondenceFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/CorrespondentFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/CorrespondentFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\CorrespondentForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class CorrespondentFormTest extends MockeryTestCase
+final class CorrespondentFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/DateCheckFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/DateCheckFormTest.php
@@ -8,7 +8,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use MakeShared\DataModel\Lpa\Document\Document;
 use MakeShared\DataModel\Lpa\Lpa;
 
-class DateCheckFormTest extends MockeryTestCase
+final class DateCheckFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/DonorFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/DonorFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\DonorForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class DonorFormTest extends MockeryTestCase
+final class DonorFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/FeeReductionFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/FeeReductionFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\FeeReductionForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class FeeReductionFormTest extends MockeryTestCase
+final class FeeReductionFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/FormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/FormTest.php
@@ -10,7 +10,7 @@ use MakeShared\DataModel\Lpa\Lpa;
 use ReflectionClass;
 use function PHPUnit\Framework\assertEquals;
 
-class FormTest extends MockeryTestCase
+final class FormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/HowAttorneysMakeDecisionFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/HowAttorneysMakeDecisionFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\HowAttorneysMakeDecisionForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class HowAttorneysMakeDecisionFormTest extends MockeryTestCase
+final class HowAttorneysMakeDecisionFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/InstructionsAndPreferencesFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/InstructionsAndPreferencesFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\InstructionsAndPreferencesForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class InstructionsAndPreferencesFormTest extends MockeryTestCase
+final class InstructionsAndPreferencesFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/LifeSustainingFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/LifeSustainingFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\LifeSustainingForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class LifeSustainingFormTest extends MockeryTestCase
+final class LifeSustainingFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/PeopleToNotifyFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/PeopleToNotifyFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\PeopleToNotifyForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class PeopleToNotifyFormTest extends MockeryTestCase
+final class PeopleToNotifyFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/RepeatApplicationFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/RepeatApplicationFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\RepeatApplicationForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class RepeatApplicationFormTest extends MockeryTestCase
+final class RepeatApplicationFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/ReuseDetailsFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/ReuseDetailsFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\ReuseDetailsForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class ReuseDetailsFormTest extends MockeryTestCase
+final class ReuseDetailsFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/TrustCorporationFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/TrustCorporationFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\TrustCorporationForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class TrustCorporationFormTest extends MockeryTestCase
+final class TrustCorporationFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/TypeFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/TypeFormTest.php
@@ -7,7 +7,7 @@ use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use MakeShared\DataModel\Lpa\Document\Document;
 
-class TypeFormTest extends MockeryTestCase
+final class TypeFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/WhenLpaStartsFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/WhenLpaStartsFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\WhenLpaStartsForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class WhenLpaStartsFormTest extends MockeryTestCase
+final class WhenLpaStartsFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/WhenReplacementAttorneyStepInFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/WhenReplacementAttorneyStepInFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\WhenReplacementAttorneyStepInForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class WhenReplacementAttorneyStepInFormTest extends MockeryTestCase
+final class WhenReplacementAttorneyStepInFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Lpa/WhoAreYouFormTest.php
+++ b/service-front/module/Application/tests/Form/Lpa/WhoAreYouFormTest.php
@@ -6,7 +6,7 @@ use Application\Form\Lpa\WhoAreYouForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class WhoAreYouFormTest extends MockeryTestCase
+final class WhoAreYouFormTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/User/AboutYouTest.php
+++ b/service-front/module/Application/tests/Form/User/AboutYouTest.php
@@ -6,7 +6,7 @@ use Application\Form\User\AboutYou as AboutYouForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class AboutYouTest extends MockeryTestCase
+final class AboutYouTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/User/ChangeEmailAddressTest.php
+++ b/service-front/module/Application/tests/Form/User/ChangeEmailAddressTest.php
@@ -8,7 +8,7 @@ use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery as m;
 
-class ChangeEmailAddressTest extends MockeryTestCase
+final class ChangeEmailAddressTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/User/ChangePasswordTest.php
+++ b/service-front/module/Application/tests/Form/User/ChangePasswordTest.php
@@ -8,7 +8,7 @@ use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery as m;
 
-class ChangePasswordTest extends MockeryTestCase
+final class ChangePasswordTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/User/ConfirmEmailTest.php
+++ b/service-front/module/Application/tests/Form/User/ConfirmEmailTest.php
@@ -6,7 +6,7 @@ use Application\Form\User\ConfirmEmail as ConfirmEmailForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class ConfirmEmailTest extends MockeryTestCase
+final class ConfirmEmailTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/User/LoginTest.php
+++ b/service-front/module/Application/tests/Form/User/LoginTest.php
@@ -6,7 +6,7 @@ use Application\Form\User\Login as LoginForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class LoginTest extends MockeryTestCase
+final class LoginTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/User/RegistrationTest.php
+++ b/service-front/module/Application/tests/Form/User/RegistrationTest.php
@@ -6,7 +6,7 @@ use Application\Form\User\Registration as RegistrationForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class RegistrationTest extends MockeryTestCase
+final class RegistrationTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/User/SetPasswordTest.php
+++ b/service-front/module/Application/tests/Form/User/SetPasswordTest.php
@@ -6,7 +6,7 @@ use Application\Form\User\SetPassword as SetPasswordForm;
 use ApplicationTest\Form\FormTestSetupTrait;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class SetPasswordTest extends MockeryTestCase
+final class SetPasswordTest extends MockeryTestCase
 {
     use FormTestSetupTrait;
 

--- a/service-front/module/Application/tests/Form/Validator/CorrespondenceTest.php
+++ b/service-front/module/Application/tests/Form/Validator/CorrespondenceTest.php
@@ -6,7 +6,7 @@ use Application\Form\Validator\Correspondence;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class CorrespondenceTest extends MockeryTestCase
+final class CorrespondenceTest extends MockeryTestCase
 {
     #[DataProvider('dataProvider')]
     public function testIsValid($data, array $errors)

--- a/service-front/module/Application/tests/Form/Validator/CsrfTest.php
+++ b/service-front/module/Application/tests/Form/Validator/CsrfTest.php
@@ -9,7 +9,7 @@ use Laminas\Session\Container;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\LoggerInterface;
 
-class CsrfTest extends MockeryTestCase
+final class CsrfTest extends MockeryTestCase
 {
     #[DataProvider('dataProvider')]
     public function testIsValid($data, array $errors)

--- a/service-front/module/Application/tests/Form/Validator/DateTest.php
+++ b/service-front/module/Application/tests/Form/Validator/DateTest.php
@@ -6,7 +6,7 @@ use Application\Form\Validator\Date;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class DateTest extends MockeryTestCase
+final class DateTest extends MockeryTestCase
 {
     #[DataProvider('dataProvider')]
     public function testIsValid($data, array $errors)

--- a/service-front/module/Application/tests/Form/Validator/EmailAddressTest.php
+++ b/service-front/module/Application/tests/Form/Validator/EmailAddressTest.php
@@ -6,7 +6,7 @@ use Application\Form\Validator\EmailAddress;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class EmailAddressTest extends MockeryTestCase
+final class EmailAddressTest extends MockeryTestCase
 {
     #[DataProvider('dataProvider')]
     public function testIsValid($data, array $errors)

--- a/service-front/module/Application/tests/Form/Validator/PasswordTest.php
+++ b/service-front/module/Application/tests/Form/Validator/PasswordTest.php
@@ -6,7 +6,7 @@ use Application\Form\Validator\Password;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class PasswordTest extends MockeryTestCase
+final class PasswordTest extends MockeryTestCase
 {
     #[DataProvider('dataProvider')]
     public function testIsValid($data, array $errors)

--- a/service-front/module/Application/tests/Form/View/Helper/FormMultiCheckboxTest.php
+++ b/service-front/module/Application/tests/Form/View/Helper/FormMultiCheckboxTest.php
@@ -5,7 +5,7 @@ namespace ApplicationTest\Form\View\Helper;
 use PHPUnit\Framework\TestCase;
 use Laminas\Form\Element\MultiCheckbox;
 
-class FormMultiCheckboxTest extends TestCase
+final class FormMultiCheckboxTest extends TestCase
 {
     public function testRenderOptions()
     {

--- a/service-front/module/Application/tests/Form/View/Helper/FormRadioTest.php
+++ b/service-front/module/Application/tests/Form/View/Helper/FormRadioTest.php
@@ -8,7 +8,7 @@ use Laminas\Form\Element\Radio;
 use Laminas\Form\Form;
 use Laminas\View\Renderer\ConsoleRenderer;
 
-class FormRadioTest extends TestCase
+final class FormRadioTest extends TestCase
 {
     protected $form;
 

--- a/service-front/module/Application/tests/Logging/ErrorEventListenerTest.php
+++ b/service-front/module/Application/tests/Logging/ErrorEventListenerTest.php
@@ -9,7 +9,7 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Psr\Log\LoggerInterface;
 
-class ErrorEventListenerTest extends MockeryTestCase
+final class ErrorEventListenerTest extends MockeryTestCase
 {
     public function testMvcEventErrorHanding()
     {

--- a/service-front/module/Application/tests/Logging/HeadersProcessorTest.php
+++ b/service-front/module/Application/tests/Logging/HeadersProcessorTest.php
@@ -8,7 +8,7 @@ use MakeShared\Logging\HeadersProcessor;
 use Monolog\Level;
 use Monolog\LogRecord;
 
-class HeadersProcessorTest extends MockeryTestCase
+final class HeadersProcessorTest extends MockeryTestCase
 {
     public function testHeadersProcessed()
     {

--- a/service-front/module/Application/tests/Logging/MvcEventProcessorTest.php
+++ b/service-front/module/Application/tests/Logging/MvcEventProcessorTest.php
@@ -11,7 +11,7 @@ use MakeShared\Logging\MvcEventProcessor;
 use Monolog\Level;
 use Monolog\LogRecord;
 
-class MvcEventProcessorTest extends MockeryTestCase
+final class MvcEventProcessorTest extends MockeryTestCase
 {
     public function testEventToArray()
     {

--- a/service-front/module/Application/tests/Logging/TraceIdProcessorTest.php
+++ b/service-front/module/Application/tests/Logging/TraceIdProcessorTest.php
@@ -8,7 +8,7 @@ use MakeShared\Logging\TraceIdProcessor;
 use Monolog\Level;
 use Monolog\LogRecord;
 
-class TraceIdProcessorTest extends MockeryTestCase
+final class TraceIdProcessorTest extends MockeryTestCase
 {
     public function testTraceIdProcessed()
     {

--- a/service-front/module/Application/tests/Model/FormFlowCheckerTest.php
+++ b/service-front/module/Application/tests/Model/FormFlowCheckerTest.php
@@ -26,7 +26,7 @@ use RuntimeException;
  * This set of unit tests with execute sequentially starting with a basic LPA datamodel - which will
  * check the correct position in the flow to return the user to
  */
-class FormFlowCheckerTest extends MockeryTestCase
+final class FormFlowCheckerTest extends MockeryTestCase
 {
     /**
      * LPA document to test

--- a/service-front/module/Application/tests/Model/Service/AddressLookup/OrdnanceSurveyFactoryTest.php
+++ b/service-front/module/Application/tests/Model/Service/AddressLookup/OrdnanceSurveyFactoryTest.php
@@ -11,7 +11,7 @@ use Http\Client\HttpClient as HttpClientInterface;
 use Application\Model\Service\AddressLookup\OrdnanceSurvey;
 use Application\Model\Service\AddressLookup\OrdnanceSurveyFactory;
 
-class OrdnanceSurveyFactoryTest extends MockeryTestCase
+final class OrdnanceSurveyFactoryTest extends MockeryTestCase
 {
     /**
      * @var MockInterface|ContainerInterface

--- a/service-front/module/Application/tests/Model/Service/AddressLookup/OrdnanceSurveyTest.php
+++ b/service-front/module/Application/tests/Model/Service/AddressLookup/OrdnanceSurveyTest.php
@@ -13,7 +13,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 use Application\Model\Service\AddressLookup\OrdnanceSurvey;
 
-class OrdnanceSurveyTest extends MockeryTestCase
+final class OrdnanceSurveyTest extends MockeryTestCase
 {
     /**
      * @var string

--- a/service-front/module/Application/tests/Model/Service/ApiClient/ApiClientTraitTest.php
+++ b/service-front/module/Application/tests/Model/Service/ApiClient/ApiClientTraitTest.php
@@ -6,7 +6,7 @@ use Application\Model\Service\ApiClient\Client;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class ApiClientTraitTest extends MockeryTestCase
+final class ApiClientTraitTest extends MockeryTestCase
 {
     public function testApiClientTrait() : void
     {

--- a/service-front/module/Application/tests/Model/Service/ApiClient/ClientFactoryTest.php
+++ b/service-front/module/Application/tests/Model/Service/ApiClient/ClientFactoryTest.php
@@ -12,7 +12,7 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
 
-class ClientFactoryTest extends MockeryTestCase
+final class ClientFactoryTest extends MockeryTestCase
 {
     /**
      * @var MockInterface|ContainerInterface

--- a/service-front/module/Application/tests/Model/Service/ApiClient/ClientTest.php
+++ b/service-front/module/Application/tests/Model/Service/ApiClient/ClientTest.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 
-class ClientTest extends MockeryTestCase
+final class ClientTest extends MockeryTestCase
 {
     /**
      * @var HttpClient|MockInterface

--- a/service-front/module/Application/tests/Model/Service/ApiClient/Exception/ApiExceptionTest.php
+++ b/service-front/module/Application/tests/Model/Service/ApiClient/Exception/ApiExceptionTest.php
@@ -9,7 +9,7 @@ use Mockery\MockInterface;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Psr7\Utils;
 
-class ApiExceptionTest extends MockeryTestCase
+final class ApiExceptionTest extends MockeryTestCase
 {
     /**
      * @var ResponseInterface|MockInterface

--- a/service-front/module/Application/tests/Model/Service/ApiClient/Response/AuthResponseTest.php
+++ b/service-front/module/Application/tests/Model/Service/ApiClient/Response/AuthResponseTest.php
@@ -5,7 +5,7 @@ namespace ApplicationTest\Model\Service\ApiClient\Response;
 use Application\Model\Service\ApiClient\Response\AuthResponse;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class AuthResponseTest extends MockeryTestCase
+final class AuthResponseTest extends MockeryTestCase
 {
     public function testBuildFromResponse(): void
     {

--- a/service-front/module/Application/tests/Model/Service/Authentication/Adapter/LpaAuthAdapterTest.php
+++ b/service-front/module/Application/tests/Model/Service/Authentication/Adapter/LpaAuthAdapterTest.php
@@ -13,7 +13,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use RuntimeException;
 use Laminas\Authentication\Result;
 
-class LpaAuthAdapterTest extends MockeryTestCase
+final class LpaAuthAdapterTest extends MockeryTestCase
 {
     /**
      * @var $client Client|MockInterface

--- a/service-front/module/Application/tests/Model/Service/Authentication/AuthenticationServiceFactoryTest.php
+++ b/service-front/module/Application/tests/Model/Service/Authentication/AuthenticationServiceFactoryTest.php
@@ -9,7 +9,7 @@ use Interop\Container\ContainerInterface;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class AuthenticationServiceFactoryTest extends MockeryTestCase
+final class AuthenticationServiceFactoryTest extends MockeryTestCase
 {
     public function testInvoke()
     {

--- a/service-front/module/Application/tests/Model/Service/Authentication/AuthenticationServiceTest.php
+++ b/service-front/module/Application/tests/Model/Service/Authentication/AuthenticationServiceTest.php
@@ -11,7 +11,7 @@ use Laminas\Authentication\Adapter\AdapterInterface;
 use Laminas\Authentication\Result;
 use Laminas\Authentication\Storage\StorageInterface;
 
-class AuthenticationServiceTest extends MockeryTestCase
+final class AuthenticationServiceTest extends MockeryTestCase
 {
     /**
      * @var $storageInterface StorageInterface|MockInterface

--- a/service-front/module/Application/tests/Model/Service/Authentication/Identity/UserTest.php
+++ b/service-front/module/Application/tests/Model/Service/Authentication/Identity/UserTest.php
@@ -9,7 +9,7 @@ use DateTime;
 use Exception;
 use PHPUnit\Framework\TestCase;
 
-class UserTest extends TestCase
+final class UserTest extends TestCase
 {
     /**
      * @var $user User

--- a/service-front/module/Application/tests/Model/Service/Date/DateServiceTest.php
+++ b/service-front/module/Application/tests/Model/Service/Date/DateServiceTest.php
@@ -8,7 +8,7 @@ use DateTime;
 use Exception;
 use PHPUnit\Framework\TestCase;
 
-class DateServiceTest extends TestCase
+final class DateServiceTest extends TestCase
 {
     /**
      * @var $dateService DateService

--- a/service-front/module/Application/tests/Model/Service/Feedback/FeedbackTest.php
+++ b/service-front/module/Application/tests/Model/Service/Feedback/FeedbackTest.php
@@ -12,7 +12,7 @@ use Hamcrest\MatcherAssert;
 use Mockery;
 use Psr\Log\LoggerInterface;
 
-class FeedbackTest extends AbstractEmailServiceTest
+final class FeedbackTest extends AbstractEmailServiceTest
 {
     /**
      * @var $apiClient Client|MockInterface

--- a/service-front/module/Application/tests/Model/Service/Guidance/GuidanceTest.php
+++ b/service-front/module/Application/tests/Model/Service/Guidance/GuidanceTest.php
@@ -5,7 +5,7 @@ namespace ApplicationTest\Model\Service\Guidance;
 use Application\Model\Service\Guidance\Guidance;
 use ApplicationTest\Model\Service\AbstractServiceTest;
 
-class GuidanceTest extends AbstractServiceTest
+final class GuidanceTest extends AbstractServiceTest
 {
     /**
      * @var $cwd string

--- a/service-front/module/Application/tests/Model/Service/Lpa/ApplicantTest.php
+++ b/service-front/module/Application/tests/Model/Service/Lpa/ApplicantTest.php
@@ -12,7 +12,7 @@ use MakeShared\DataModel\Lpa\Document\Decisions\PrimaryAttorneyDecisions;
 use MakeShared\DataModel\Lpa\Document\Document;
 use MakeShared\DataModel\Lpa\Lpa;
 
-class ApplicantTest extends AbstractServiceTest
+final class ApplicantTest extends AbstractServiceTest
 {
     /**
      * @var $applicationService Application|MockInterface

--- a/service-front/module/Application/tests/Model/Service/Lpa/ApplicationTest.php
+++ b/service-front/module/Application/tests/Model/Service/Lpa/ApplicationTest.php
@@ -18,7 +18,7 @@ use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Psr7\Utils;
 use Psr\Log\LoggerInterface;
 
-class ApplicationTest extends MockeryTestCase
+final class ApplicationTest extends MockeryTestCase
 {
     /**
      * @var MockInterface|AuthenticationService

--- a/service-front/module/Application/tests/Model/Service/Lpa/CommunicationTest.php
+++ b/service-front/module/Application/tests/Model/Service/Lpa/CommunicationTest.php
@@ -20,7 +20,7 @@ use Application\Model\Service\Mail\Exception\InvalidArgumentException;
 use Laminas\Session\Container;
 use Psr\Log\LoggerInterface;
 
-class CommunicationTest extends AbstractEmailServiceTest
+final class CommunicationTest extends AbstractEmailServiceTest
 {
     /**
      * @var $service Communication

--- a/service-front/module/Application/tests/Model/Service/Lpa/ContinuationSheetsTest.php
+++ b/service-front/module/Application/tests/Model/Service/Lpa/ContinuationSheetsTest.php
@@ -7,7 +7,7 @@ use MakeShared\DataModel\Lpa\Document\Decisions\AbstractDecisions;
 use MakeShared\DataModel\Lpa\Lpa;
 use Application\Model\Service\Lpa\ContinuationSheets;
 
-class ContinuationSheetsTest extends AbstractHttpControllerTestCase
+final class ContinuationSheetsTest extends AbstractHttpControllerTestCase
 {
     /**
      * @var $service Applicant

--- a/service-front/module/Application/tests/Model/Service/Lpa/MetadataTest.php
+++ b/service-front/module/Application/tests/Model/Service/Lpa/MetadataTest.php
@@ -8,7 +8,7 @@ use ApplicationTest\Model\Service\AbstractServiceTest;
 use Mockery;
 use MakeShared\DataModel\Lpa\Lpa;
 
-class MetadataTest extends AbstractServiceTest
+final class MetadataTest extends AbstractServiceTest
 {
     /**
      * @var $applicationService Application|MockInterface

--- a/service-front/module/Application/tests/Model/Service/Lpa/ReplacementAttorneyCleanupTest.php
+++ b/service-front/module/Application/tests/Model/Service/Lpa/ReplacementAttorneyCleanupTest.php
@@ -12,7 +12,7 @@ use Mockery;
 use MakeShared\DataModel\Lpa\Document\Decisions\ReplacementAttorneyDecisions;
 use MakeShared\DataModel\Lpa\Lpa;
 
-class ReplacementAttorneyCleanupTest extends AbstractServiceTest
+final class ReplacementAttorneyCleanupTest extends AbstractServiceTest
 {
     /**
      * @var $lpaApplicationService LpaApplicationService|MockInterface

--- a/service-front/module/Application/tests/Model/Service/Mail/Transport/MailTransportFactoryTest.php
+++ b/service-front/module/Application/tests/Model/Service/Mail/Transport/MailTransportFactoryTest.php
@@ -11,7 +11,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
 use RuntimeException;
 
-class MailTransportFactoryTest extends MockeryTestCase
+final class MailTransportFactoryTest extends MockeryTestCase
 {
     /**
      * @throws ContainerException

--- a/service-front/module/Application/tests/Model/Service/Mail/Transport/NotifyMailTransportTest.php
+++ b/service-front/module/Application/tests/Model/Service/Mail/Transport/NotifyMailTransportTest.php
@@ -13,7 +13,7 @@ use Application\Model\Service\Mail\MailParameters;
 use Application\Model\Service\Mail\Transport\NotifyMailTransport;
 use Psr\Log\LoggerInterface;
 
-class NotifyMailTransportTest extends MockeryTestCase
+final class NotifyMailTransportTest extends MockeryTestCase
 {
     public function setUp(): void
     {

--- a/service-front/module/Application/tests/Model/Service/Payment/Helper/LpaIdHelperTest.php
+++ b/service-front/module/Application/tests/Model/Service/Payment/Helper/LpaIdHelperTest.php
@@ -9,7 +9,7 @@ use Application\Model\Service\Payment\Helper\LpaIdHelper;
 /**
  * Payment test case.
  */
-class LpaIdHelperTest extends AbstractHttpControllerTestCase
+final class LpaIdHelperTest extends AbstractHttpControllerTestCase
 {
     /**
      * Prepares the environment before running a test.

--- a/service-front/module/Application/tests/Model/Service/Redis/RedisClientTest.php
+++ b/service-front/module/Application/tests/Model/Service/Redis/RedisClientTest.php
@@ -11,7 +11,7 @@ use Redis;
 use RedisException;
 use ReflectionProperty;
 
-class RedisClientTest extends MockeryTestCase
+final class RedisClientTest extends MockeryTestCase
 {
     // returns the mock for setting expectations
     private function makeRedisClientWithMock(string $redisUrl): Redis

--- a/service-front/module/Application/tests/Model/Service/Session/FilteringSaveHandlerTest.php
+++ b/service-front/module/Application/tests/Model/Service/Session/FilteringSaveHandlerTest.php
@@ -7,7 +7,7 @@ use Application\Model\Service\Session\FilteringSaveHandler;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class FilteringSaveHandlerTest extends MockeryTestCase
+final class FilteringSaveHandlerTest extends MockeryTestCase
 {
     // returns the mock for setting expectations
     private function makeSaveHandlerWithMock(): RedisClient

--- a/service-front/module/Application/tests/Model/Service/Session/PersistentSessionDetailsTest.php
+++ b/service-front/module/Application/tests/Model/Service/Session/PersistentSessionDetailsTest.php
@@ -10,7 +10,7 @@ use Laminas\Router\RouteMatch;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
-class PersistentSessionDetailsTest extends TestCase {
+final class PersistentSessionDetailsTest extends TestCase {
 
     #[Test]
     public function testSuccessfullyCreateClass() {

--- a/service-front/module/Application/tests/Model/Service/Session/SessionFactoryTest.php
+++ b/service-front/module/Application/tests/Model/Service/Session/SessionFactoryTest.php
@@ -13,7 +13,7 @@ use Laminas\Http\Request;
 use Laminas\Http\Uri;
 use Laminas\Session\Exception\RuntimeException;
 
-class SessionFactoryTest extends MockeryTestCase
+final class SessionFactoryTest extends MockeryTestCase
 {
     /**
      * Because SessionFactory messes with ini_set, we have to run this test

--- a/service-front/module/Application/tests/Model/Service/Session/SessionManagerTest.php
+++ b/service-front/module/Application/tests/Model/Service/Session/SessionManagerTest.php
@@ -6,7 +6,7 @@ use Application\Model\Service\Session\SessionManager;
 use Laminas\Session\Container;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class SessionManagerTest extends MockeryTestCase
+final class SessionManagerTest extends MockeryTestCase
 {
     /**
      * (@runInSeparateProcess annotation is required so that session handling is

--- a/service-front/module/Application/tests/Model/Service/Signatures/DateCheckTest.php
+++ b/service-front/module/Application/tests/Model/Service/Signatures/DateCheckTest.php
@@ -12,7 +12,7 @@ use DateTime;
 /**
  * FormFlowChecker test case.
  */
-class DateCheckTest extends AbstractHttpControllerTestCase
+final class DateCheckTest extends AbstractHttpControllerTestCase
 {
     /**
      * @var MockInterface|IDateService

--- a/service-front/module/Application/tests/Model/Service/Stats/StatsTest.php
+++ b/service-front/module/Application/tests/Model/Service/Stats/StatsTest.php
@@ -8,7 +8,7 @@ use ApplicationTest\Model\Service\AbstractServiceTest;
 use ApplicationTest\Model\Service\ServiceTestHelper;
 use Mockery;
 
-class StatsTest extends AbstractServiceTest
+final class StatsTest extends AbstractServiceTest
 {
     /**
      * @var $apiClient Client|MockInterface

--- a/service-front/module/Application/tests/Model/Service/System/StatusTest.php
+++ b/service-front/module/Application/tests/Model/Service/System/StatusTest.php
@@ -17,7 +17,7 @@ use MakeShared\Constants;
 use Mockery;
 use Mockery\MockInterface;
 
-class StatusTest extends AbstractServiceTest
+final class StatusTest extends AbstractServiceTest
 {
     /**
      * @var Client|MockInterface

--- a/service-front/module/Application/tests/Model/Service/User/DetailsTest.php
+++ b/service-front/module/Application/tests/Model/Service/User/DetailsTest.php
@@ -20,7 +20,7 @@ use Hamcrest\Matchers;
 use Mockery;
 use Mockery\MockInterface;
 
-class DetailsTest extends AbstractEmailServiceTest
+final class DetailsTest extends AbstractEmailServiceTest
 {
     /**
      * @var $apiClient Client|MockInterface

--- a/service-front/module/Application/tests/View/ContinuationNotesTwigMacroTest.php
+++ b/service-front/module/Application/tests/View/ContinuationNotesTwigMacroTest.php
@@ -12,7 +12,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
  * Unit tests for the Twig macro which renders continuation sheet prompts
  * for both the "Last steps" and date check pages.
  */
-class ContinuationNotesTwigMacroTest extends MockeryTestCase
+final class ContinuationNotesTwigMacroTest extends MockeryTestCase
 {
     /** @var ViewModelRenderer */
     private $renderer;

--- a/service-front/module/Application/tests/View/DateCheckViewModelHelperTest.php
+++ b/service-front/module/Application/tests/View/DateCheckViewModelHelperTest.php
@@ -12,7 +12,7 @@ use MakeShared\DataModel\Lpa\Document\Decisions\AbstractDecisions;
 use MakeShared\DataModel\Lpa\Document\Decisions\ReplacementAttorneyDecisions;
 use MakeShared\DataModel\Lpa\Lpa;
 
-class DateCheckViewModelHelperTest extends MockeryTestCase
+final class DateCheckViewModelHelperTest extends MockeryTestCase
 {
     /** @var ViewModelRenderer */
     private $renderer;

--- a/service-front/module/Application/tests/View/Helper/AccordionFactoryTest.php
+++ b/service-front/module/Application/tests/View/Helper/AccordionFactoryTest.php
@@ -10,7 +10,7 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Laminas\Router\RouteMatch;
 
-class AccordionFactoryTest extends MockeryTestCase
+final class AccordionFactoryTest extends MockeryTestCase
 {
     public function testInvoke() : void
     {

--- a/service-front/module/Application/tests/View/Helper/AccordionTest.php
+++ b/service-front/module/Application/tests/View/Helper/AccordionTest.php
@@ -12,7 +12,7 @@ use Laminas\Router\RouteMatch;
 /**
  * AccordionTest
  */
-class AccordionTest extends MockeryTestCase
+final class AccordionTest extends MockeryTestCase
 {
     public function testLpaType()
     {

--- a/service-front/module/Application/tests/View/Helper/AccountInfoFactoryTest.php
+++ b/service-front/module/Application/tests/View/Helper/AccountInfoFactoryTest.php
@@ -15,7 +15,7 @@ use Laminas\Session\Container;
 use Laminas\View\Model\ViewModel;
 use Twig\Environment as TwigEnvironment;
 
-class AccountInfoFactoryTest extends MockeryTestCase
+final class AccountInfoFactoryTest extends MockeryTestCase
 {
 
     public function testInvoke():void

--- a/service-front/module/Application/tests/View/Helper/AccountInfoTest.php
+++ b/service-front/module/Application/tests/View/Helper/AccountInfoTest.php
@@ -24,7 +24,7 @@ use Laminas\View\Renderer\RendererInterface;
 use Application\Model\Service\Lpa\Application as LpaApplicationService;
 use Application\View\Helper\LocalViewRenderer;
 
-class AccountInfoTest extends MockeryTestCase
+final class AccountInfoTest extends MockeryTestCase
 {
     /**
      * @var AuthenticationService|MockInterface

--- a/service-front/module/Application/tests/View/Helper/ApplicantNamesTest.php
+++ b/service-front/module/Application/tests/View/Helper/ApplicantNamesTest.php
@@ -6,7 +6,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use MakeShared\DataModel\Lpa\Lpa;
 use Application\View\Helper\Traits\ConcatNamesTrait;
 
-class ApplicantNamesTest extends MockeryTestCase
+final class ApplicantNamesTest extends MockeryTestCase
 {
     use ConcatNamesTrait;
 

--- a/service-front/module/Application/tests/View/Helper/FinalCheckAccessibleTest.php
+++ b/service-front/module/Application/tests/View/Helper/FinalCheckAccessibleTest.php
@@ -6,7 +6,7 @@ use Application\View\Helper\FinalCheckAccessible;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use MakeShared\DataModel\Lpa\Lpa;
 
-class FinalCheckAccessibleTest extends MockeryTestCase
+final class FinalCheckAccessibleTest extends MockeryTestCase
 {
     public function testInvoke(): void
     {

--- a/service-front/module/Application/tests/View/Helper/MoneyFormatTest.php
+++ b/service-front/module/Application/tests/View/Helper/MoneyFormatTest.php
@@ -5,7 +5,7 @@ namespace ApplicationTest\View\Helper;
 use Application\View\Helper\MoneyFormat;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class MoneyFormatTest extends MockeryTestCase
+final class MoneyFormatTest extends MockeryTestCase
 {
     public function testInvokeWithWholePoundsAsInt(): void
     {

--- a/service-front/module/Application/tests/View/Helper/RouteNameFactoryTest.php
+++ b/service-front/module/Application/tests/View/Helper/RouteNameFactoryTest.php
@@ -9,7 +9,7 @@ use Interop\Container\ContainerInterface;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class RouteNameFactoryTest extends MockeryTestCase
+final class RouteNameFactoryTest extends MockeryTestCase
 {
     public function testInvoke():void
     {

--- a/service-front/module/Application/tests/View/Helper/SystemMessageFactoryTest.php
+++ b/service-front/module/Application/tests/View/Helper/SystemMessageFactoryTest.php
@@ -8,7 +8,7 @@ use Interop\Container\ContainerInterface;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class SystemMessageFactoryTest extends MockeryTestCase
+final class SystemMessageFactoryTest extends MockeryTestCase
 {
     public function testInvoke(): void
     {

--- a/service-front/module/Application/tests/View/Helper/SystemMessageTest.php
+++ b/service-front/module/Application/tests/View/Helper/SystemMessageTest.php
@@ -7,7 +7,7 @@ use Application\View\Helper\SystemMessage;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-class SystemMessageTest extends MockeryTestCase
+final class SystemMessageTest extends MockeryTestCase
 {
     public function testInvokeEmptySystemMessage(): void
     {

--- a/service-front/module/Application/tests/View/StatusViewModelHelperTest.php
+++ b/service-front/module/Application/tests/View/StatusViewModelHelperTest.php
@@ -22,7 +22,7 @@ use MakeShared\DataModel\Lpa\Document\Document;
  * at the top of the status detail page). They also don't check that the expected
  * receipt date is shown in the correct format in the HTML.
  */
-class StatusViewModelHelperTest extends MockeryTestCase
+final class StatusViewModelHelperTest extends MockeryTestCase
 {
     /** @var DateTime */
     private $trackFromDate;


### PR DESCRIPTION
Unit test cases are marked final as it allows better detection of unused code, and test case inheritance is often a source of issues for maintenance