### PR TITLE
Add type declarations for service-front Controller tests

### DIFF
--- a/service-front/module/Application/tests/Controller/AbstractAuthenticatedControllerTestCase.php
+++ b/service-front/module/Application/tests/Controller/AbstractAuthenticatedControllerTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller;
 
 use DateTime;
@@ -14,7 +16,7 @@ use Laminas\View\Model\ViewModel;
 
 class AbstractAuthenticatedControllerTestCase extends AbstractControllerTestCase
 {
-    public function testOnDispatchNotAuthenticated()
+    public function testOnDispatchNotAuthenticated(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(TestableAbstractAuthenticatedController::class);
@@ -31,7 +33,7 @@ class AbstractAuthenticatedControllerTestCase extends AbstractControllerTestCase
         $this->assertEquals($result, $response);
     }
 
-    public function testOnDispatchRedirectToTermsChanged()
+    public function testOnDispatchRedirectToTermsChanged(): void
     {
         $now = new DateTime();
         $this->config['terms']['lastUpdated'] = $now->format('Y-m-d H:i T');
@@ -53,7 +55,7 @@ class AbstractAuthenticatedControllerTestCase extends AbstractControllerTestCase
         $this->assertEquals($result, $response);
     }
 
-    public function testOnDispatchBadUserData()
+    public function testOnDispatchBadUserData(): void
     {
         $this->user = Mockery::mock(User::class);
         $this->user->shouldReceive('get')->andReturn('name');
@@ -79,7 +81,7 @@ class AbstractAuthenticatedControllerTestCase extends AbstractControllerTestCase
         $this->assertEquals($result, $response);
     }
 
-    public function testOnDispatchRedirectToNewUser()
+    public function testOnDispatchRedirectToNewUser(): void
     {
         $this->user = new User();
 
@@ -99,7 +101,7 @@ class AbstractAuthenticatedControllerTestCase extends AbstractControllerTestCase
         $this->assertEquals($result, $response);
     }
 
-    public function testOnDispatchLoadUser()
+    public function testOnDispatchLoadUser(): void
     {
         $controller = $this->getController(TestableAbstractAuthenticatedController::class);
 
@@ -124,7 +126,7 @@ class AbstractAuthenticatedControllerTestCase extends AbstractControllerTestCase
         $this->assertEquals('Placeholder page', $result->content);
     }
 
-    public function testOnDispatchDatabaseDown()
+    public function testOnDispatchDatabaseDown(): void
     {
         // Simulate the database being unavailable, which results in a marker in the session;
         // see Module.php, where this marker is added before the session is handed over to the controller
@@ -156,12 +158,12 @@ class AbstractAuthenticatedControllerTestCase extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testResetSessionCloneData()
+    public function testResetSessionCloneData(): void
     {
         $controller = $this->getController(TestableAbstractAuthenticatedController::class);
 
         $this->sessionManager->shouldReceive('start')->once();
-        $seedId = new ArrayObject(['12345' => '12345']);
+        new ArrayObject(['12345' => '12345']);
 
         Container::setDefaultManager($this->sessionManager);
         $result = $controller->testResetSessionCloneData('12345');

--- a/service-front/module/Application/tests/Controller/AbstractControllerTestCase.php
+++ b/service-front/module/Application/tests/Controller/AbstractControllerTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller;
 
 use Exception;
@@ -143,11 +145,11 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
     /**
      * @var User
      */
-    protected $user = null;
+    protected $user;
     /**
      * @var UserIdentity
      */
-    protected $userIdentity = null;
+    protected $userIdentity;
     /**
      * @var MockInterface|ReplacementAttorneyCleanup
      */
@@ -305,7 +307,6 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
     }
 
     /**
-     * @param string $controllerName
      * @return AbstractBaseController
      */
     protected function getController(string $controllerName)
@@ -424,7 +425,7 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
         return $routeMatch;
     }
 
-    public function setSeedLpa($lpa, $seedLpa)
+    public function setSeedLpa($lpa, $seedLpa): void
     {
         $lpa->seed = $seedLpa->id;
         $this->lpaApplicationService->shouldReceive('getSeedDetails')
@@ -459,20 +460,16 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
                 'peopleToNotify'
             ]));
 
-        $result = array_filter($result, function ($v) {
+        return array_filter($result, function ($v): bool {
             return !empty($v);
         });
-
-        return $result;
     }
 
     /**
      * @param MockInterface $form
-     * @param array $postData
-     * @param null $dataToSet
      * @param int $expectedPostTimes
      */
-    public function setPostInvalid($form, array $postData = [], $dataToSet = null, $expectedPostTimes = 1)
+    public function setPostInvalid($form, array $postData = [], $dataToSet = null, $expectedPostTimes = 1): void
     {
         //  Post data is got from the form it will be a Parameters object
         $postData = (is_array($postData) ? new Parameters($postData) : $postData);
@@ -490,8 +487,6 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
 
     /**
      * @param MockInterface $form
-     * @param array $postData
-     * @param null $dataToSet
      * @param int $expectedPostTimes
      * @param int $expectedGetPostTimes
      */
@@ -501,7 +496,7 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
         $dataToSet = null,
         $expectedPostTimes = 1,
         $expectedGetPostTimes = 1
-    ) {
+    ): void {
         //  Post data is got from the form it will be a Parameters object
         $postData = (is_array($postData) ? new Parameters($postData) : $postData);
 
@@ -516,7 +511,7 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
         $form->shouldReceive('isValid')->andReturn(true)->once();
     }
 
-    public function setRedirectToRoute($route, $lpa, $response)
+    public function setRedirectToRoute($route, $lpa, $response): void
     {
         $args = [$route, ['lpa-id' => $lpa->id]];
         $args[] = $this->getExpectedRouteOptions($route);
@@ -529,7 +524,7 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
      * @param string $lpaRoute e.g. lpa/certificate-provider/edit
      * @param Response $response
      */
-    public function setRedirectToReuseDetails($user, $lpa, $lpaRoute, $response)
+    public function setRedirectToReuseDetails($user, $lpa, $lpaRoute, $response): void
     {
         $this->userDetailsSession->user = $user;
 
@@ -564,7 +559,7 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
             'actor-name'     => $actorName,
         ];
 
-        $reuseDetailsUrl = "lpa/{$lpa->getId()}/reuse-details?" . implode('&', array_map(function ($value, $key) {
+        $reuseDetailsUrl = "lpa/{$lpa->getId()}/reuse-details?" . implode('&', array_map(function ($value, $key): string {
             $valueString = is_bool($value) ? $value === true ? '1' : '0' : $value;
             return "$key=$valueString";
         }, $queryParams, array_keys($queryParams)));
@@ -699,11 +694,8 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
     /**
      * @param $lpa
      * @param $route
-     * @param null $queryParameters
-     * @param null $fragment
-     * @return mixed
      */
-    private function getLpaUrl($lpa, $route, $queryParameters = null, $fragment = null)
+    private function getLpaUrl($lpa, $route, $queryParameters = null, $fragment = null): array|string
     {
         $url = str_replace('lpa/', "lpa/{$lpa->id}/", $route);
         $queryParams = [];
@@ -714,7 +706,7 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
             $queryParams = array_merge($queryParams, $fragment);
         }
         if (count($queryParams) > 0) {
-            $url .= '?' . implode('&', array_map(function ($value, $key) {
+            $url .= '?' . implode('&', array_map(function ($value, $key): string {
                 $valueString = is_bool($value) ? $value === true ? '1' : '0' : $value;
                 return "$key=$valueString";
             }, $queryParams, array_keys($queryParams)));
@@ -731,10 +723,9 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
      * Get sample user details
      *
      * @param bool $newDetails
-     * @return User
      * @throws Exception
      */
-    private function getUserDetails($newDetails = false)
+    private function getUserDetails($newDetails = false): User
     {
         $user = new User();
 

--- a/service-front/module/Application/tests/Controller/AbstractLpaActorControllerTest.php
+++ b/service-front/module/Application/tests/Controller/AbstractLpaActorControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller;
 
 use Application\Form\Lpa\AbstractActorForm;
@@ -10,7 +12,7 @@ use RuntimeException;
 
 final class AbstractLpaActorControllerTest extends AbstractControllerTestCase
 {
-    public function testReuseActorDetailsHttpOneOption()
+    public function testReuseActorDetailsHttpOneOption(): void
     {
         $controller = $this->getController(TestableAbstractLpaActorController::class);
 
@@ -25,7 +27,7 @@ final class AbstractLpaActorControllerTest extends AbstractControllerTestCase
         $this->assertTrue($result);
     }
 
-    public function testGetActorReuseDetailsCorrespondentOther()
+    public function testGetActorReuseDetailsCorrespondentOther(): void
     {
         $controller = $this->getController(TestableAbstractLpaActorController::class);
 
@@ -42,7 +44,7 @@ final class AbstractLpaActorControllerTest extends AbstractControllerTestCase
 
     // Test that the correspondent from the reused (seed) LPA appears in the
     // reusable actors list when on the correspondent page
-    public function testGetActorReuseDetailsWasCorrespondentForCorrespondentPopup()
+    public function testGetActorReuseDetailsWasCorrespondentForCorrespondentPopup(): void
     {
         $controller = $this->getController(TestableAbstractLpaActorController::class);
 
@@ -57,7 +59,7 @@ final class AbstractLpaActorControllerTest extends AbstractControllerTestCase
         $this->assertNotNull($reuseDetails);
     }
 
-    public function testGetActorReuseDetailsTrustNotIncluded()
+    public function testGetActorReuseDetailsTrustNotIncluded(): void
     {
         $controller = $this->getController(TestableAbstractLpaActorController::class);
 
@@ -73,7 +75,7 @@ final class AbstractLpaActorControllerTest extends AbstractControllerTestCase
         $this->assertNull($reuseDetails);
     }
 
-    public function testGetActorReuseDetailsTrustIncluded()
+    public function testGetActorReuseDetailsTrustIncluded(): void
     {
         $controller = $this->getController(TestableAbstractLpaActorController::class);
 
@@ -92,7 +94,7 @@ final class AbstractLpaActorControllerTest extends AbstractControllerTestCase
         $this->assertEquals($reuseDetails, $reuseDetailsTrust);
     }
 
-    public function testGetActorReuseDetailsUserDetailsAlreadyUsedAsDonor()
+    public function testGetActorReuseDetailsUserDetailsAlreadyUsedAsDonor(): void
     {
         $controller = $this->getController(TestableAbstractLpaActorController::class);
 
@@ -111,13 +113,13 @@ final class AbstractLpaActorControllerTest extends AbstractControllerTestCase
         $this->assertNull($reuseDetails);
     }
 
-    public function testUpdateCorrespondentDataTrust()
+    public function testUpdateCorrespondentDataTrust(): void
     {
         $controller = $this->getController(TestableAbstractLpaActorController::class);
 
         $this->lpa->document->correspondent->who = Correspondence::WHO_ATTORNEY;
 
-        $this->lpaApplicationService->shouldReceive('setCorrespondent')->withArgs(function ($lpa, $correspondent) {
+        $this->lpaApplicationService->shouldReceive('setCorrespondent')->withArgs(function ($lpa, $correspondent): bool {
             return $lpa->id === $this->lpa->id && $correspondent->company === FixturesData::getAttorneyTrust()->name;
         })->andReturn(true)->once();
 
@@ -127,7 +129,7 @@ final class AbstractLpaActorControllerTest extends AbstractControllerTestCase
         $this->assertNull($result);
     }
 
-    public function testUpdateCorrespondentDataFailed()
+    public function testUpdateCorrespondentDataFailed(): void
     {
         $controller = $this->getController(TestableAbstractLpaActorController::class);
 
@@ -142,7 +144,7 @@ final class AbstractLpaActorControllerTest extends AbstractControllerTestCase
         $controller->testUpdateCorrespondentData($trust);
     }
 
-    public function testUpdateCorrespondentDataFailedOnDelete()
+    public function testUpdateCorrespondentDataFailedOnDelete(): void
     {
         $controller = $this->getController(TestableAbstractLpaActorController::class);
 
@@ -160,7 +162,7 @@ final class AbstractLpaActorControllerTest extends AbstractControllerTestCase
         $controller->testUpdateCorrespondentData($trust, $isDelete);
     }
 
-    private function getReuseDetailsByLabelContains($actorReuseDetails, $label)
+    private function getReuseDetailsByLabelContains(array $actorReuseDetails, $label)
     {
         $index = null;
         foreach ($actorReuseDetails as $key => $value) {

--- a/service-front/module/Application/tests/Controller/AbstractLpaControllerTest.php
+++ b/service-front/module/Application/tests/Controller/AbstractLpaControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller;
 
 use Application\Model\FormFlowChecker;
@@ -12,7 +14,7 @@ use Laminas\View\Model\ViewModel;
 
 final class AbstractLpaControllerTest extends AbstractControllerTestCase
 {
-    public function testOnDispatchNotAuthenticated()
+    public function testOnDispatchNotAuthenticated(): void
     {
         $this->setIdentity(null);
 
@@ -30,7 +32,7 @@ final class AbstractLpaControllerTest extends AbstractControllerTestCase
         $this->assertEquals($result, $response);
     }
 
-    public function testOnDispatchNoLpaException()
+    public function testOnDispatchNoLpaException(): void
     {
         $this->lpa = false;
 
@@ -51,7 +53,7 @@ final class AbstractLpaControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Page not found', $result->content);
     }
 
-    public function testOnDispatchNoMethod()
+    public function testOnDispatchNoMethod(): void
     {
         $controller = $this->getController(TestableAbstractLpaController::class);
 
@@ -74,7 +76,7 @@ final class AbstractLpaControllerTest extends AbstractControllerTestCase
         $this->assertEquals($result, $response);
     }
 
-    public function testOnDispatchCalculatedRouteNotEqual()
+    public function testOnDispatchCalculatedRouteNotEqual(): void
     {
         $controller = $this->getController(TestableAbstractLpaController::class);
 
@@ -99,7 +101,7 @@ final class AbstractLpaControllerTest extends AbstractControllerTestCase
         $this->assertEquals($result, $response);
     }
 
-    public function testOnDispatchDownload()
+    public function testOnDispatchDownload(): void
     {
         $controller = $this->getController(TestableAbstractLpaController::class);
 
@@ -131,7 +133,7 @@ final class AbstractLpaControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Placeholder page', $result->content);
     }
 
-    public function testMoveToNextRouteNotRouteMatch()
+    public function testMoveToNextRouteNotRouteMatch(): void
     {
         $controller = $this->getController(TestableAbstractLpaController::class);
 

--- a/service-front/module/Application/tests/Controller/Authenticated/AboutYouControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/AboutYouControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated;
 
 use Application\Controller\Authenticated\AboutYouController;
@@ -15,11 +17,8 @@ use Laminas\View\Model\ViewModel;
 
 final class AboutYouControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|AboutYou
-     */
-    private $form;
-    private $postData = [];
+    private MockInterface|AboutYou $form;
+    private array $postData = [];
 
     public function setUp(): void
     {
@@ -30,7 +29,7 @@ final class AboutYouControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\User\AboutYou'])->andReturn($this->form);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var AboutYouController $controller */
         $controller = $this->getController(AboutYouController::class);
@@ -56,7 +55,7 @@ final class AboutYouControllerTest extends AbstractControllerTestCase
         ];
 
         $this->form->shouldReceive('bind')
-            ->with(Mockery::on(function ($userData) use ($expectedUserData) {
+            ->with(Mockery::on(function ($userData) use ($expectedUserData): true {
                 MatcherAssert::assertThat($expectedUserData, Matchers::equalTo($userData));
                 return true;
             }))
@@ -70,7 +69,7 @@ final class AboutYouControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var AboutYouController $controller */
         $controller = $this->getController(AboutYouController::class);
@@ -93,7 +92,7 @@ final class AboutYouControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostValid()
+    public function testIndexActionPostValid(): void
     {
         /** @var AboutYouController $controller */
         $controller = $this->getController(AboutYouController::class);
@@ -120,7 +119,7 @@ final class AboutYouControllerTest extends AbstractControllerTestCase
         $this->assertInstanceOf(Response::class, $result);
     }
 
-    public function testNewActionGet()
+    public function testNewActionGet(): void
     {
         /** @var AboutYouController $controller */
         $controller = $this->getController(AboutYouController::class);
@@ -147,7 +146,7 @@ final class AboutYouControllerTest extends AbstractControllerTestCase
         ];
 
         $this->form->shouldReceive('bind')
-            ->with(Mockery::on(function ($userData) use ($expectedUserData) {
+            ->with(Mockery::on(function ($userData) use ($expectedUserData): true {
                 MatcherAssert::assertThat($expectedUserData, Matchers::equalTo($userData));
                 return true;
             }))
@@ -161,7 +160,7 @@ final class AboutYouControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testNewActionPostValid()
+    public function testNewActionPostValid(): void
     {
         /** @var AboutYouController $controller */
         $controller = $this->getController(AboutYouController::class);
@@ -190,11 +189,8 @@ final class AboutYouControllerTest extends AbstractControllerTestCase
 
     /**
      * The data expected to set in the form will be different to the form data
-     *
-     * @param User $user
-     * @return array
      */
-    private function getExpectedDataToSet(User $user)
+    private function getExpectedDataToSet(User $user): array
     {
         //  Get the filtered user data in the same way a controller would
         $userDetails = $user->flatten();

--- a/service-front/module/Application/tests/Controller/Authenticated/ChangeEmailAddressControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/ChangeEmailAddressControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated;
 
 use Application\Controller\Authenticated\ChangeEmailAddressController;
@@ -11,11 +13,8 @@ use Laminas\View\Model\ViewModel;
 
 final class ChangeEmailAddressControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|ChangeEmailAddress
-     */
-    private $form;
-    private $postData = [
+    private MockInterface|ChangeEmailAddress $form;
+    private array $postData = [
         'email' => 'newunit@test.com'
     ];
 
@@ -31,7 +30,7 @@ final class ChangeEmailAddressControllerTest extends AbstractControllerTestCase
         $this->form->shouldReceive('setAuthenticationService')->withArgs([$this->authenticationService])->once();
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var ChangeEmailAddressController $controller */
         $controller = $this->getController(ChangeEmailAddressController::class);
@@ -51,7 +50,7 @@ final class ChangeEmailAddressControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->user->email, $result->getVariable('currentEmailAddress'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var ChangeEmailAddressController $controller */
         $controller = $this->getController(ChangeEmailAddressController::class);
@@ -71,7 +70,7 @@ final class ChangeEmailAddressControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->user->email, $result->getVariable('currentEmailAddress'));
     }
 
-    public function testIndexActionPostValid()
+    public function testIndexActionPostValid(): void
     {
         /** @var ChangeEmailAddressController $controller */
         $controller = $this->getController(ChangeEmailAddressController::class);
@@ -91,7 +90,7 @@ final class ChangeEmailAddressControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->postData['email'], $result->getVariable('email'));
     }
 
-    public function testIndexActionPostUpdateFailed()
+    public function testIndexActionPostUpdateFailed(): void
     {
         /** @var ChangeEmailAddressController $controller */
         $controller = $this->getController(ChangeEmailAddressController::class);

--- a/service-front/module/Application/tests/Controller/Authenticated/ChangePasswordControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/ChangePasswordControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated;
 
 use Application\Controller\Authenticated\ChangePasswordController;
@@ -12,11 +14,8 @@ use Laminas\View\Model\ViewModel;
 
 final class ChangePasswordControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|ChangePassword
-     */
-    private $form;
-    private $postData = [
+    private MockInterface|ChangePassword $form;
+    private array $postData = [
         'password_current' => 'Abcd1234',
         'password'         => 'Abcd1234',
     ];
@@ -33,7 +32,7 @@ final class ChangePasswordControllerTest extends AbstractControllerTestCase
         $this->form->shouldReceive('setAuthenticationService')->withArgs([$this->authenticationService])->once();
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var ChangePasswordController $controller */
         $controller = $this->getController(ChangePasswordController::class);
@@ -53,7 +52,7 @@ final class ChangePasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Change your password', $result->getVariable('pageTitle'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var ChangePasswordController $controller */
         $controller = $this->getController(ChangePasswordController::class);
@@ -73,7 +72,7 @@ final class ChangePasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Change your password', $result->getVariable('pageTitle'));
     }
 
-    public function testIndexActionPostValid()
+    public function testIndexActionPostValid(): void
     {
         /** @var ChangePasswordController $controller */
         $controller = $this->getController(ChangePasswordController::class);
@@ -100,7 +99,7 @@ final class ChangePasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionUpdateFails()
+    public function testIndexActionUpdateFails(): void
     {
         /** @var ChangePasswordController $controller */
         $controller = $this->getController(ChangePasswordController::class);

--- a/service-front/module/Application/tests/Controller/Authenticated/DashboardControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/DashboardControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated;
 
 use Application\Controller\Authenticated\DashboardController;
@@ -15,7 +17,7 @@ use Mockery;
 
 final class DashboardControllerTest extends AbstractControllerTestCase
 {
-    public function testIndexActionZeroLpas()
+    public function testIndexActionZeroLpas(): void
     {
         /** @var DashboardController $controller */
         $controller = $this->getController(TestableDashboardController::class);
@@ -39,7 +41,7 @@ final class DashboardControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         /** @var DashboardController $controller */
         $controller = $this->getController(TestableDashboardController::class);
@@ -76,7 +78,7 @@ final class DashboardControllerTest extends AbstractControllerTestCase
         $this->assertEquals(['lastLogin' => $this->userIdentity->lastLogin()], $result->getVariable('user'));
     }
 
-    public function testIndexActionMultiplePages()
+    public function testIndexActionMultiplePages(): void
     {
         /** @var DashboardController $controller */
         $controller = $this->getController(TestableDashboardController::class);
@@ -118,7 +120,7 @@ final class DashboardControllerTest extends AbstractControllerTestCase
         $this->assertEquals(['lastLogin' => $this->userIdentity->lastLogin()], $result->getVariable('user'));
     }
 
-    public function testIndexActionLastPage()
+    public function testIndexActionLastPage(): void
     {
         /** @var DashboardController $controller */
         $controller = $this->getController(TestableDashboardController::class);
@@ -160,7 +162,7 @@ final class DashboardControllerTest extends AbstractControllerTestCase
         $this->assertEquals(['lastLogin' => $this->userIdentity->lastLogin()], $result->getVariable('user'));
     }
 
-    public function testCreateActionSeedLpaFailed()
+    public function testCreateActionSeedLpaFailed(): void
     {
         /** @var DashboardController $controller */
         $controller = $this->getController(TestableDashboardController::class);
@@ -178,7 +180,7 @@ final class DashboardControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testCreateActionSeedLpaPartialSuccess()
+    public function testCreateActionSeedLpaPartialSuccess(): void
     {
         /** @var DashboardController $controller */
         $controller = $this->getController(TestableDashboardController::class);
@@ -199,7 +201,7 @@ final class DashboardControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testDeleteActionLPAAlreadyDeleted()
+    public function testDeleteActionLPAAlreadyDeleted(): void
     {
         /** @var DashboardController $controller */
         $controller = $this->getController(TestableDashboardController::class);
@@ -219,7 +221,7 @@ final class DashboardControllerTest extends AbstractControllerTestCase
         $controller->deleteLpaAction();
     }
 
-    public function testDeleteActionSuccess()
+    public function testDeleteActionSuccess(): void
     {
         /** @var DashboardController $controller */
         $controller = $this->getController(TestableDashboardController::class);
@@ -241,7 +243,7 @@ final class DashboardControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testConfirmDeleteLpaActionNonJs()
+    public function testConfirmDeleteLpaActionNonJs(): void
     {
         /** @var DashboardController $controller */
         $controller = $this->getController(TestableDashboardController::class);
@@ -264,7 +266,7 @@ final class DashboardControllerTest extends AbstractControllerTestCase
         $this->assertEquals($lpa->document->donor->name, $lpaOut->document->donor->name);
     }
 
-    public function testConfirmDeleteLpaActionJs()
+    public function testConfirmDeleteLpaActionJs(): void
     {
         /** @var DashboardController $controller */
         $controller = $this->getController(TestableDashboardController::class);
@@ -290,7 +292,7 @@ final class DashboardControllerTest extends AbstractControllerTestCase
         $this->assertEquals($lpa->document->donor->name, $lpaOut->document->donor->name);
     }
 
-    public function testTermsAction()
+    public function testTermsAction(): void
     {
         /** @var DashboardController $controller */
         $controller = $this->getController(TestableDashboardController::class);
@@ -302,7 +304,7 @@ final class DashboardControllerTest extends AbstractControllerTestCase
         $this->assertEquals('', $result->getTemplate());
     }
 
-    public function testCheckAuthenticated()
+    public function testCheckAuthenticated(): void
     {
         $this->setIdentity(null);
         /** @var DashboardController $controller */
@@ -326,7 +328,7 @@ final class DashboardControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testStatusesAction()
+    public function testStatusesAction(): void
     {
         /** @var DashboardController $controller */
         $controller = $this->getController(TestableDashboardController::class);

--- a/service-front/module/Application/tests/Controller/Authenticated/DeleteControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/DeleteControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated;
 
 use Application\Controller\Authenticated\DeleteController;
@@ -10,7 +12,7 @@ use Laminas\View\Model\ViewModel;
 
 final class DeleteControllerTest extends AbstractControllerTestCase
 {
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         /** @var DeleteController $controller */
         $controller = $this->getController(TestableDeleteController::class);
@@ -21,7 +23,7 @@ final class DeleteControllerTest extends AbstractControllerTestCase
         $this->assertInstanceOf(ViewModel::class, $result);
     }
 
-    public function testConfirmActionFailed()
+    public function testConfirmActionFailed(): void
     {
         /** @var DeleteController $controller */
         $controller = $this->getController(TestableDeleteController::class);
@@ -35,7 +37,7 @@ final class DeleteControllerTest extends AbstractControllerTestCase
         $this->assertEquals('error/500.twig', $result->getTemplate());
     }
 
-    public function testConfirmAction()
+    public function testConfirmAction(): void
     {
         /** @var DeleteController $controller */
         $controller = $this->getController(TestableDeleteController::class);
@@ -50,7 +52,7 @@ final class DeleteControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testCheckAuthenticated()
+    public function testCheckAuthenticated(): void
     {
         /** @var DeleteController $controller */
         $this->setIdentity(null);

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/ApplicantControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/ApplicantControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\ApplicantController;
@@ -15,10 +17,7 @@ use Laminas\View\Model\ViewModel;
 
 final class ApplicantControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|ApplicantForm
-     */
-    private $form;
+    private MockInterface|ApplicantForm $form;
 
     public function setUp(): void
     {
@@ -29,7 +28,7 @@ final class ApplicantControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\Lpa\ApplicantForm', ['lpa' => $this->lpa]])->andReturn($this->form);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var ApplicantController $controller */
         $controller = $this->getController(ApplicantController::class);
@@ -46,7 +45,7 @@ final class ApplicantControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionGetMultiplePrimaryAttorneysJointly()
+    public function testIndexActionGetMultiplePrimaryAttorneysJointly(): void
     {
         /** @var ApplicantController $controller */
         $controller = $this->getController(ApplicantController::class);
@@ -67,7 +66,7 @@ final class ApplicantControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionGetMultiplePrimaryAttorneysJointlyAndSeverally()
+    public function testIndexActionGetMultiplePrimaryAttorneysJointlyAndSeverally(): void
     {
         /** @var ApplicantController $controller */
         $controller = $this->getController(ApplicantController::class);
@@ -90,7 +89,7 @@ final class ApplicantControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var ApplicantController $controller */
         $controller = $this->getController(ApplicantController::class);
@@ -105,7 +104,7 @@ final class ApplicantControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostDonorRegisteringValueNotChanged()
+    public function testIndexActionPostDonorRegisteringValueNotChanged(): void
     {
         /** @var ApplicantController $controller */
         $controller = $this->getController(ApplicantController::class);
@@ -130,7 +129,7 @@ final class ApplicantControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionPostDonorRegisteringValueChangedException()
+    public function testIndexActionPostDonorRegisteringValueChangedException(): void
     {
         /** @var ApplicantController $controller */
         $controller = $this->getController(ApplicantController::class);
@@ -150,7 +149,7 @@ final class ApplicantControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionPostAttorneyRegisteringJointlyChangedSuccessful()
+    public function testIndexActionPostAttorneyRegisteringJointlyChangedSuccessful(): void
     {
         /** @var ApplicantController $controller */
         $controller = $this->getController(ApplicantController::class);
@@ -180,7 +179,7 @@ final class ApplicantControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionPostAttorneyRegisteringJointlyAndSeverallyChangedSuccessful()
+    public function testIndexActionPostAttorneyRegisteringJointlyAndSeverallyChangedSuccessful(): void
     {
         /** @var ApplicantController $controller */
         $controller = $this->getController(ApplicantController::class);

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/CertificateProviderControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/CertificateProviderControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\CertificateProviderController;
@@ -17,14 +19,8 @@ use Laminas\View\Model\ViewModel;
 
 final class CertificateProviderControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|BlankMainFlowForm
-     */
-    private $blankMainFlowForm;
-    /**
-     * @var MockInterface|CertificateProviderForm
-     */
-    private $form;
+    private MockInterface|BlankMainFlowForm $blankMainFlowForm;
+    private MockInterface|CertificateProviderForm $form;
 
     public function setUp(): void
     {
@@ -42,7 +38,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\Lpa\BlankMainFlowForm', ['lpa' => $this->lpa]])->andReturn($this->blankMainFlowForm);
     }
 
-    public function testIndexActionNoCertificateProvider()
+    public function testIndexActionNoCertificateProvider(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -61,7 +57,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/people-to-notify', $result->nextRoute);
     }
 
-    public function testIndexActionCertificateProvider()
+    public function testIndexActionCertificateProvider(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -81,7 +77,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/people-to-notify', $result->nextRoute);
     }
 
-    public function testAddActionGetCertificateProvider()
+    public function testAddActionGetCertificateProvider(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -98,7 +94,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionGetReuseDetails()
+    public function testAddActionGetReuseDetails(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -116,7 +112,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionGetCertificateProviderJs()
+    public function testAddActionGetCertificateProviderJs(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -133,7 +129,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionGetNoCertificateProvider()
+    public function testAddActionGetNoCertificateProvider(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -160,7 +156,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals("lpa/{$this->lpa->id}/certificate-provider", $result->cancelUrl);
     }
 
-    public function testAddActionPostInvalid()
+    public function testAddActionPostInvalid(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -185,7 +181,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals("lpa/{$this->lpa->id}/certificate-provider", $result->cancelUrl);
     }
 
-    public function testAddActionPostException()
+    public function testAddActionPostException(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -208,7 +204,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $controller->addAction();
     }
 
-    public function testAddActionPostSuccess()
+    public function testAddActionPostSuccess(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -234,7 +230,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionPostReuseDetails()
+    public function testAddActionPostReuseDetails(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -265,7 +261,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals($cancelUrl, $result->cancelUrl);
     }
 
-    public function testEditActionGet()
+    public function testEditActionGet(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -289,7 +285,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals("lpa/{$this->lpa->id}/certificate-provider", $result->cancelUrl);
     }
 
-    public function testEditActionPostInvalid()
+    public function testEditActionPostInvalid(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -312,7 +308,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals("lpa/{$this->lpa->id}/certificate-provider", $result->cancelUrl);
     }
 
-    public function testEditActionPostException()
+    public function testEditActionPostException(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -334,7 +330,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $controller->editAction();
     }
 
-    public function testEditActionPostSuccess()
+    public function testEditActionPostSuccess(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -359,7 +355,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testConfirmDeleteAction()
+    public function testConfirmDeleteAction(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -387,7 +383,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->isPopup);
     }
 
-    public function testConfirmDeleteActionJs()
+    public function testConfirmDeleteActionJs(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -415,7 +411,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->isPopup);
     }
 
-    public function testDeleteActionException()
+    public function testDeleteActionException(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);
@@ -428,7 +424,7 @@ final class CertificateProviderControllerTest extends AbstractControllerTestCase
         $controller->deleteAction();
     }
 
-    public function testDeleteActionSuccess()
+    public function testDeleteActionSuccess(): void
     {
         /** @var CertificateProviderController $controller */
         $controller = $this->getController(TestableCertificateProviderController::class);

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/CheckoutControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/CheckoutControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\CheckoutController;
@@ -19,22 +21,10 @@ use Alphagov\Pay\Response\Payment as GovPayPayment;
 
 final class CheckoutControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|Communication
-     */
-    private $communication;
-    /**
-     * @var MockInterface|GovPayClient
-     */
-    private $govPayClient;
-    /**
-     * @var MockInterface|BlankMainFlowForm
-     */
-    private $blankMainFlowForm;
-    /**
-     * @var MockInterface|ElementInterface
-     */
-    private $submitButton;
+    private MockInterface|Communication $communication;
+    private MockInterface|GovPayClient $govPayClient;
+    private MockInterface|BlankMainFlowForm $blankMainFlowForm;
+    private MockInterface|ElementInterface $submitButton;
 
     public function setUp(): void
     {
@@ -45,7 +35,6 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
     }
 
     /**
-     * @param string $controllerName
      * @return CheckoutController
      */
     protected function getController(string $controllerName)
@@ -61,7 +50,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         return $controller;
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -78,7 +67,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals(82, $result->getVariable('fullFee'));
     }
 
-    public function testIndexActionPostIncompleteLpa()
+    public function testIndexActionPostIncompleteLpa(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -93,7 +82,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testChequeActionIncompleteLpa()
+    public function testChequeActionIncompleteLpa(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -107,7 +96,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testChequeActionFailed()
+    public function testChequeActionFailed(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -122,7 +111,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $controller->chequeAction();
     }
 
-    public function testChequeActionIncorrectAmountFailed()
+    public function testChequeActionIncorrectAmountFailed(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -137,7 +126,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $controller->chequeAction();
     }
 
-    public function testChequeActionSuccess()
+    public function testChequeActionSuccess(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -157,7 +146,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testConfirmActionIncompleteLpa()
+    public function testConfirmActionIncompleteLpa(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -171,7 +160,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testConfirmActionInvalidAmount()
+    public function testConfirmActionInvalidAmount(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -184,7 +173,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $controller->confirmAction();
     }
 
-    public function testConfirmActionSuccess()
+    public function testConfirmActionSuccess(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -204,7 +193,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testPayActionIncompleteLpa()
+    public function testPayActionIncompleteLpa(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -218,7 +207,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testPayActionNoExistingPayment()
+    public function testPayActionNoExistingPayment(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -249,7 +238,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testPayActionExistingPaymentNull()
+    public function testPayActionExistingPaymentNull(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -272,7 +261,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $controller->payAction();
     }
 
-    public function testPayActionExistingPaymentSuccessful()
+    public function testPayActionExistingPaymentSuccessful(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -303,7 +292,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testPayActionExistingPaymentNotFinished()
+    public function testPayActionExistingPaymentNotFinished(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -330,7 +319,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testPayActionExistingPaymentFinishedNotSuccessful()
+    public function testPayActionExistingPaymentFinishedNotSuccessful(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -365,7 +354,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testPayResponseActionNoGatewayReference()
+    public function testPayResponseActionNoGatewayReference(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -377,7 +366,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $controller->payResponseAction();
     }
 
-    public function testPayResponseActionNotSuccessfulCancelled()
+    public function testPayResponseActionNotSuccessfulCancelled(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -397,7 +386,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals('application/authenticated/lpa/checkout/govpay-cancel.twig', $result->getTemplate());
     }
 
-    public function testPayResponseActionNotSuccessfulOther()
+    public function testPayResponseActionNotSuccessfulOther(): void
     {
         $controller = $this->getController(CheckoutController::class);
 
@@ -417,7 +406,7 @@ final class CheckoutControllerTest extends AbstractControllerTestCase
         $this->assertEquals('application/authenticated/lpa/checkout/govpay-failure.twig', $result->getTemplate());
     }
 
-    private function setPayByCardExpectations($submitButtonValue)
+    private function setPayByCardExpectations(string $submitButtonValue): void
     {
         $this->formElementManager->shouldReceive('get')
             ->withArgs(['Application\Form\Lpa\BlankMainFlowForm', ['lpa' => $this->lpa]])

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/CompleteControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/CompleteControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\CompleteController;
@@ -9,7 +11,7 @@ use Laminas\View\Model\ViewModel;
 
 final class CompleteControllerTest extends AbstractControllerTestCase
 {
-    public function testIndexActionGetNotLocked()
+    public function testIndexActionGetNotLocked(): void
     {
         /** @var CompleteController $controller */
         $controller = $this->getController(CompleteController::class);
@@ -40,7 +42,7 @@ final class CompleteControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('isPaymentSkipped'));
     }
 
-    public function testViewDocsActionPeopleToNotifyFeeReduction()
+    public function testViewDocsActionPeopleToNotifyFeeReduction(): void
     {
         /** @var CompleteController $controller */
         $controller = $this->getController(CompleteController::class);

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/CorrespondentControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/CorrespondentControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\CorrespondentController;
@@ -19,11 +21,8 @@ use Laminas\View\Model\ViewModel;
 
 final class CorrespondentControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|CorrespondentForm
-     */
-    private $form;
-    private $postDataNoContact = [
+    private MockInterface|CorrespondentForm $form;
+    private array $postDataNoContact = [
         'contactInWelsh' => false,
         'correspondence' => [
             'contactByPost' => false,
@@ -31,7 +30,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
             'contactByPhone' => false,
         ]
     ];
-    private $postDataContact = [
+    private array $postDataContact = [
         'contactInWelsh' => false,
         'correspondence' => [
             'contactByPost' => true,
@@ -41,7 +40,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
             'phone-number' => '0123456789'
         ]
     ];
-    private $postDataCorrespondence = [
+    private array $postDataCorrespondence = [
         'name' => [
             'title' => 'Miss',
             'first' => 'Unit',
@@ -62,7 +61,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\Lpa\CorrespondenceForm', ['lpa' => $this->lpa]])->andReturn($this->form);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -98,7 +97,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('allowEditButton'));
     }
 
-    public function testIndexActionGetCorrespondentTrustCorporation()
+    public function testIndexActionGetCorrespondentTrustCorporation(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -138,7 +137,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('allowEditButton'));
     }
 
-    public function testIndexActionGetNoCorrespondentDonor()
+    public function testIndexActionGetNoCorrespondentDonor(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -176,7 +175,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('allowEditButton'));
     }
 
-    public function testIndexActionGetNoCorrespondentAttorney()
+    public function testIndexActionGetNoCorrespondentAttorney(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -214,7 +213,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('allowEditButton'));
     }
 
-    public function testIndexActionGetCorrespondentCompany()
+    public function testIndexActionGetCorrespondentCompany(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -245,7 +244,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->allowEditButton);
     }
 
-    public function testIndexActionGetCorrespondentOther()
+    public function testIndexActionGetCorrespondentOther(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -276,7 +275,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->allowEditButton);
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -302,7 +301,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('allowEditButton'));
     }
 
-    public function testIndexActionPostFailure()
+    public function testIndexActionPostFailure(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -311,7 +310,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->setPostValid($this->form, $this->postDataNoContact);
         $this->form->shouldReceive('getData')->andReturn($this->postDataNoContact)->once();
         $this->lpaApplicationService->shouldReceive('setCorrespondent')
-            ->withArgs(function ($lpa, $correspondent) {
+            ->withArgs(function ($lpa, $correspondent): bool {
                 return $lpa->id === $this->lpa->id
                     && $correspondent->contactInWelsh === false
                     && $correspondent->contactByPost === false;
@@ -323,7 +322,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionPostSuccess()
+    public function testIndexActionPostSuccess(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -336,7 +335,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->setPostValid($this->form, $this->postDataContact);
         $this->form->shouldReceive('getData')->andReturn($this->postDataContact)->once();
         $this->lpaApplicationService->shouldReceive('setCorrespondent')
-            ->withArgs(function ($lpa, $correspondent) {
+            ->withArgs(function ($lpa, $correspondent): bool {
                 return $lpa->id === $this->lpa->id
                     && $correspondent->contactInWelsh === false
                     && $correspondent->contactByPost === true
@@ -352,7 +351,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testEditActionGet()
+    public function testEditActionGet(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -377,7 +376,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('allowEditButton'));
     }
 
-    public function testEditActionPostInvalid()
+    public function testEditActionPostInvalid(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -401,7 +400,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('allowEditButton'));
     }
 
-    public function testEditActionPostFailed()
+    public function testEditActionPostFailed(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -413,7 +412,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->form->shouldReceive('getModelDataFromValidatedForm')->andReturn($this->postDataCorrespondence)->once();
         $this->setFormAction($this->form, $this->lpa, 'lpa/correspondent/edit');
         $this->lpaApplicationService->shouldReceive('setCorrespondent')
-            ->withArgs(function ($lpa, $correspondent) {
+            ->withArgs(function ($lpa, $correspondent): bool {
                 return $lpa->id === $this->lpa->id
                     && $correspondent->name == new LongName($this->postDataCorrespondence['name'])
                     && $correspondent->email == new EmailAddress($this->postDataCorrespondence['email'])
@@ -426,7 +425,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $controller->editAction();
     }
 
-    public function testEditActionPostSuccess()
+    public function testEditActionPostSuccess(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -438,7 +437,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->form->shouldReceive('getModelDataFromValidatedForm')->andReturn($this->postDataCorrespondence)->once();
         $this->setFormAction($this->form, $this->lpa, 'lpa/correspondent/edit');
         $this->lpaApplicationService->shouldReceive('setCorrespondent')
-            ->withArgs(function ($lpa, $correspondent) {
+            ->withArgs(function ($lpa, $correspondent): bool {
                 return $lpa->id === $this->lpa->id
                     && $correspondent->name == new LongName($this->postDataCorrespondence['name'])
                     && $correspondent->email == new EmailAddress($this->postDataCorrespondence['email'])
@@ -452,7 +451,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('success'));
     }
 
-    public function testEditActionPostSuccessNoJs()
+    public function testEditActionPostSuccessNoJs(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -466,7 +465,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->form->shouldReceive('getModelDataFromValidatedForm')->andReturn($this->postDataCorrespondence)->once();
         $this->setFormAction($this->form, $this->lpa, 'lpa/correspondent/edit');
         $this->lpaApplicationService->shouldReceive('setCorrespondent')
-            ->withArgs(function ($lpa, $correspondent) {
+            ->withArgs(function ($lpa, $correspondent): bool {
                 return $lpa->id === $this->lpa->id
                     && $correspondent->name == new LongName($this->postDataCorrespondence['name'])
                     && $correspondent->email == new EmailAddress($this->postDataCorrespondence['email'])
@@ -479,7 +478,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testEditActionGetReuseDetailsNull()
+    public function testEditActionGetReuseDetailsNull(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -495,7 +494,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testEditActionPostReuseDonorDetailsFormEditable()
+    public function testEditActionPostReuseDonorDetailsFormEditable(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -529,7 +528,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('allowEditButton'));
     }
 
-    public function testEditActionPostReuseDonorDetailsFormNotEditable()
+    public function testEditActionPostReuseDonorDetailsFormNotEditable(): void
     {
         /** @var CorrespondentController $controller */
         $controller = $this->getController(TestableCorrespondentController::class);
@@ -546,7 +545,7 @@ final class CorrespondentControllerTest extends AbstractControllerTestCase
         $this->form->shouldReceive('isValid')->andReturn(true)->once();
         $this->form->shouldReceive('getModelDataFromValidatedForm')->andReturn($this->postDataCorrespondence)->once();
         $this->lpaApplicationService->shouldReceive('setCorrespondent')
-            ->withArgs(function ($lpa, $correspondent) {
+            ->withArgs(function ($lpa, $correspondent): bool {
                 return $lpa->id === $this->lpa->id
                     && $correspondent->name == new LongName($this->postDataCorrespondence['name'])
                     && $correspondent->email == new EmailAddress($this->postDataCorrespondence['email'])

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/DateCheckControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/DateCheckControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\DateCheckController;
@@ -8,15 +10,12 @@ use ApplicationTest\Controller\AbstractControllerTestCase;
 use Mockery;
 use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
+use Mockery\MockInterface;
 
 final class DateCheckControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|DateCheckForm
-     */
-    private $form;
-
-    private $postData = [
+    private MockInterface|DateCheckForm $form;
+    private array $postData = [
         'sign-date-donor'                 => ['day' => 1, 'month' => 2, 'year' => 2016],
         'sign-date-donor-life-sustaining' => ['day' => 1, 'month' => 2, 'year' => 2016],
         'sign-date-attorney-0'  => ['day' => 1, 'month' => 2, 'year' => 2016],
@@ -35,7 +34,7 @@ final class DateCheckControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\Lpa\DateCheckForm', ['lpa' => $this->lpa]])->andReturn($this->form);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var DateCheckController $controller */
         $controller = $this->getController(DateCheckController::class);
@@ -55,7 +54,7 @@ final class DateCheckControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/complete', $result->getVariable('returnRoute'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var DateCheckController $controller */
         $controller = $this->getController(DateCheckController::class);
@@ -75,7 +74,7 @@ final class DateCheckControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/complete', $result->getVariable('returnRoute'));
     }
 
-    public function testIndexActionPostInvalidDates()
+    public function testIndexActionPostInvalidDates(): void
     {
         /** @var DateCheckController $controller */
         $controller = $this->getController(DateCheckController::class);
@@ -102,7 +101,7 @@ final class DateCheckControllerTest extends AbstractControllerTestCase
         $this->assertEquals(null, $result->dateError);
     }
 
-    public function testIndexActionPostValidDates()
+    public function testIndexActionPostValidDates(): void
     {
         /** @var DateCheckController $controller */
         $controller = $this->getController(DateCheckController::class);
@@ -129,7 +128,7 @@ final class DateCheckControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testValidActionNoReturnRoute()
+    public function testValidActionNoReturnRoute(): void
     {
         /** @var DateCheckController $controller */
         $controller = $this->getController(DateCheckController::class);
@@ -144,7 +143,7 @@ final class DateCheckControllerTest extends AbstractControllerTestCase
         $this->assertEquals('user/dashboard', $result->returnRoute);
     }
 
-    public function testValidActionReturnRoute()
+    public function testValidActionReturnRoute(): void
     {
         /** @var DateCheckController $controller */
         $controller = $this->getController(DateCheckController::class);

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/DonorControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/DonorControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\DonorController;
@@ -19,11 +21,8 @@ use Laminas\View\Model\ViewModel;
 
 final class DonorControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|DonorForm
-     */
-    private $form;
-    private $postData = [
+    private MockInterface|DonorForm $form;
+    private array $postData = [
         'name' => [
             'title' => 'Miss',
             'first' => 'Unit',
@@ -45,7 +44,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\Lpa\DonorForm', ['lpa' => $this->lpa]])->andReturn($this->form);
     }
 
-    public function testIndexActionNoDonor()
+    public function testIndexActionNoDonor(): void
     {
         /** @var DonorController $controller */
         $controller = $this->getController(TestableDonorController::class);
@@ -63,7 +62,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/donor/add', $result->addUrl);
     }
 
-    public function testIndexActionDonor()
+    public function testIndexActionDonor(): void
     {
         /** @var DonorController $controller */
         $controller = $this->getController(TestableDonorController::class);
@@ -91,7 +90,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/when-lpa-starts', $result->nextUrl);
     }
 
-    public function testAddActionGetReuseDetails()
+    public function testAddActionGetReuseDetails(): void
     {
         /** @var DonorController $controller */
         $controller = $this->getController(TestableDonorController::class);
@@ -107,7 +106,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionGetDonorAlreadyProvided()
+    public function testAddActionGetDonorAlreadyProvided(): void
     {
         /** @var DonorController $controller */
         $controller = $this->getController(TestableDonorController::class);
@@ -125,7 +124,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionGetNoDonor()
+    public function testAddActionGetNoDonor(): void
     {
         /** @var DonorController $controller */
         $controller = $this->getController(TestableDonorController::class);
@@ -149,7 +148,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $this->assertEquals("lpa/{$this->lpa->id}/donor", $result->cancelUrl);
     }
 
-    public function testAddActionPostInvalid()
+    public function testAddActionPostInvalid(): void
     {
         /** @var DonorController $controller */
         $controller = $this->getController(TestableDonorController::class);
@@ -173,7 +172,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $this->assertEquals("lpa/{$this->lpa->id}/donor", $result->cancelUrl);
     }
 
-    public function testAddActionPostFailed()
+    public function testAddActionPostFailed(): void
     {
         /** @var DonorController $controller */
         $controller = $this->getController(TestableDonorController::class);
@@ -187,7 +186,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
             ->withArgs(['donor', $controller->testGetActorsList()])->once();
         $this->form->shouldReceive('getModelDataFromValidatedForm')->andReturn($this->postData);
         $this->lpaApplicationService->shouldReceive('setDonor')
-            ->withArgs(function ($lpa, $donor) {
+            ->withArgs(function ($lpa, $donor): bool {
                 return $lpa->id === $this->lpa->id
                     && $donor->name == new LongName($this->postData['name'])
                     && $donor->email == new EmailAddress($this->postData['email'])
@@ -200,7 +199,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $controller->addAction();
     }
 
-    public function testAddActionPostSuccess()
+    public function testAddActionPostSuccess(): void
     {
         /** @var DonorController $controller */
         $controller = $this->getController(TestableDonorController::class);
@@ -214,7 +213,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
             ->withArgs(['donor', $controller->testGetActorsList()])->once();
         $this->form->shouldReceive('getModelDataFromValidatedForm')->andReturn($this->postData);
         $this->lpaApplicationService->shouldReceive('setDonor')
-            ->withArgs(function ($lpa, $donor) {
+            ->withArgs(function ($lpa, $donor): bool {
                 return $lpa->id === $this->lpa->id
                     && $donor->name == new LongName($this->postData['name'])
                     && $donor->email == new EmailAddress($this->postData['email'])
@@ -228,7 +227,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('success'));
     }
 
-    public function testEditActionGet()
+    public function testEditActionGet(): void
     {
         /** @var DonorController $controller */
         $controller = $this->getController(TestableDonorController::class);
@@ -253,7 +252,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $this->assertEquals("lpa/{$this->lpa->id}/donor", $result->cancelUrl);
     }
 
-    public function testEditActionPostInvalid()
+    public function testEditActionPostInvalid(): void
     {
         /** @var DonorController $controller */
         $controller = $this->getController(TestableDonorController::class);
@@ -277,7 +276,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $this->assertEquals("lpa/{$this->lpa->id}/donor", $result->cancelUrl);
     }
 
-    public function testEditActionPostFailed()
+    public function testEditActionPostFailed(): void
     {
         /** @var DonorController $controller */
         $controller = $this->getController(TestableDonorController::class);
@@ -290,7 +289,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $this->form->shouldReceive('setActorData')
             ->withArgs(['donor', $controller->testGetActorsList()])->once();
         $this->form->shouldReceive('getModelDataFromValidatedForm')->andReturn($this->postData);
-        $this->lpaApplicationService->shouldReceive('setDonor')->withArgs(function ($lpa, $donor) {
+        $this->lpaApplicationService->shouldReceive('setDonor')->withArgs(function ($lpa, $donor): bool {
             return $lpa->id === $this->lpa->id
                 && $donor->name == new LongName($this->postData['name'])
                 && $donor->email == new EmailAddress($this->postData['email'])
@@ -304,7 +303,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $controller->editAction();
     }
 
-    public function testEditActionPostSuccess()
+    public function testEditActionPostSuccess(): void
     {
         /** @var DonorController $controller */
         $controller = $this->getController(TestableDonorController::class);
@@ -321,7 +320,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
             ->withArgs(['donor', $controller->testGetActorsList()])->once();
         $this->form->shouldReceive('getModelDataFromValidatedForm')->andReturn($postData);
         $this->lpaApplicationService->shouldReceive('setDonor')
-            ->withArgs(function ($lpa, $donor) {
+            ->withArgs(function ($lpa, $donor): bool {
                 return $lpa->id === $this->lpa->id
                     && $donor->name == new LongName($this->postData['name'])
                     && $donor->email == new EmailAddress($this->postData['email'])
@@ -329,7 +328,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
                     && $donor->canSign === false;
             })->andReturn(true)->once();
         $this->lpaApplicationService->shouldReceive('setCorrespondent')
-            ->withArgs(function ($lpa, $correspondent) {
+            ->withArgs(function ($lpa, $correspondent): bool {
                 return $lpa->id === $this->lpa->id
                     && $correspondent->name == new LongName($this->postData['name']); //Only changes name
             })->andReturn(true)->once();
@@ -341,7 +340,7 @@ final class DonorControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('success'));
     }
 
-    private function setDonorBinding()
+    private function setDonorBinding(): void
     {
         $donor = $this->lpa->document->donor->flatten();
         $dob = $this->lpa->document->donor->dob->date;

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/DownloadControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/DownloadControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\DownloadController;
@@ -13,7 +15,7 @@ use Mockery;
 
 final class DownloadControllerTest extends AbstractControllerTestCase
 {
-    public function testIndexActionNoPdfAvailable()
+    public function testIndexActionNoPdfAvailable(): void
     {
         /** @var DownloadController $controller */
         $controller = $this->getController(DownloadController::class);
@@ -28,7 +30,7 @@ final class DownloadControllerTest extends AbstractControllerTestCase
         $this->assertEquals('', $result->getTemplate());
     }
 
-    public function testIndexActionInQueue()
+    public function testIndexActionInQueue(): void
     {
         /** @var DownloadController $controller */
         $controller = $this->getController(DownloadController::class);
@@ -45,7 +47,7 @@ final class DownloadControllerTest extends AbstractControllerTestCase
         $this->assertFalse($result);
     }
 
-    public function testIndexActionLp1Ready()
+    public function testIndexActionLp1Ready(): void
     {
         /** @var DownloadController $controller */
         $controller = $this->getController(DownloadController::class);
@@ -69,7 +71,7 @@ final class DownloadControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionDraftLp1Ready()
+    public function testIndexActionDraftLp1Ready(): void
     {
         /** @var DownloadController $controller */
         $controller = $this->getController(DownloadController::class);
@@ -96,7 +98,7 @@ final class DownloadControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionLp3Ready()
+    public function testIndexActionLp3Ready(): void
     {
         /** @var DownloadController $controller */
         $controller = $this->getController(DownloadController::class);
@@ -124,7 +126,7 @@ final class DownloadControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testDownloadActionInQueue()
+    public function testDownloadActionInQueue(): void
     {
         /** @var DownloadController $controller */
         $controller = $this->getController(DownloadController::class);
@@ -149,7 +151,7 @@ final class DownloadControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testDownloadActionReady()
+    public function testDownloadActionReady(): void
     {
         /** @var DownloadController $controller */
         $controller = $this->getController(DownloadController::class);
@@ -197,7 +199,7 @@ final class DownloadControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    private function setPdfType($controller, $lpa, $pdfType)
+    private function setPdfType($controller, $lpa, string $pdfType): void
     {
         $routeMatch = $this->getRouteMatch($controller);
         $routeMatch->shouldReceive('getParam')->withArgs(['pdf-type'])->andReturn($pdfType)->once();

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/FeeReductionControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/FeeReductionControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\FeeReductionController;
@@ -14,15 +16,9 @@ use Laminas\View\Model\ViewModel;
 
 final class FeeReductionControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|FeeReductionForm
-     */
-    private $form;
-    private $options;
-    /**
-     * @var MockInterface|Select
-     */
-    private $reductionOptions;
+    private MockInterface|FeeReductionForm $form;
+    private array $options;
+    private MockInterface|Select $reductionOptions;
 
     public function setUp() : void
     {
@@ -45,7 +41,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->reductionOptions->shouldReceive('getOptions')->andReturn($this->options);
     }
 
-    public function testIndexActionGetNoPayment()
+    public function testIndexActionGetNoPayment(): void
     {
         /** @var FeeReductionController $controller */
         $controller = $this->getController(FeeReductionController::class);
@@ -65,7 +61,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->assertEquals(4, count($result->getVariable('reductionOptions')));
     }
 
-    public function testIndexActionGetExistingPaymentReducedFeeReceivesBenefits()
+    public function testIndexActionGetExistingPaymentReducedFeeReceivesBenefits(): void
     {
         /** @var FeeReductionController $controller */
         $controller = $this->getController(FeeReductionController::class);
@@ -89,7 +85,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->assertEquals(4, count($result->getVariable('reductionOptions')));
     }
 
-    public function testIndexActionGetExistingPaymentReducedFeeUniversalCredit()
+    public function testIndexActionGetExistingPaymentReducedFeeUniversalCredit(): void
     {
         /** @var FeeReductionController $controller */
         $controller = $this->getController(FeeReductionController::class);
@@ -112,7 +108,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->assertEquals(4, count($result->getVariable('reductionOptions')));
     }
 
-    public function testIndexActionGetExistingPaymentReducedFeeLowIncome()
+    public function testIndexActionGetExistingPaymentReducedFeeLowIncome(): void
     {
         /** @var FeeReductionController $controller */
         $controller = $this->getController(FeeReductionController::class);
@@ -135,7 +131,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->assertEquals(4, count($result->getVariable('reductionOptions')));
     }
 
-    public function testIndexActionGetExistingPaymentReducedFeeNotApply()
+    public function testIndexActionGetExistingPaymentReducedFeeNotApply(): void
     {
         /** @var FeeReductionController $controller */
         $controller = $this->getController(FeeReductionController::class);
@@ -161,7 +157,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->assertEquals(4, count($result->getVariable('reductionOptions')));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var FeeReductionController $controller */
         $controller = $this->getController(FeeReductionController::class);
@@ -180,7 +176,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->assertEquals(4, count($result->getVariable('reductionOptions')));
     }
 
-    public function testIndexActionPostFailed()
+    public function testIndexActionPostFailed(): void
     {
         /** @var FeeReductionController $controller */
         $controller = $this->getController(FeeReductionController::class);
@@ -193,7 +189,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->setPostValid($this->form, $postData);
         $this->form->shouldReceive('getData')->andReturn($postData)->once();
         $this->lpaApplicationService->shouldReceive('setPayment')
-            ->withArgs(function ($lpa, $payment) {
+            ->withArgs(function ($lpa, $payment): bool {
                 return $lpa->id === $this->lpa->id
                     && $payment->reducedFeeReceivesBenefits == true
                     && $payment->reducedFeeAwardedDamages == true
@@ -207,7 +203,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionSuccessReducedFeeUniversalCredit()
+    public function testIndexActionSuccessReducedFeeUniversalCredit(): void
     {
         /** @var FeeReductionController $controller */
         $controller = $this->getController(FeeReductionController::class);
@@ -221,7 +217,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->setPostValid($this->form, $postData);
         $this->form->shouldReceive('getData')->andReturn($postData)->once();
         $this->lpaApplicationService->shouldReceive('setPayment')
-            ->withArgs(function ($lpa, $payment) {
+            ->withArgs(function ($lpa, $payment): bool {
                 return $lpa->id === $this->lpa->id
                     && $payment->reducedFeeReceivesBenefits == false
                     && $payment->reducedFeeAwardedDamages == null
@@ -238,7 +234,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionSuccessReducedFeeLowIncome()
+    public function testIndexActionSuccessReducedFeeLowIncome(): void
     {
         /** @var FeeReductionController $controller */
         $controller = $this->getController(FeeReductionController::class);
@@ -252,7 +248,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->setPostValid($this->form, $postData);
         $this->form->shouldReceive('getData')->andReturn($postData)->once();
         $this->lpaApplicationService->shouldReceive('setPayment')
-            ->withArgs(function ($lpa, $payment) {
+            ->withArgs(function ($lpa, $payment): bool {
                 return $lpa->id === $this->lpa->id
                     && $payment->reducedFeeReceivesBenefits == false
                     && $payment->reducedFeeAwardedDamages == null
@@ -269,7 +265,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionSuccessNotApply()
+    public function testIndexActionSuccessNotApply(): void
     {
         /** @var FeeReductionController $controller */
         $controller = $this->getController(FeeReductionController::class);
@@ -283,7 +279,7 @@ final class FeeReductionControllerTest extends AbstractControllerTestCase
         $this->setPostValid($this->form, $postData);
         $this->form->shouldReceive('getData')->andReturn($postData)->once();
         $this->lpaApplicationService->shouldReceive('setPayment')
-            ->withArgs(function ($lpa, $payment) {
+            ->withArgs(function ($lpa, $payment): bool {
                 return $lpa->id === $this->lpa->id
                     && $payment->reducedFeeReceivesBenefits == null
                     && $payment->reducedFeeAwardedDamages == null

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/HowPrimaryAttorneysMakeDecisionControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/HowPrimaryAttorneysMakeDecisionControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\HowPrimaryAttorneysMakeDecisionController;
@@ -15,11 +17,8 @@ use Laminas\View\Model\ViewModel;
 
 final class HowPrimaryAttorneysMakeDecisionControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|HowAttorneysMakeDecisionForm
-     */
-    private $form;
-    private $postData = [
+    private MockInterface|HowAttorneysMakeDecisionForm $form;
+    private array $postData = [
         'how' => AbstractDecisions::LPA_DECISION_HOW_JOINTLY_AND_SEVERALLY,
         'howDetails' => 'Details'
     ];
@@ -50,7 +49,7 @@ final class HowPrimaryAttorneysMakeDecisionControllerTest extends AbstractContro
         return $controller;
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         $controller = $this->getController(HowPrimaryAttorneysMakeDecisionController::class);
 
@@ -66,7 +65,7 @@ final class HowPrimaryAttorneysMakeDecisionControllerTest extends AbstractContro
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         $controller = $this->getController(HowPrimaryAttorneysMakeDecisionController::class);
 
@@ -81,7 +80,7 @@ final class HowPrimaryAttorneysMakeDecisionControllerTest extends AbstractContro
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostNotChanged()
+    public function testIndexActionPostNotChanged(): void
     {
         $controller = $this->getController(HowPrimaryAttorneysMakeDecisionController::class);
 
@@ -99,7 +98,7 @@ final class HowPrimaryAttorneysMakeDecisionControllerTest extends AbstractContro
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionPostFailed()
+    public function testIndexActionPostFailed(): void
     {
         $controller = $this->getController(HowPrimaryAttorneysMakeDecisionController::class);
 
@@ -112,7 +111,7 @@ final class HowPrimaryAttorneysMakeDecisionControllerTest extends AbstractContro
         $this->form->shouldReceive('setValidationGroup')->withArgs([['how']])->once();
         $this->form->shouldReceive('getData')->andReturn($postData)->once();
         $this->lpaApplicationService->shouldReceive('setPrimaryAttorneyDecisions')
-            ->withArgs(function ($lpa, $primaryAttorneyDecisions) {
+            ->withArgs(function ($lpa, $primaryAttorneyDecisions): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorneyDecisions->how == AbstractDecisions::LPA_DECISION_HOW_JOINTLY
                     && $primaryAttorneyDecisions->howDetails == null;
@@ -126,7 +125,7 @@ final class HowPrimaryAttorneysMakeDecisionControllerTest extends AbstractContro
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionPostSuccess()
+    public function testIndexActionPostSuccess(): void
     {
         $controller = $this->getController(HowPrimaryAttorneysMakeDecisionController::class);
 
@@ -138,7 +137,7 @@ final class HowPrimaryAttorneysMakeDecisionControllerTest extends AbstractContro
         $this->setPostValid($this->form, $postData);
         $this->form->shouldReceive('getData')->andReturn($postData)->twice();
         $this->lpaApplicationService->shouldReceive('setPrimaryAttorneyDecisions')
-            ->withArgs(function ($lpa, $primaryAttorneyDecisions) {
+            ->withArgs(function ($lpa, $primaryAttorneyDecisions): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorneyDecisions->how == AbstractDecisions::LPA_DECISION_HOW_DEPENDS
                     && $primaryAttorneyDecisions->howDetails == 'Details';

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/HowReplacementAttorneysMakeDecisionControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/HowReplacementAttorneysMakeDecisionControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\HowReplacementAttorneysMakeDecisionController;
@@ -14,11 +16,8 @@ use Laminas\View\Model\ViewModel;
 
 final class HowReplacementAttorneysMakeDecisionControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|HowAttorneysMakeDecisionForm
-     */
-    private $form;
-    private $postData = [
+    private MockInterface|HowAttorneysMakeDecisionForm $form;
+    private array $postData = [
         'how' => null,
         'howDetails' => null
     ];
@@ -33,7 +32,7 @@ final class HowReplacementAttorneysMakeDecisionControllerTest extends AbstractCo
             ->andReturn($this->form);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var HowReplacementAttorneysMakeDecisionController $controller */
         $controller = $this->getController(HowReplacementAttorneysMakeDecisionController::class);
@@ -50,7 +49,7 @@ final class HowReplacementAttorneysMakeDecisionControllerTest extends AbstractCo
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var HowReplacementAttorneysMakeDecisionController $controller */
         $controller = $this->getController(HowReplacementAttorneysMakeDecisionController::class);
@@ -66,7 +65,7 @@ final class HowReplacementAttorneysMakeDecisionControllerTest extends AbstractCo
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostNotChanged()
+    public function testIndexActionPostNotChanged(): void
     {
         /** @var HowReplacementAttorneysMakeDecisionController $controller */
         $controller = $this->getController(HowReplacementAttorneysMakeDecisionController::class);
@@ -85,7 +84,7 @@ final class HowReplacementAttorneysMakeDecisionControllerTest extends AbstractCo
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionPostFailed()
+    public function testIndexActionPostFailed(): void
     {
         /** @var HowReplacementAttorneysMakeDecisionController $controller */
         $controller = $this->getController(HowReplacementAttorneysMakeDecisionController::class);
@@ -99,7 +98,7 @@ final class HowReplacementAttorneysMakeDecisionControllerTest extends AbstractCo
         $this->form->shouldReceive('setValidationGroup')->withArgs([['how']])->once();
         $this->form->shouldReceive('getData')->andReturn($postData)->once();
         $this->lpaApplicationService->shouldReceive('setReplacementAttorneyDecisions')
-            ->withArgs(function ($lpa, $replacementAttorneyDecisions) {
+            ->withArgs(function ($lpa, $replacementAttorneyDecisions): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorneyDecisions->how == AbstractDecisions::LPA_DECISION_HOW_JOINTLY
                     && $replacementAttorneyDecisions->howDetails == null;
@@ -113,7 +112,7 @@ final class HowReplacementAttorneysMakeDecisionControllerTest extends AbstractCo
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionPostSuccess()
+    public function testIndexActionPostSuccess(): void
     {
         /** @var HowReplacementAttorneysMakeDecisionController $controller */
         $controller = $this->getController(HowReplacementAttorneysMakeDecisionController::class);
@@ -128,7 +127,7 @@ final class HowReplacementAttorneysMakeDecisionControllerTest extends AbstractCo
         $this->setPostValid($this->form, $postData);
         $this->form->shouldReceive('getData')->andReturn($postData)->twice();
         $this->lpaApplicationService->shouldReceive('setReplacementAttorneyDecisions')
-            ->withArgs(function ($lpa, $replacementAttorneyDecisions) {
+            ->withArgs(function ($lpa, $replacementAttorneyDecisions): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorneyDecisions->how == AbstractDecisions::LPA_DECISION_HOW_DEPENDS
                     && $replacementAttorneyDecisions->howDetails == 'Details';

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/IndexControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/IndexControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\IndexController;
@@ -9,7 +11,7 @@ use Laminas\Http\Response;
 
 final class IndexControllerTest extends AbstractControllerTestCase
 {
-    public function testIndexActionNoSeed()
+    public function testIndexActionNoSeed(): void
     {
         /** @var IndexController $controller */
         $controller = $this->getController(IndexController::class);
@@ -28,7 +30,7 @@ final class IndexControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionSeed()
+    public function testIndexActionSeed(): void
     {
         /** @var IndexController $controller */
         $controller = $this->getController(IndexController::class);

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/InstructionsControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/InstructionsControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\InstructionsController;
@@ -13,11 +15,8 @@ use Laminas\View\Model\ViewModel;
 
 final class InstructionsControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|InstructionsAndPreferencesForm
-     */
-    private $form;
-    private $postData = [
+    private MockInterface|InstructionsAndPreferencesForm $form;
+    private array $postData = [
         'instruction' => 'Unit test instructions',
         'preference' => 'Unit test preferences'
     ];
@@ -32,7 +31,7 @@ final class InstructionsControllerTest extends AbstractControllerTestCase
             ->andReturn($this->form);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var InstructionsController $controller */
         $controller = $this->getController(InstructionsController::class);
@@ -48,7 +47,7 @@ final class InstructionsControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var InstructionsController $controller */
         $controller = $this->getController(InstructionsController::class);
@@ -63,7 +62,7 @@ final class InstructionsControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostInstructionsFailed()
+    public function testIndexActionPostInstructionsFailed(): void
     {
         /** @var InstructionsController $controller */
         $controller = $this->getController(InstructionsController::class);
@@ -79,7 +78,7 @@ final class InstructionsControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionPostPreferencesFailed()
+    public function testIndexActionPostPreferencesFailed(): void
     {
         /** @var InstructionsController $controller */
         $controller = $this->getController(InstructionsController::class);
@@ -97,7 +96,7 @@ final class InstructionsControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionPostSuccess()
+    public function testIndexActionPostSuccess(): void
     {
         /** @var InstructionsController $controller */
         $controller = $this->getController(InstructionsController::class);
@@ -119,7 +118,7 @@ final class InstructionsControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionPostMetadata()
+    public function testIndexActionPostMetadata(): void
     {
         /** @var InstructionsController $controller */
         $controller = $this->getController(InstructionsController::class);

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/LifeSustainingControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/LifeSustainingControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\LifeSustainingController;
@@ -13,11 +15,8 @@ use Laminas\View\Model\ViewModel;
 
 final class LifeSustainingControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|LifeSustainingForm
-     */
-    private $form;
-    private $postData = [
+    private MockInterface|LifeSustainingForm $form;
+    private array $postData = [
         'canSustainLife' => true
     ];
 
@@ -30,7 +29,7 @@ final class LifeSustainingControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\Lpa\LifeSustainingForm', ['lpa' => $this->lpa]])->andReturn($this->form);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var LifeSustainingController $controller */
         $controller = $this->getController(LifeSustainingController::class);
@@ -47,7 +46,7 @@ final class LifeSustainingControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var LifeSustainingController $controller */
         $controller = $this->getController(LifeSustainingController::class);
@@ -62,7 +61,7 @@ final class LifeSustainingControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostFailed()
+    public function testIndexActionPostFailed(): void
     {
         /** @var LifeSustainingController $controller */
         $controller = $this->getController(LifeSustainingController::class);
@@ -80,7 +79,7 @@ final class LifeSustainingControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionPostSuccess()
+    public function testIndexActionPostSuccess(): void
     {
         /** @var LifeSustainingController $controller */
         $controller = $this->getController(LifeSustainingController::class);
@@ -92,7 +91,7 @@ final class LifeSustainingControllerTest extends AbstractControllerTestCase
         $this->setPostValid($this->form, $this->postData);
         $this->form->shouldReceive('getData')->andReturn($this->postData)->once();
         $this->lpaApplicationService->shouldReceive('setPrimaryAttorneyDecisions')
-            ->withArgs(function ($lpa, $primaryAttorneyDecisions) {
+            ->withArgs(function ($lpa, $primaryAttorneyDecisions): bool {
                 return $lpa->id === $this->lpa->id
                         && $primaryAttorneyDecisions->canSustainLife === true;
             })->andReturn(true)->once();

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/MoreInfoRequiredControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/MoreInfoRequiredControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\MoreInfoRequiredController;
@@ -8,7 +10,7 @@ use Laminas\View\Model\ViewModel;
 
 final class MoreInfoRequiredControllerTest extends AbstractControllerTestCase
 {
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         /** @var MoreInfoRequiredController $controller */
         $controller = $this->getController(MoreInfoRequiredController::class);

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/PeopleToNotifyControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/PeopleToNotifyControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\PeopleToNotifyController;
@@ -21,15 +23,9 @@ use Laminas\View\Model\ViewModel;
 
 final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|BlankMainFlowForm
-     */
-    private $blankMainFlowForm;
-    /**
-     * @var MockInterface|PeopleToNotifyForm
-     */
-    private $peopleToNotifyForm;
-    private $postData = [
+    private MockInterface|BlankMainFlowForm $blankMainFlowForm;
+    private MockInterface|PeopleToNotifyForm $peopleToNotifyForm;
+    private array $postData = [
         'name' => [
             'title' => 'Miss',
             'first' => 'Unit',
@@ -74,7 +70,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\Lpa\PeopleToNotifyForm'])->andReturn($this->peopleToNotifyForm);
     }
 
-    public function testIndexActionGetNoPeopleToNotify()
+    public function testIndexActionGetNoPeopleToNotify(): void
     {
         $this->lpa->document->peopleToNotify = [];
 
@@ -96,7 +92,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals([], $result->getVariable('peopleToNotify'));
     }
 
-    public function testIndexActionGetMultiplePeopleToNotify()
+    public function testIndexActionGetMultiplePeopleToNotify(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -119,7 +115,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($expectedPeopleToNotifyParams, $result->getVariable('peopleToNotify'));
     }
 
-    public function testIndexActionGetFivePeopleToNotify()
+    public function testIndexActionGetFivePeopleToNotify(): void
     {
         while (count($this->lpa->document->peopleToNotify) < 5) {
             $this->lpa->document->peopleToNotify[] = FixturesData::getNotifiedPerson();
@@ -146,7 +142,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($expectedPeopleToNotifyParams, $result->getVariable('peopleToNotify'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         $this->lpa->document->peopleToNotify = [];
 
@@ -168,7 +164,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals([], $result->getVariable('peopleToNotify'));
     }
 
-    public function testIndexActionPostUpdateMetadata()
+    public function testIndexActionPostUpdateMetadata(): void
     {
         $this->lpa->document->peopleToNotify = [];
 
@@ -188,7 +184,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionGetReuseDetails()
+    public function testAddActionGetReuseDetails(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -206,7 +202,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionGetFivePeopleToNotify()
+    public function testAddActionGetFivePeopleToNotify(): void
     {
         while (count($this->lpa->document->peopleToNotify) < 5) {
             $this->lpa->document->peopleToNotify[] = FixturesData::getNotifiedPerson();
@@ -226,7 +222,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionGet()
+    public function testAddActionGet(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -246,7 +242,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($cancelUrl, $result->cancelUrl);
     }
 
-    public function testAddActionPostInvalid()
+    public function testAddActionPostInvalid(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -266,7 +262,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($cancelUrl, $result->cancelUrl);
     }
 
-    public function testAddActionPostFailed()
+    public function testAddActionPostFailed(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -277,7 +273,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->peopleToNotifyForm->shouldReceive('setActorData')->once();
         $this->peopleToNotifyForm->shouldReceive('getModelDataFromValidatedForm')->andReturn($this->postData)->once();
         $this->lpaApplicationService->shouldReceive('addNotifiedPerson')
-            ->withArgs(function ($lpa, $notifiedPerson) {
+            ->withArgs(function ($lpa, $notifiedPerson): bool {
                 return $lpa->id === $this->lpa->id
                     && $notifiedPerson->name == new Name($this->postData['name'])
                     && $notifiedPerson->address == new Address($this->postData['address']);
@@ -289,7 +285,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $controller->addAction();
     }
 
-    public function testAddActionPostSuccess()
+    public function testAddActionPostSuccess(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -302,7 +298,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->peopleToNotifyForm->shouldReceive('setActorData')->once();
         $this->peopleToNotifyForm->shouldReceive('getModelDataFromValidatedForm')->andReturn($this->postData)->once();
         $this->lpaApplicationService->shouldReceive('addNotifiedPerson')
-            ->withArgs(function ($lpa, $notifiedPerson) {
+            ->withArgs(function ($lpa, $notifiedPerson): bool {
                 return $lpa->id === $this->lpa->id
                     && $notifiedPerson->name == new Name($this->postData['name'])
                     && $notifiedPerson->address == new Address($this->postData['address']);
@@ -315,7 +311,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionPostMetadata()
+    public function testAddActionPostMetadata(): void
     {
         unset($this->lpa->metadata[Lpa::PEOPLE_TO_NOTIFY_CONFIRMED]);
 
@@ -328,7 +324,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->peopleToNotifyForm->shouldReceive('setActorData')->once();
         $this->peopleToNotifyForm->shouldReceive('getModelDataFromValidatedForm')->andReturn($this->postData)->once();
         $this->lpaApplicationService->shouldReceive('addNotifiedPerson')
-            ->withArgs(function ($lpa, $notifiedPerson) {
+            ->withArgs(function ($lpa, $notifiedPerson): bool {
                 return $lpa->id === $this->lpa->id
                     && $notifiedPerson->name == new Name($this->postData['name'])
                     && $notifiedPerson->address == new Address($this->postData['address']);
@@ -342,7 +338,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('success'));
     }
 
-    public function testAddActionPostReuseDetails()
+    public function testAddActionPostReuseDetails(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -369,7 +365,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($cancelUrl, $result->cancelUrl);
     }
 
-    public function testEditActionInvalidIndex()
+    public function testEditActionInvalidIndex(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -393,7 +389,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Page not found', $result->content);
     }
 
-    public function testEditActionGet()
+    public function testEditActionGet(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -418,7 +414,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($cancelUrl, $result->cancelUrl);
     }
 
-    public function testEditActionPostInvalid()
+    public function testEditActionPostInvalid(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -441,7 +437,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($cancelUrl, $result->cancelUrl);
     }
 
-    public function testEditActionPostFailed()
+    public function testEditActionPostFailed(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -455,7 +451,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->peopleToNotifyForm->shouldReceive('setActorData')->once();
         $this->peopleToNotifyForm->shouldReceive('getModelDataFromValidatedForm')->andReturn($this->postData)->once();
         $this->lpaApplicationService->shouldReceive('setNotifiedPerson')
-            ->withArgs(function ($lpa, $notifiedPerson) {
+            ->withArgs(function ($lpa, $notifiedPerson): bool {
                 return $lpa->id === $this->lpa->id
                     && $notifiedPerson->name == new Name($this->postData['name'])
                     && $notifiedPerson->address == new Address($this->postData['address']);
@@ -467,7 +463,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $controller->editAction();
     }
 
-    public function testEditActionPostSuccess()
+    public function testEditActionPostSuccess(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -481,7 +477,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->peopleToNotifyForm->shouldReceive('setActorData')->once();
         $this->peopleToNotifyForm->shouldReceive('getModelDataFromValidatedForm')->andReturn($this->postData)->once();
         $this->lpaApplicationService->shouldReceive('setNotifiedPerson')
-            ->withArgs(function ($lpa, $notifiedPerson) {
+            ->withArgs(function ($lpa, $notifiedPerson): bool {
                 return $lpa->id === $this->lpa->id
                     && $notifiedPerson->name == new Name($this->postData['name'])
                     && $notifiedPerson->address == new Address($this->postData['address']);
@@ -494,7 +490,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('success'));
     }
 
-    public function testConfirmDeleteActionInvalidIndex()
+    public function testConfirmDeleteActionInvalidIndex(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -517,7 +513,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Page not found', $result->content);
     }
 
-    public function testConfirmDeleteActionGetJs()
+    public function testConfirmDeleteActionGetJs(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -541,7 +537,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->isPopup);
     }
 
-    public function testConfirmDeleteActionGetNoJs()
+    public function testConfirmDeleteActionGetNoJs(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -565,7 +561,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->isPopup);
     }
 
-    public function testDeleteActionInvalidIndex()
+    public function testDeleteActionInvalidIndex(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -588,7 +584,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Page not found', $result->content);
     }
 
-    public function testDeleteActionFailed()
+    public function testDeleteActionFailed(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -606,7 +602,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $controller->deleteAction();
     }
 
-    public function testDeleteActionSuccess()
+    public function testDeleteActionSuccess(): void
     {
         /** @var PeopleToNotifyController $controller */
         $controller = $this->getController(TestablePeopleToNotifyController::class);
@@ -626,10 +622,7 @@ final class PeopleToNotifyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    /**
-     * @return array
-     */
-    private function getExpectedPeopleToNotifyParams()
+    private function getExpectedPeopleToNotifyParams(): array
     {
         $expectedPeopleToNotifyParams = [];
         foreach ($this->lpa->document->peopleToNotify as $idx => $peopleToNotify) {

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/PrimaryAttorneyControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/PrimaryAttorneyControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\PrimaryAttorneyController;
@@ -24,15 +26,9 @@ use Laminas\View\Model\ViewModel;
 
 final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|AttorneyForm
-     */
-    private $primaryAttorneyForm;
-    /**
-     * @var MockInterface|TrustCorporationForm
-     */
-    private $trustCorporationForm;
-    private $postDataHuman = [
+    private MockInterface|AttorneyForm $primaryAttorneyForm;
+    private MockInterface|TrustCorporationForm $trustCorporationForm;
+    private array $postDataHuman = [
         'name' => [
             'title' => 'Miss',
             'first' => 'Unit',
@@ -46,7 +42,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         ],
         'email' => ['address' => 'unit@test.com']
     ];
-    private $postDataTrust = [
+    private array $postDataTrust = [
         'name' => 'Unit Test Company',
         'number' => '0123456789',
         'address' => [
@@ -89,7 +85,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         return $controller;
     }
 
-    public function testIndexActionNoPrimaryAttorneys()
+    public function testIndexActionNoPrimaryAttorneys(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -104,7 +100,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('', $result->getTemplate());
     }
 
-    public function testIndexActionMultiplePrimaryAttorneys()
+    public function testIndexActionMultiplePrimaryAttorneys(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -139,7 +135,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($expectedPrimaryAttorneysParams, $result->attorneys);
     }
 
-    public function testAddActionGetReuseDetails()
+    public function testAddActionGetReuseDetails(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -156,7 +152,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionGet()
+    public function testAddActionGet(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -176,7 +172,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/primary-attorney/add-trust', $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddActionGetExistingTrust()
+    public function testAddActionGetExistingTrust(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -198,7 +194,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(null, $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddActionGetNoTrustHw()
+    public function testAddActionGetNoTrustHw(): void
     {
         $this->lpa = FixturesData::getHwLpa();
         $this->lpa->seed = null;
@@ -221,7 +217,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(null, $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddActionPostInvalid()
+    public function testAddActionPostInvalid(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -241,7 +237,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/primary-attorney/add-trust', $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddActionPostFailed()
+    public function testAddActionPostFailed(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -252,7 +248,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->primaryAttorneyForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataHuman)->once();
         $this->lpaApplicationService->shouldReceive('addPrimaryAttorney')
-            ->withArgs(function ($lpa, $primaryAttorney) {
+            ->withArgs(function ($lpa, $primaryAttorney): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorney->name == new Name($this->postDataHuman['name'])
                     && $primaryAttorney->address == new Address($this->postDataHuman['address'])
@@ -265,7 +261,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $controller->addAction();
     }
 
-    public function testAddActionPostSuccess()
+    public function testAddActionPostSuccess(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -278,7 +274,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->primaryAttorneyForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataHuman)->once();
         $this->lpaApplicationService->shouldReceive('addPrimaryAttorney')
-            ->withArgs(function ($lpa, $primaryAttorney) {
+            ->withArgs(function ($lpa, $primaryAttorney): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorney->name == new Name($this->postDataHuman['name'])
                     && $primaryAttorney->address == new Address($this->postDataHuman['address'])
@@ -294,7 +290,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionPostUpdateWhoIsRegistering()
+    public function testAddActionPostUpdateWhoIsRegistering(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -310,7 +306,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->primaryAttorneyForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataHuman)->once();
         $this->lpaApplicationService->shouldReceive('addPrimaryAttorney')
-            ->withArgs(function ($lpa, $primaryAttorney) {
+            ->withArgs(function ($lpa, $primaryAttorney): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorney->name == new Name($this->postDataHuman['name'])
                     && $primaryAttorney->address == new Address($this->postDataHuman['address'])
@@ -326,7 +322,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionPostReuseDetails()
+    public function testAddActionPostReuseDetails(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -352,7 +348,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/primary-attorney/add-trust', $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddTrustActionGetRedirectToAddHuman()
+    public function testAddTrustActionGetRedirectToAddHuman(): void
     {
         $this->lpa = FixturesData::getHwLpa();
         $this->lpa->seed = null;
@@ -369,7 +365,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddTrustActionGet()
+    public function testAddTrustActionGet(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -388,7 +384,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/primary-attorney/add', $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddTrustActionPostInvalid()
+    public function testAddTrustActionPostInvalid(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -407,7 +403,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/primary-attorney/add', $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddTrustActionPostFailed()
+    public function testAddTrustActionPostFailed(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -417,7 +413,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->trustCorporationForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataTrust)->once();
         $this->lpaApplicationService->shouldReceive('addPrimaryAttorney')
-            ->withArgs(function ($lpa, $primaryAttorney) {
+            ->withArgs(function ($lpa, $primaryAttorney): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorney->name === $this->postDataTrust['name']
                     && $primaryAttorney->number === $this->postDataTrust['number']
@@ -431,7 +427,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $controller->addTrustAction();
     }
 
-    public function testAddTrustActionPostSuccess()
+    public function testAddTrustActionPostSuccess(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -443,7 +439,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->trustCorporationForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataTrust)->once();
         $this->lpaApplicationService->shouldReceive('addPrimaryAttorney')
-            ->withArgs(function ($lpa, $primaryAttorney) {
+            ->withArgs(function ($lpa, $primaryAttorney): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorney->name === $this->postDataTrust['name']
                     && $primaryAttorney->number === $this->postDataTrust['number']
@@ -460,7 +456,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddTrustActionPostReuseDetails()
+    public function testAddTrustActionPostReuseDetails(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -485,7 +481,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/primary-attorney/add', $result->switchAttorneyTypeRoute);
     }
 
-    public function testEditActionInvalidIndex()
+    public function testEditActionInvalidIndex(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -508,7 +504,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Page not found', $result->content);
     }
 
-    public function testEditActionGet()
+    public function testEditActionGet(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -532,7 +528,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($cancelUrl, $result->cancelUrl);
     }
 
-    public function testEditActionGetTrust()
+    public function testEditActionGetTrust(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -556,7 +552,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($cancelUrl, $result->cancelUrl);
     }
 
-    public function testEditActionPostInvalid()
+    public function testEditActionPostInvalid(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -578,7 +574,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($cancelUrl, $result->cancelUrl);
     }
 
-    public function testEditActionPostFailed()
+    public function testEditActionPostFailed(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -592,7 +588,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->primaryAttorneyForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataHuman)->once();
         $this->lpaApplicationService->shouldReceive('setPrimaryAttorney')
-            ->withArgs(function ($lpa, $primaryAttorney, $primaryAttorneyId) {
+            ->withArgs(function ($lpa, $primaryAttorney, $primaryAttorneyId): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorney->name == new Name($this->postDataHuman['name'])
                     && $primaryAttorney->address == new Address($this->postDataHuman['address'])
@@ -606,7 +602,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $controller->editAction();
     }
 
-    public function testEditActionPostSuccess()
+    public function testEditActionPostSuccess(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -620,7 +616,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->primaryAttorneyForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataHuman)->once();
         $this->lpaApplicationService->shouldReceive('setPrimaryAttorney')
-            ->withArgs(function ($lpa, $primaryAttorney, $primaryAttorneyId) {
+            ->withArgs(function ($lpa, $primaryAttorney, $primaryAttorneyId): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorney->name == new Name($this->postDataHuman['name'])
                     && $primaryAttorney->address == new Address($this->postDataHuman['address'])
@@ -635,7 +631,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('success'));
     }
 
-    public function testEditActionPostCorrespondent()
+    public function testEditActionPostCorrespondent(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -656,7 +652,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->primaryAttorneyForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataHuman)->once();
         $this->lpaApplicationService->shouldReceive('setPrimaryAttorney')
-            ->withArgs(function ($lpa, $primaryAttorney, $primaryAttorneyId) {
+            ->withArgs(function ($lpa, $primaryAttorney, $primaryAttorneyId): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorney->name == new Name($this->postDataHuman['name'])
                     && $primaryAttorney->address == new Address($this->postDataHuman['address'])
@@ -665,7 +661,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
             })->andReturn(true)->once();
 
         $this->lpaApplicationService->shouldReceive('setCorrespondent')
-            ->withArgs(function ($lpa, $correspondent) {
+            ->withArgs(function ($lpa, $correspondent): bool {
                 return $lpa->id === $this->lpa->id
                     && $correspondent->name == new LongName($this->postDataHuman['name'])
                     && $correspondent->address == new Address($this->postDataHuman['address']);
@@ -678,7 +674,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('success'));
     }
 
-    public function testEditActionPostSuccessTrust()
+    public function testEditActionPostSuccessTrust(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -692,7 +688,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->trustCorporationForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataTrust)->once();
         $this->lpaApplicationService->shouldReceive('setPrimaryAttorney')
-            ->withArgs(function ($lpa, $primaryAttorney, $primaryAttorneyId) {
+            ->withArgs(function ($lpa, $primaryAttorney, $primaryAttorneyId): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorney->name === $this->postDataTrust['name']
                     && $primaryAttorney->number === $this->postDataTrust['number']
@@ -708,7 +704,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('success'));
     }
 
-    public function testConfirmDeleteActionInvalidIndex()
+    public function testConfirmDeleteActionInvalidIndex(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -730,7 +726,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Page not found', $result->content);
     }
 
-    public function testConfirmDeleteActionGetJs()
+    public function testConfirmDeleteActionGetJs(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -754,7 +750,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->isPopup);
     }
 
-    public function testConfirmDeleteActionGetNoJs()
+    public function testConfirmDeleteActionGetNoJs(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -778,7 +774,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->isPopup);
     }
 
-    public function testConfirmDeleteActionTrust()
+    public function testConfirmDeleteActionTrust(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -803,7 +799,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->isPopup);
     }
 
-    public function testDeleteActionInvalidIndex()
+    public function testDeleteActionInvalidIndex(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -825,7 +821,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Page not found', $result->content);
     }
 
-    public function testDeleteActionFailed()
+    public function testDeleteActionFailed(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -844,7 +840,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $controller->deleteAction();
     }
 
-    public function testDeleteActionSuccess()
+    public function testDeleteActionSuccess(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -867,7 +863,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testDeleteActionOneAttorneyRemaining()
+    public function testDeleteActionOneAttorneyRemaining(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -883,7 +879,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $routeMatch->shouldReceive('getParam')->withArgs(['idx'])->andReturn($idx)->once();
 
         $this->lpaApplicationService->shouldReceive('setPrimaryAttorneyDecisions')
-            ->withArgs(function ($lpa, $primaryAttorneyDecisions) {
+            ->withArgs(function ($lpa, $primaryAttorneyDecisions): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorneyDecisions->how === null
                     && $primaryAttorneyDecisions->howDetails === null;
@@ -901,7 +897,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testDeleteActionAttorneyRegistering()
+    public function testDeleteActionAttorneyRegistering(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 
@@ -926,7 +922,7 @@ final class PrimaryAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testDeleteActionAllAttorneyRegistering()
+    public function testDeleteActionAllAttorneyRegistering(): void
     {
         $controller = $this->getController(TestablePrimaryAttorneyController::class);
 

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/RepeatApplicationControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/RepeatApplicationControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\RepeatApplicationController;
@@ -14,14 +16,11 @@ use Laminas\View\Model\ViewModel;
 
 final class RepeatApplicationControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|RepeatApplicationForm
-     */
-    private $form;
-    private $postDataNoRepeat = [
+    private MockInterface|RepeatApplicationForm $form;
+    private array $postDataNoRepeat = [
         'isRepeatApplication' => 'no-repeat'
     ];
-    private $postDataRepeat = [
+    private array $postDataRepeat = [
         'isRepeatApplication' => 'is-repeat',
         'repeatCaseNumber' => '12345'
     ];
@@ -35,7 +34,7 @@ final class RepeatApplicationControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\Lpa\RepeatApplicationForm', ['lpa' => $this->lpa]])->andReturn($this->form);
     }
 
-    public function testIndexActionGetNotRepeatApplication()
+    public function testIndexActionGetNotRepeatApplication(): void
     {
         unset($this->lpa->metadata[Lpa::REPEAT_APPLICATION_CONFIRMED]);
 
@@ -52,7 +51,7 @@ final class RepeatApplicationControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var RepeatApplicationController $controller */
         $controller = $this->getController(RepeatApplicationController::class);
@@ -71,7 +70,7 @@ final class RepeatApplicationControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostNoRepeatInvalid()
+    public function testIndexActionPostNoRepeatInvalid(): void
     {
         /** @var RepeatApplicationController $controller */
         $controller = $this->getController(RepeatApplicationController::class);
@@ -87,7 +86,7 @@ final class RepeatApplicationControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostRepeatInvalid()
+    public function testIndexActionPostRepeatInvalid(): void
     {
         /** @var RepeatApplicationController $controller */
         $controller = $this->getController(RepeatApplicationController::class);
@@ -102,7 +101,7 @@ final class RepeatApplicationControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostNoRepeatFailed()
+    public function testIndexActionPostNoRepeatFailed(): void
     {
         $this->lpa->repeatCaseNumber = 12345;
 
@@ -121,7 +120,7 @@ final class RepeatApplicationControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionPostRepeatFailed()
+    public function testIndexActionPostRepeatFailed(): void
     {
         /** @var RepeatApplicationController $controller */
         $controller = $this->getController(RepeatApplicationController::class);
@@ -137,7 +136,7 @@ final class RepeatApplicationControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionPostRepeatSetPaymentFailed()
+    public function testIndexActionPostRepeatSetPaymentFailed(): void
     {
         /** @var RepeatApplicationController $controller */
         $controller = $this->getController(RepeatApplicationController::class);
@@ -147,7 +146,7 @@ final class RepeatApplicationControllerTest extends AbstractControllerTestCase
         $this->lpaApplicationService->shouldReceive('setRepeatCaseNumber')
             ->withArgs([$this->lpa, $this->postDataRepeat['repeatCaseNumber']])->andReturn(true)->once();
         $this->lpaApplicationService->shouldReceive('setPayment')
-            ->withArgs(function ($lpa, $payment) {
+            ->withArgs(function ($lpa, $payment): bool {
                 return $lpa->id === $this->lpa->id
                     && $payment->amount === 41.0;
             })->andReturn(false)->once();
@@ -158,7 +157,7 @@ final class RepeatApplicationControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionPostNoRepeatSuccess()
+    public function testIndexActionPostNoRepeatSuccess(): void
     {
         $this->lpa->repeatCaseNumber = 12345;
 
@@ -173,7 +172,7 @@ final class RepeatApplicationControllerTest extends AbstractControllerTestCase
         $this->lpaApplicationService->shouldReceive('deleteRepeatCaseNumber')
             ->withArgs([$this->lpa])->andReturn(true)->once();
         $this->lpaApplicationService->shouldReceive('setPayment')
-            ->withArgs(function ($lpa, $payment) {
+            ->withArgs(function ($lpa, $payment): bool {
                 return $lpa->id === $this->lpa->id
                     && $payment->amount === 82.0;
             })->andReturn(true)->once();

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/ReplacementAttorneyControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/ReplacementAttorneyControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\ReplacementAttorneyController;
@@ -22,19 +24,10 @@ use Laminas\View\Model\ViewModel;
 
 final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|BlankMainFlowForm
-     */
-    private $blankMainFlowForm;
-    /**
-     * @var MockInterface|AttorneyForm
-     */
-    private $replacementAttorneyForm;
-    /**
-     * @var MockInterface|TrustCorporationForm
-     */
-    private $trustCorporationForm;
-    private $postDataHuman = [
+    private MockInterface|BlankMainFlowForm $blankMainFlowForm;
+    private MockInterface|AttorneyForm $replacementAttorneyForm;
+    private MockInterface|TrustCorporationForm $trustCorporationForm;
+    private array $postDataHuman = [
         'name' => [
             'title' => 'Miss',
             'first' => 'Unit',
@@ -48,7 +41,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         ],
         'email' => ['address' => 'unit@test.com']
     ];
-    private $postDataTrust = [
+    private array $postDataTrust = [
         'name' => 'Unit Test Company',
         'number' => '0123456789',
         'address' => [
@@ -81,7 +74,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\Lpa\TrustCorporationForm'])->andReturn($this->trustCorporationForm);
     }
 
-    public function testIndexActionGetNoReplacementAttorney()
+    public function testIndexActionGetNoReplacementAttorney(): void
     {
         $this->lpa->document->replacementAttorneys = [];
 
@@ -103,7 +96,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals([], $result->getVariable('attorneys'));
     }
 
-    public function testIndexActionGetMultipleReplacementAttorney()
+    public function testIndexActionGetMultipleReplacementAttorney(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -124,7 +117,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($expectedAttorneyParams, $result->getVariable('attorneys'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -145,7 +138,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($expectedAttorneyParams, $result->getVariable('attorneys'));
     }
 
-    public function testIndexActionPostSuccess()
+    public function testIndexActionPostSuccess(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -163,7 +156,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionGetReuseDetails()
+    public function testAddActionGetReuseDetails(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -181,7 +174,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionGet()
+    public function testAddActionGet(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -202,7 +195,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/replacement-attorney/add-trust', $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddActionGetExistingTrust()
+    public function testAddActionGetExistingTrust(): void
     {
         $this->lpa->document->replacementAttorneys[] = FixturesData::getAttorneyTrust();
 
@@ -225,7 +218,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(null, $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddActionGetNoTrustHw()
+    public function testAddActionGetNoTrustHw(): void
     {
         $this->lpa = FixturesData::getHwLpa();
         $this->lpa->seed = null;
@@ -249,7 +242,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(null, $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddActionPostInvalid()
+    public function testAddActionPostInvalid(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -270,7 +263,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/replacement-attorney/add-trust', $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddActionPostFailed()
+    public function testAddActionPostFailed(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -282,7 +275,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->replacementAttorneyForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataHuman)->once();
         $this->lpaApplicationService->shouldReceive('addReplacementAttorney')
-            ->withArgs(function ($lpa, $replacementAttorney) {
+            ->withArgs(function ($lpa, $replacementAttorney): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorney->name == new Name($this->postDataHuman['name'])
                     && $replacementAttorney->address == new Address($this->postDataHuman['address'])
@@ -295,7 +288,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $controller->addAction();
     }
 
-    public function testAddActionPostSuccess()
+    public function testAddActionPostSuccess(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -309,7 +302,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->replacementAttorneyForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataHuman)->once();
         $this->lpaApplicationService->shouldReceive('addReplacementAttorney')
-            ->withArgs(function ($lpa, $replacementAttorney) {
+            ->withArgs(function ($lpa, $replacementAttorney): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorney->name == new Name($this->postDataHuman['name'])
                     && $replacementAttorney->address == new Address($this->postDataHuman['address'])
@@ -324,7 +317,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionPostMetadata()
+    public function testAddActionPostMetadata(): void
     {
         unset($this->lpa->metadata[Lpa::REPLACEMENT_ATTORNEYS_CONFIRMED]);
 
@@ -340,7 +333,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->replacementAttorneyForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataHuman)->once();
         $this->lpaApplicationService->shouldReceive('addReplacementAttorney')
-            ->withArgs(function ($lpa, $replacementAttorney) {
+            ->withArgs(function ($lpa, $replacementAttorney): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorney->name == new Name($this->postDataHuman['name'])
                     && $replacementAttorney->address == new Address($this->postDataHuman['address'])
@@ -356,7 +349,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddActionPostReuseDetails()
+    public function testAddActionPostReuseDetails(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -384,7 +377,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/replacement-attorney/add-trust', $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddTrustActionGetRedirectToAddHuman()
+    public function testAddTrustActionGetRedirectToAddHuman(): void
     {
         $this->lpa = FixturesData::getHwLpa();
         $this->lpa->seed = null;
@@ -402,7 +395,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddTrustActionGet()
+    public function testAddTrustActionGet(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -422,7 +415,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/replacement-attorney/add', $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddTrustActionPostInvalid()
+    public function testAddTrustActionPostInvalid(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -442,7 +435,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/replacement-attorney/add', $result->switchAttorneyTypeRoute);
     }
 
-    public function testAddTrustActionPostFailed()
+    public function testAddTrustActionPostFailed(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -453,7 +446,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->trustCorporationForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataTrust)->once();
         $this->lpaApplicationService->shouldReceive('addReplacementAttorney')
-            ->withArgs(function ($lpa, $replacementAttorney) {
+            ->withArgs(function ($lpa, $replacementAttorney): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorney->name === $this->postDataTrust['name']
                     && $replacementAttorney->number === $this->postDataTrust['number']
@@ -467,7 +460,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $controller->addTrustAction();
     }
 
-    public function testAddTrustActionPostSuccess()
+    public function testAddTrustActionPostSuccess(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -480,7 +473,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->trustCorporationForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataTrust)->once();
         $this->lpaApplicationService->shouldReceive('addReplacementAttorney')
-            ->withArgs(function ($lpa, $replacementAttorney) {
+            ->withArgs(function ($lpa, $replacementAttorney): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorney->name === $this->postDataTrust['name']
                     && $replacementAttorney->number === $this->postDataTrust['number']
@@ -496,7 +489,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddTrustActionPostMetadata()
+    public function testAddTrustActionPostMetadata(): void
     {
         unset($this->lpa->metadata[Lpa::REPLACEMENT_ATTORNEYS_CONFIRMED]);
 
@@ -511,7 +504,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->trustCorporationForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataTrust)->once();
         $this->lpaApplicationService->shouldReceive('addReplacementAttorney')
-            ->withArgs(function ($lpa, $replacementAttorney) {
+            ->withArgs(function ($lpa, $replacementAttorney): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorney->name === $this->postDataTrust['name']
                     && $replacementAttorney->number === $this->postDataTrust['number']
@@ -528,7 +521,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testAddTrustActionPostReuseDetails()
+    public function testAddTrustActionPostReuseDetails(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -555,7 +548,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('lpa/replacement-attorney/add', $result->switchAttorneyTypeRoute);
     }
 
-    public function testEditActionInvalidIndex()
+    public function testEditActionInvalidIndex(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -579,7 +572,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Page not found', $result->content);
     }
 
-    public function testEditActionGet()
+    public function testEditActionGet(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -604,7 +597,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($cancelUrl, $result->cancelUrl);
     }
 
-    public function testEditActionGetTrust()
+    public function testEditActionGetTrust(): void
     {
         $this->lpa->document->replacementAttorneys[] = FixturesData::getAttorneyTrust();
 
@@ -629,7 +622,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($cancelUrl, $result->cancelUrl);
     }
 
-    public function testEditActionPostInvalid()
+    public function testEditActionPostInvalid(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -652,7 +645,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($cancelUrl, $result->cancelUrl);
     }
 
-    public function testEditActionPostFailed()
+    public function testEditActionPostFailed(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -667,7 +660,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->replacementAttorneyForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataHuman)->once();
         $this->lpaApplicationService->shouldReceive('setReplacementAttorney')
-            ->withArgs(function ($lpa, $replacementAttorney, $replacementAttorneyId) {
+            ->withArgs(function ($lpa, $replacementAttorney, $replacementAttorneyId): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorney->name == new Name($this->postDataHuman['name'])
                     && $replacementAttorney->address == new Address($this->postDataHuman['address'])
@@ -681,7 +674,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $controller->editAction();
     }
 
-    public function testEditActionPostSuccess()
+    public function testEditActionPostSuccess(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -696,7 +689,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->replacementAttorneyForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataHuman)->once();
         $this->lpaApplicationService->shouldReceive('setReplacementAttorney')
-            ->withArgs(function ($lpa, $replacementAttorney, $replacementAttorneyId) {
+            ->withArgs(function ($lpa, $replacementAttorney, $replacementAttorneyId): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorney->name == new Name($this->postDataHuman['name'])
                     && $replacementAttorney->address == new Address($this->postDataHuman['address'])
@@ -711,7 +704,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('success'));
     }
 
-    public function testEditActionPostSuccessTrust()
+    public function testEditActionPostSuccessTrust(): void
     {
         $this->lpa->document->replacementAttorneys[] = FixturesData::getAttorneyTrust();
 
@@ -727,7 +720,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->trustCorporationForm->shouldReceive('getModelDataFromValidatedForm')
             ->andReturn($this->postDataTrust)->once();
         $this->lpaApplicationService->shouldReceive('setReplacementAttorney')
-            ->withArgs(function ($lpa, $replacementAttorney, $replacementAttorneyId) {
+            ->withArgs(function ($lpa, $replacementAttorney, $replacementAttorneyId): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorney->name === $this->postDataTrust['name']
                     && $replacementAttorney->number === $this->postDataTrust['number']
@@ -743,7 +736,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('success'));
     }
 
-    public function testConfirmDeleteActionInvalidIndex()
+    public function testConfirmDeleteActionInvalidIndex(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -766,7 +759,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Page not found', $result->content);
     }
 
-    public function testConfirmDeleteActionGetJs()
+    public function testConfirmDeleteActionGetJs(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -791,7 +784,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->isPopup);
     }
 
-    public function testConfirmDeleteActionGetNoJs()
+    public function testConfirmDeleteActionGetNoJs(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -816,7 +809,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->isPopup);
     }
 
-    public function testConfirmDeleteActionTrust()
+    public function testConfirmDeleteActionTrust(): void
     {
         $this->lpa->document->replacementAttorneys[] = FixturesData::getAttorneyTrust();
 
@@ -842,7 +835,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->isPopup);
     }
 
-    public function testDeleteActionInvalidIndex()
+    public function testDeleteActionInvalidIndex(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -865,7 +858,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Page not found', $result->content);
     }
 
-    public function testDeleteActionFailed()
+    public function testDeleteActionFailed(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -884,7 +877,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $controller->deleteAction();
     }
 
-    public function testDeleteActionSuccess()
+    public function testDeleteActionSuccess(): void
     {
         /** @var ReplacementAttorneyController $controller */
         $controller = $this->getController(TestableReplacementAttorneyController::class);
@@ -905,10 +898,7 @@ final class ReplacementAttorneyControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    /**
-     * @return array
-     */
-    private function getExpectedAttorneyParams()
+    private function getExpectedAttorneyParams(): array
     {
         $expectedAttorneyParams = [];
         foreach ($this->lpa->document->replacementAttorneys as $idx => $attorney) {

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/ReuseDetailsControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/ReuseDetailsControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\ReuseDetailsController;
@@ -14,11 +16,8 @@ use Laminas\View\Model\ViewModel;
 
 final class ReuseDetailsControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|ReuseDetailsForm
-     */
-    private $form;
-    private $postData = [
+    private MockInterface|ReuseDetailsForm $form;
+    private array $postData = [
         'reuse-details' => 1
     ];
 
@@ -39,7 +38,7 @@ final class ReuseDetailsControllerTest extends AbstractControllerTestCase
         return $controller;
     }
 
-    public function testIndexActionRequiredDataMissing()
+    public function testIndexActionRequiredDataMissing(): void
     {
         $controller = $this->getController(TestableReuseDetailsController::class);
 
@@ -52,7 +51,7 @@ final class ReuseDetailsControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionGetMissingParameters()
+    public function testIndexActionGetMissingParameters(): void
     {
         $controller = $this->getController(TestableReuseDetailsController::class);
 
@@ -71,7 +70,7 @@ final class ReuseDetailsControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         $controller = $this->getController(TestableReuseDetailsController::class);
 
@@ -107,7 +106,7 @@ final class ReuseDetailsControllerTest extends AbstractControllerTestCase
         $this->assertEquals($queryParameters['actor-name'], $result->actorName);
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         $controller = $this->getController(TestableReuseDetailsController::class);
 
@@ -144,7 +143,7 @@ final class ReuseDetailsControllerTest extends AbstractControllerTestCase
         $this->assertEquals($queryParameters['actor-name'], $result->actorName);
     }
 
-    public function testIndexActionPostInvalidRouteMatch()
+    public function testIndexActionPostInvalidRouteMatch(): void
     {
         $controller = $this->getController(TestableReuseDetailsController::class);
 
@@ -186,7 +185,7 @@ final class ReuseDetailsControllerTest extends AbstractControllerTestCase
         $this->assertEquals($queryParameters['actor-name'], $result->actorName);
     }
 
-    public function testIndexActionPostPrimaryAttorneyAdd()
+    public function testIndexActionPostPrimaryAttorneyAdd(): void
     {
         $controller = $this->getController(TestableReuseDetailsController::class);
 

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/StatusControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/StatusControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\StatusController;
@@ -12,7 +14,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 final class StatusControllerTest extends AbstractControllerTestCase
 {
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         /** @var StatusController $controller */
         $controller = $this->getController(TestableStatusController::class);
@@ -28,7 +30,7 @@ final class StatusControllerTest extends AbstractControllerTestCase
         $this->assertEquals('', $result->getTemplate());
     }
 
-    public function testIndexActionWithReturnUnpaid()
+    public function testIndexActionWithReturnUnpaid(): void
     {
         /** @var StatusController $controller */
         $controller = $this->getController(TestableStatusController::class);
@@ -44,7 +46,7 @@ final class StatusControllerTest extends AbstractControllerTestCase
         $this->assertEquals('', $result->getTemplate());
     }
 
-    public function testIndexActionInvalidStatus()
+    public function testIndexActionInvalidStatus(): void
     {
         /** @var StatusController $controller */
         $controller = $this->getController(TestableStatusController::class);
@@ -66,7 +68,7 @@ final class StatusControllerTest extends AbstractControllerTestCase
      * @param $status
      */
     #[DataProvider('statusProvider')]
-    public function testIndexActionWithValidStatuses($status)
+    public function testIndexActionWithValidStatuses(string $status): void
     {
         /** @var StatusController $controller */
         $controller = $this->getController(TestableStatusController::class);
@@ -79,7 +81,7 @@ final class StatusControllerTest extends AbstractControllerTestCase
 
         $this->assertInstanceOf(ViewModel::class, $result);
     }
-    static public function statusProvider()
+    static public function statusProvider(): array
     {
         return[
             ['waiting'],
@@ -90,7 +92,7 @@ final class StatusControllerTest extends AbstractControllerTestCase
         ];
     }
 
-    public function testIndexActionResultContainsCanGenerateLPA120()
+    public function testIndexActionResultContainsCanGenerateLPA120(): void
     {
         /** @var StatusController $controller */
         $controller = $this->getController(TestableStatusController::class);
@@ -114,7 +116,7 @@ final class StatusControllerTest extends AbstractControllerTestCase
      *
      */
     #[DataProvider('processedDateFixtureProvider')]
-    public function testIndexActionProcessedDateGeneration($dates, $shouldReceiveByDate)
+    public function testIndexActionProcessedDateGeneration(array $dates, ?string $shouldReceiveByDate): void
     {
         if (!is_null($shouldReceiveByDate)) {
             $shouldReceiveByDate = new DateTime($shouldReceiveByDate);
@@ -165,7 +167,7 @@ final class StatusControllerTest extends AbstractControllerTestCase
         $this->assertEquals($result->shouldReceiveByDate, $shouldReceiveByDate);
     }
 
-    static public function processedDateFixtureProvider()
+    static public function processedDateFixtureProvider(): array
     {
         /*
          * Each element in the returned array represents the data for a test

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/SummaryControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/SummaryControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\SummaryController;
@@ -8,7 +10,7 @@ use Laminas\View\Model\ViewModel;
 
 final class SummaryControllerTest extends AbstractControllerTestCase
 {
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         /** @var SummaryController $controller */
         $controller = $this->getController(SummaryController::class);

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestableCertificateProviderController.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestableCertificateProviderController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\CertificateProviderController;

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestableCorrespondentController.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestableCorrespondentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\CorrespondentController;

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestableDonorController.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestableDonorController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\DonorController;

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestablePeopleToNotifyController.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestablePeopleToNotifyController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\PeopleToNotifyController;

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestablePrimaryAttorneyController.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestablePrimaryAttorneyController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\PrimaryAttorneyController;

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestableReplacementAttorneyController.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestableReplacementAttorneyController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\ReplacementAttorneyController;

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestableReuseDetailsController.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestableReuseDetailsController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\ReuseDetailsController;

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestableStatusController.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/TestableStatusController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\StatusController;
@@ -12,4 +14,3 @@ class TestableStatusController extends StatusController
         return parent::checkAuthenticated($allowRedirect);
     }
 }
-

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/TypeControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/TypeControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\TypeController;
@@ -14,11 +16,8 @@ use Laminas\View\Model\ViewModel;
 
 final class TypeControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|TypeForm
-     */
-    private $form;
-    private $postData = [
+    private MockInterface|TypeForm $form;
+    private array $postData = [
         'type' => Document::LPA_TYPE_HW
     ];
 
@@ -31,7 +30,7 @@ final class TypeControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\Lpa\TypeForm'])->andReturn($this->form);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var TypeController $controller */
         $controller = $this->getController(TypeController::class);
@@ -56,7 +55,7 @@ final class TypeControllerTest extends AbstractControllerTestCase
         $this->assertEquals('', $result->getVariable('isChangeAllowed'));
     }
 
-    public function testIndexActionGetNoType()
+    public function testIndexActionGetNoType(): void
     {
         $this->lpa->document = new Document();
 
@@ -83,7 +82,7 @@ final class TypeControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('isChangeAllowed'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var TypeController $controller */
         $controller = $this->getController(TypeController::class);
@@ -107,7 +106,7 @@ final class TypeControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('isChangeAllowed'));
     }
 
-    public function testIndexActionPostFailed()
+    public function testIndexActionPostFailed(): void
     {
         /** @var TypeController $controller */
         $controller = $this->getController(TypeController::class);
@@ -123,7 +122,7 @@ final class TypeControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionPostSuccess()
+    public function testIndexActionPostSuccess(): void
     {
         /** @var TypeController $controller */
         $controller = $this->getController(TypeController::class);

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/WhenLpaStartsControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/WhenLpaStartsControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\WhenLpaStartsController;
@@ -14,11 +16,8 @@ use Laminas\View\Model\ViewModel;
 
 final class WhenLpaStartsControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|WhenLpaStartsForm
-     */
-    private $form;
-    private $postData = [
+    private MockInterface|WhenLpaStartsForm $form;
+    private array $postData = [
         'when' => PrimaryAttorneyDecisions::LPA_DECISION_WHEN_NO_CAPACITY
     ];
 
@@ -31,7 +30,7 @@ final class WhenLpaStartsControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\Lpa\WhenLpaStartsForm', ['lpa' => $this->lpa]])->andReturn($this->form);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var WhenLpaStartsController $controller */
         $controller = $this->getController(WhenLpaStartsController::class);
@@ -48,7 +47,7 @@ final class WhenLpaStartsControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var WhenLpaStartsController $controller */
         $controller = $this->getController(WhenLpaStartsController::class);
@@ -63,7 +62,7 @@ final class WhenLpaStartsControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostFailed()
+    public function testIndexActionPostFailed(): void
     {
         /** @var WhenLpaStartsController $controller */
         $controller = $this->getController(WhenLpaStartsController::class);
@@ -72,7 +71,7 @@ final class WhenLpaStartsControllerTest extends AbstractControllerTestCase
         $this->setPostValid($this->form, $this->postData);
         $this->form->shouldReceive('getData')->andReturn($this->postData)->once();
         $this->lpaApplicationService->shouldReceive('setPrimaryAttorneyDecisions')
-            ->withArgs(function ($lpa, $primaryAttorneyDecisions) {
+            ->withArgs(function ($lpa, $primaryAttorneyDecisions): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorneyDecisions->when === $this->postData['when'];
             })->andReturn(false)->once();
@@ -83,7 +82,7 @@ final class WhenLpaStartsControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionPostSuccess()
+    public function testIndexActionPostSuccess(): void
     {
         /** @var WhenLpaStartsController $controller */
         $controller = $this->getController(WhenLpaStartsController::class);
@@ -93,7 +92,7 @@ final class WhenLpaStartsControllerTest extends AbstractControllerTestCase
         $this->setPostValid($this->form, $this->postData);
         $this->form->shouldReceive('getData')->andReturn($this->postData)->once();
         $this->lpaApplicationService->shouldReceive('setPrimaryAttorneyDecisions')
-            ->withArgs(function ($lpa, $primaryAttorneyDecisions) {
+            ->withArgs(function ($lpa, $primaryAttorneyDecisions): bool {
                 return $lpa->id === $this->lpa->id
                     && $primaryAttorneyDecisions->when === $this->postData['when'];
             })->andReturn(true)->once();

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/WhenReplacementAttorneyStepInControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/WhenReplacementAttorneyStepInControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\WhenReplacementAttorneyStepInController;
@@ -14,18 +16,12 @@ use Laminas\View\Model\ViewModel;
 
 final class WhenReplacementAttorneyStepInControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|WhenReplacementAttorneyStepInForm
-     */
-    private $form;
-    private $postDataDepends = [
+    private MockInterface|WhenReplacementAttorneyStepInForm $form;
+    private array $postDataDepends = [
         'when' => ReplacementAttorneyDecisions::LPA_DECISION_WHEN_DEPENDS,
         'whenDetails' => 'Unit test instruction'
     ];
-    private $postDataFirst = [
-        'when' => ReplacementAttorneyDecisions::LPA_DECISION_WHEN_FIRST
-    ];
-    private $postDataLast = [
+    private array $postDataLast = [
         'when' => ReplacementAttorneyDecisions::LPA_DECISION_WHEN_LAST
     ];
 
@@ -39,7 +35,7 @@ final class WhenReplacementAttorneyStepInControllerTest extends AbstractControll
             ->andReturn($this->form);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var WhenReplacementAttorneyStepInController $controller */
         $controller = $this->getController(WhenReplacementAttorneyStepInController::class);
@@ -56,7 +52,7 @@ final class WhenReplacementAttorneyStepInControllerTest extends AbstractControll
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var WhenReplacementAttorneyStepInController $controller */
         $controller = $this->getController(WhenReplacementAttorneyStepInController::class);
@@ -71,7 +67,7 @@ final class WhenReplacementAttorneyStepInControllerTest extends AbstractControll
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testIndexActionPostFailed()
+    public function testIndexActionPostFailed(): void
     {
         /** @var WhenReplacementAttorneyStepInController $controller */
         $controller = $this->getController(WhenReplacementAttorneyStepInController::class);
@@ -80,7 +76,7 @@ final class WhenReplacementAttorneyStepInControllerTest extends AbstractControll
         $this->form->shouldReceive('setValidationGroup')->withArgs([['when']])->once();
         $this->form->shouldReceive('getData')->andReturn($this->postDataLast)->once();
         $this->lpaApplicationService->shouldReceive('setReplacementAttorneyDecisions')
-            ->withArgs(function ($lpa, $replacementAttorneyDecisions) {
+            ->withArgs(function ($lpa, $replacementAttorneyDecisions): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorneyDecisions->when === $this->postDataLast['when'];
             })->andReturn(false)->once();
@@ -91,7 +87,7 @@ final class WhenReplacementAttorneyStepInControllerTest extends AbstractControll
         $controller->indexAction();
     }
 
-    public function testIndexActionPostSuccess()
+    public function testIndexActionPostSuccess(): void
     {
         /** @var WhenReplacementAttorneyStepInController $controller */
         $controller = $this->getController(WhenReplacementAttorneyStepInController::class);
@@ -102,7 +98,7 @@ final class WhenReplacementAttorneyStepInControllerTest extends AbstractControll
         $this->form->shouldReceive('setValidationGroup')->withArgs([['when']])->once();
         $this->form->shouldReceive('getData')->andReturn($this->postDataLast)->once();
         $this->lpaApplicationService->shouldReceive('setReplacementAttorneyDecisions')
-            ->withArgs(function ($lpa, $replacementAttorneyDecisions) {
+            ->withArgs(function ($lpa, $replacementAttorneyDecisions): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorneyDecisions->when === $this->postDataLast['when'];
             })->andReturn(true)->once();
@@ -116,7 +112,7 @@ final class WhenReplacementAttorneyStepInControllerTest extends AbstractControll
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionPostSuccessDepends()
+    public function testIndexActionPostSuccessDepends(): void
     {
         /** @var WhenReplacementAttorneyStepInController $controller */
         $controller = $this->getController(WhenReplacementAttorneyStepInController::class);
@@ -127,7 +123,7 @@ final class WhenReplacementAttorneyStepInControllerTest extends AbstractControll
         $this->setPostValid($this->form, $this->postDataDepends);
         $this->form->shouldReceive('getData')->andReturn($this->postDataDepends)->twice();
         $this->lpaApplicationService->shouldReceive('setReplacementAttorneyDecisions')
-            ->withArgs(function ($lpa, $replacementAttorneyDecisions) {
+            ->withArgs(function ($lpa, $replacementAttorneyDecisions): bool {
                 return $lpa->id === $this->lpa->id
                     && $replacementAttorneyDecisions->when === $this->postDataDepends['when']
                     && $replacementAttorneyDecisions->whenDetails === $this->postDataDepends['whenDetails'];

--- a/service-front/module/Application/tests/Controller/Authenticated/Lpa/WhoAreYouControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/Lpa/WhoAreYouControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated\Lpa;
 
 use Application\Controller\Authenticated\Lpa\WhoAreYouController;
@@ -14,21 +16,10 @@ use Mockery\MockInterface;
 
 final class WhoAreYouControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|WhoAreYouForm
-     */
-    private $form;
-
-    private $who;
-    /**
-     * @var MockInterface|Select
-     */
-    private $whoOptions;
-    /**
-     * @var MockInterface|Select
-     */
-    private $professionalOptions;
-    private $postData = [
+    private MockInterface|WhoAreYouForm $form;
+    private array $who;
+    private MockInterface|Select $whoOptions;
+    private array $postData = [
         'who' => 'donor'
     ];
 
@@ -57,11 +48,9 @@ final class WhoAreYouControllerTest extends AbstractControllerTestCase
 
         $this->whoOptions = Mockery::mock(Select::class);
         $this->whoOptions->shouldReceive('getOptions')->andReturn($this->who);
-
-        $this->professionalOptions = Mockery::mock(Select::class);
     }
 
-    public function testIndexActionGetWhoAreYouAnsweredTrue()
+    public function testIndexActionGetWhoAreYouAnsweredTrue(): void
     {
         $this->lpa->whoAreYouAnswered = true;
 
@@ -79,7 +68,7 @@ final class WhoAreYouControllerTest extends AbstractControllerTestCase
         $this->assertEquals($nextUrl, $result->nextUrl);
     }
 
-    public function testIndexActionGetWhoAreYouAnsweredFalse()
+    public function testIndexActionGetWhoAreYouAnsweredFalse(): void
     {
         $this->lpa->whoAreYouAnswered = false;
 
@@ -101,7 +90,7 @@ final class WhoAreYouControllerTest extends AbstractControllerTestCase
         $this->assertEquals(10, count($result->getVariable('whoOptions')));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         $this->lpa->whoAreYouAnswered = false;
 
@@ -123,7 +112,7 @@ final class WhoAreYouControllerTest extends AbstractControllerTestCase
         $this->assertEquals(10, count($result->getVariable('whoOptions')));
     }
 
-    public function testIndexActionPostFailed()
+    public function testIndexActionPostFailed(): void
     {
         $this->lpa->whoAreYouAnswered = false;
 
@@ -142,7 +131,7 @@ final class WhoAreYouControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexActionPostSuccess()
+    public function testIndexActionPostSuccess(): void
     {
         $this->lpa->whoAreYouAnswered = false;
 

--- a/service-front/module/Application/tests/Controller/Authenticated/PostcodeControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/PostcodeControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated;
 
 use Application\Controller\Authenticated\PostcodeController;
@@ -41,7 +43,7 @@ final class PostcodeControllerTest extends AbstractControllerTestCase
         return $controller;
     }
 
-    public function testIndexActionPostcodeNotFound()
+    public function testIndexActionPostcodeNotFound(): void
     {
         $controller = $this->getController(PostcodeController::class);
 
@@ -57,7 +59,7 @@ final class PostcodeControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Page not found', $result->getVariable('content'));
     }
 
-    public function testIndexActionSinglePostcode()
+    public function testIndexActionSinglePostcode(): void
     {
         $controller = $this->getController(PostcodeController::class);
 

--- a/service-front/module/Application/tests/Controller/Authenticated/SessionKeepAliveControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/SessionKeepAliveControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated;
 
 use Application\Controller\Authenticated\SessionKeepAliveController;

--- a/service-front/module/Application/tests/Controller/Authenticated/TestableDashboardController.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/TestableDashboardController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated;
 
 use Application\Controller\Authenticated\DashboardController;

--- a/service-front/module/Application/tests/Controller/Authenticated/TestableDeleteController.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/TestableDeleteController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated;
 
 use Application\Controller\Authenticated\DeleteController;

--- a/service-front/module/Application/tests/Controller/Authenticated/TypeControllerTest.php
+++ b/service-front/module/Application/tests/Controller/Authenticated/TypeControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\Authenticated;
 
 use Application\Controller\Authenticated\TypeController;
@@ -15,11 +17,8 @@ use RuntimeException;
 
 final class TypeControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|TypeForm
-     */
-    private $form;
-    private $postData = [
+    private MockInterface|TypeForm $form;
+    private array $postData = [
         'type' => 'property-and-financial'
     ];
 
@@ -32,7 +31,7 @@ final class TypeControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\Lpa\TypeForm'])->andReturn($this->form);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         /** @var TypeController $controller */
         $controller = $this->getController(TypeController::class);
@@ -48,7 +47,7 @@ final class TypeControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('isChangeAllowed'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         /** @var TypeController $controller */
         $controller = $this->getController(TypeController::class);
@@ -64,7 +63,7 @@ final class TypeControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('isChangeAllowed'));
     }
 
-    public function testIndexActionPostCreationError()
+    public function testIndexActionPostCreationError(): void
     {
         /** @var TypeController $controller */
         $controller = $this->getController(TypeController::class);
@@ -82,7 +81,7 @@ final class TypeControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionPostSetTypeException()
+    public function testIndexActionPostSetTypeException(): void
     {
         /** @var TypeController $controller */
         $controller = $this->getController(TypeController::class);
@@ -100,7 +99,7 @@ final class TypeControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         /** @var TypeController $controller */
         $controller = $this->getController(TypeController::class);

--- a/service-front/module/Application/tests/Controller/General/AuthControllerCookieTest.php
+++ b/service-front/module/Application/tests/Controller/General/AuthControllerCookieTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\General;
 
 use Application\Controller\General\AuthController;
@@ -12,7 +14,7 @@ use Laminas\View\Model\ViewModel;
 
 final class AuthControllerCookieTest extends AbstractControllerTestCase
 {
-    public function testIndexActionAlreadySignedIn()
+    public function testIndexActionAlreadySignedIn(): void
     {
         /** @var AuthController $controller */
         $controller = $this->getController(AuthController::class);
@@ -26,7 +28,7 @@ final class AuthControllerCookieTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionCheckCookieFails()
+    public function testIndexActionCheckCookieFails(): void
     {
         $this->setIdentity(null);
 
@@ -45,7 +47,7 @@ final class AuthControllerCookieTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionCheckCookieRedirect()
+    public function testIndexActionCheckCookieRedirect(): void
     {
         $this->setIdentity(null);
 
@@ -65,7 +67,7 @@ final class AuthControllerCookieTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionCheckCookieExistsFalse()
+    public function testIndexActionCheckCookieExistsFalse(): void
     {
         $this->setIdentity(null);
 
@@ -89,7 +91,7 @@ final class AuthControllerCookieTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionCheckCookieExists()
+    public function testIndexActionCheckCookieExists(): void
     {
         $this->setIdentity(null);
 
@@ -119,7 +121,7 @@ final class AuthControllerCookieTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('isTimeout'));
     }
 
-    public function testIndexActionCheckCookiePost()
+    public function testIndexActionCheckCookiePost(): void
     {
         $this->setIdentity(null);
 

--- a/service-front/module/Application/tests/Controller/General/AuthControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/AuthControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\General;
 
 use Application\Controller\General\AuthController;
@@ -19,11 +21,8 @@ use DateTime;
 
 final class AuthControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|Login
-     */
-    private $form;
-    private $postData = [
+    private MockInterface|Login $form;
+    private array $postData = [
         'email' => 'unit@test.com',
         'password' => 'unitTest'
     ];
@@ -59,7 +58,7 @@ final class AuthControllerTest extends AbstractControllerTestCase
         return $controller;
     }
 
-    public function testIndexActionFormInvalid()
+    public function testIndexActionFormInvalid(): void
     {
         $controller = $this->getController(AuthController::class);
 
@@ -75,7 +74,7 @@ final class AuthControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('isTimeout'));
     }
 
-    public function testIndexActionFormAuthenticationFailed()
+    public function testIndexActionFormAuthenticationFailed(): void
     {
         $controller = $this->getController(AuthController::class);
 
@@ -108,7 +107,7 @@ final class AuthControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('isTimeout'));
     }
 
-    public function testIndexActionFormAuthenticationSuccessfulDashboard()
+    public function testIndexActionFormAuthenticationSuccessfulDashboard(): void
     {
         $controller = $this->getController(AuthController::class);
 
@@ -138,7 +137,7 @@ final class AuthControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionFormAuthenticationSuccessfulRedirect()
+    public function testIndexActionFormAuthenticationSuccessfulRedirect(): void
     {
         $controller = $this->getController(AuthController::class);
 
@@ -174,7 +173,7 @@ final class AuthControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionFormAuthenticationSuccessfulRedirectLpa()
+    public function testIndexActionFormAuthenticationSuccessfulRedirectLpa(): void
     {
         $controller = $this->getController(AuthController::class);
 
@@ -216,7 +215,7 @@ final class AuthControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testSessionExpiryAction()
+    public function testSessionExpiryAction(): void
     {
         $controller = $this->getController(AuthController::class);
 
@@ -229,7 +228,7 @@ final class AuthControllerTest extends AbstractControllerTestCase
         $this->assertEquals('{"remainingSeconds":100}', $result->serialize());
     }
 
-    public function testSessionExpiryActionExpired()
+    public function testSessionExpiryActionExpired(): void
     {
         $controller = $this->getController(AuthController::class);
 
@@ -249,7 +248,7 @@ final class AuthControllerTest extends AbstractControllerTestCase
         $this->assertEquals('', $result->getBody());
     }
 
-    public function testLogoutAction()
+    public function testLogoutAction(): void
     {
         $controller = $this->getController(AuthController::class);
 
@@ -265,7 +264,7 @@ final class AuthControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testDeletedAction()
+    public function testDeletedAction(): void
     {
         $controller = $this->getController(AuthController::class);
 
@@ -279,7 +278,7 @@ final class AuthControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('strictVars'));
     }
 
-    private function setPreAuthRequestUrl($url)
+    private function setPreAuthRequestUrl(string $url): void
     {
         $this->sessionManager->shouldReceive('start')->once();
         $this->storage->offsetSet('PreAuthRequest', new ArrayObject(['url' => $url]));

--- a/service-front/module/Application/tests/Controller/General/FeedbackControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/FeedbackControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\General;
 
 use Application\Controller\General\FeedbackController;
@@ -16,12 +18,9 @@ use Laminas\View\Model\ViewModel;
 
 final class FeedbackControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|FeedbackForm
-     */
-    private $form;
+    private MockInterface|FeedbackForm $form;
 
-    private $postData = [
+    private array $postData = [
         'rating' => '5',
         'details' => 'Awesome!',
         'email' => 'unit@test.com',
@@ -55,7 +54,7 @@ final class FeedbackControllerTest extends AbstractControllerTestCase
         return $controller;
     }
 
-    public function testSendFeedbackFormInvalid()
+    public function testSendFeedbackFormInvalid(): void
     {
         $controller = $this->getController(FeedbackController::class);
 
@@ -69,7 +68,7 @@ final class FeedbackControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testSendFeedbackFail()
+    public function testSendFeedbackFail(): void
     {
         $controller = $this->getController(FeedbackController::class);
 
@@ -84,7 +83,7 @@ final class FeedbackControllerTest extends AbstractControllerTestCase
         $controller->indexAction();
     }
 
-    public function testSendFeedbackSuccess()
+    public function testSendFeedbackSuccess(): void
     {
         $controller = $this->getController(FeedbackController::class);
 
@@ -101,7 +100,7 @@ final class FeedbackControllerTest extends AbstractControllerTestCase
         $this->assertEquals($result, $response);
     }
 
-    public function testSendFeedbackFormGetReferer()
+    public function testSendFeedbackFormGetReferer(): void
     {
         $controller = $this->getController(FeedbackController::class);
 
@@ -121,7 +120,7 @@ final class FeedbackControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->form, $result->getVariable('form'));
     }
 
-    public function testSendFeedbackFormNoReferer()
+    public function testSendFeedbackFormNoReferer(): void
     {
         $controller = $this->getController(FeedbackController::class);
 

--- a/service-front/module/Application/tests/Controller/General/ForgotPasswordControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/ForgotPasswordControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\General;
 
 use Application\Controller\General\ForgotPasswordController;
@@ -14,15 +16,9 @@ use Laminas\View\Model\ViewModel;
 
 final class ForgotPasswordControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|ConfirmEmail
-     */
-    private $resetPasswordEmailForm;
-    /**
-     * @var MockInterface|SetPassword
-     */
-    private $setPasswordForm;
-    private $postData = [
+    private MockInterface|ConfirmEmail $resetPasswordEmailForm;
+    private MockInterface|SetPassword $setPasswordForm;
+    private array $postData = [
         'token' => 'unitTest',
         'email' => 'unit@test.com',
         'password' => 'newPassword'
@@ -53,7 +49,7 @@ final class ForgotPasswordControllerTest extends AbstractControllerTestCase
         return $controller;
     }
 
-    public function testIndexActionAlreadyLoggedIn()
+    public function testIndexActionAlreadyLoggedIn(): void
     {
         $controller = $this->getController(ForgotPasswordController::class);
 
@@ -66,7 +62,7 @@ final class ForgotPasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(ForgotPasswordController::class);
@@ -84,7 +80,7 @@ final class ForgotPasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals(null, $result->getVariable('error'));
     }
 
-    public function testIndexActionFormInvalid()
+    public function testIndexActionFormInvalid(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(ForgotPasswordController::class);
@@ -102,7 +98,7 @@ final class ForgotPasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals(null, $result->getVariable('error'));
     }
 
-    public function testIndexActionPostError()
+    public function testIndexActionPostError(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(ForgotPasswordController::class);
@@ -126,7 +122,7 @@ final class ForgotPasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('accountNotActivated'));
     }
 
-    public function testIndexActionPostAccountNotActivated()
+    public function testIndexActionPostAccountNotActivated(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(ForgotPasswordController::class);
@@ -149,7 +145,7 @@ final class ForgotPasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals(true, $result->getVariable('accountNotActivated'));
     }
 
-    public function testResetPasswordActionEmptyToken()
+    public function testResetPasswordActionEmptyToken(): void
     {
         $controller = $this->getController(ForgotPasswordController::class);
 
@@ -162,7 +158,7 @@ final class ForgotPasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals('application/general/forgot-password/invalid-reset-token.twig', $result->getTemplate());
     }
 
-    public function testResetPasswordActionAlreadyLoggedIn()
+    public function testResetPasswordActionAlreadyLoggedIn(): void
     {
         $controller = $this->getController(ForgotPasswordController::class);
 
@@ -179,7 +175,7 @@ final class ForgotPasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testResetPasswordActionGet()
+    public function testResetPasswordActionGet(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(ForgotPasswordController::class);
@@ -200,7 +196,7 @@ final class ForgotPasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals(null, $result->getVariable('error'));
     }
 
-    public function testResetPasswordActionPostInvalid()
+    public function testResetPasswordActionPostInvalid(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(ForgotPasswordController::class);
@@ -221,7 +217,7 @@ final class ForgotPasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals(null, $result->getVariable('error'));
     }
 
-    public function testResetPasswordActionPostError()
+    public function testResetPasswordActionPostError(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(ForgotPasswordController::class);
@@ -249,7 +245,7 @@ final class ForgotPasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Password change failed', $result->getVariable('error'));
     }
 
-    public function testResetPasswordActionPostInvalidToken()
+    public function testResetPasswordActionPostInvalidToken(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(ForgotPasswordController::class);
@@ -275,7 +271,7 @@ final class ForgotPasswordControllerTest extends AbstractControllerTestCase
         $this->assertEquals('application/general/forgot-password/invalid-reset-token.twig', $result->getTemplate());
     }
 
-    public function testResetPasswordActionPostSuccess()
+    public function testResetPasswordActionPostSuccess(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(ForgotPasswordController::class);

--- a/service-front/module/Application/tests/Controller/General/GuidanceControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/GuidanceControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\General;
 
 use Application\Controller\General\GuidanceController;
@@ -27,7 +29,7 @@ final class GuidanceControllerTest extends AbstractControllerTestCase
         return $controller;
     }
 
-    public function testIndexActionIsXmlHttpRequestTrue()
+    public function testIndexActionIsXmlHttpRequestTrue(): void
     {
         $controller = $this->getController(GuidanceController::class);
 
@@ -41,7 +43,7 @@ final class GuidanceControllerTest extends AbstractControllerTestCase
         $this->assertEquals('guidance/opg-help-content.twig', $result->getTemplate());
     }
 
-    public function testIndexActionIsXmlHttpRequestFalse()
+    public function testIndexActionIsXmlHttpRequestFalse(): void
     {
         $controller = $this->getController(GuidanceController::class);
 

--- a/service-front/module/Application/tests/Controller/General/HomeControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/HomeControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\General;
 
 use Application\Controller\General\HomeController;
@@ -8,7 +10,7 @@ use Laminas\View\Model\ViewModel;
 
 final class HomeControllerTest extends AbstractControllerTestCase
 {
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         /** @var HomeController $controller */
         $controller = $this->getController(HomeController::class);
@@ -22,7 +24,7 @@ final class HomeControllerTest extends AbstractControllerTestCase
         $this->assertEquals('1.2.3.4-test', $result->getVariable('dockerTag'));
     }
 
-    public function testRedirectAction()
+    public function testRedirectAction(): void
     {
         /** @var HomeController $controller */
         $controller = $this->getController(HomeController::class);
@@ -36,7 +38,7 @@ final class HomeControllerTest extends AbstractControllerTestCase
         $this->assertEquals('https://www.gov.uk/power-of-attorney/make-lasting-power', $result);
     }
 
-    public function testCookieAction()
+    public function testCookieAction(): void
     {
         /** @var HomeController $controller */
         $controller = $this->getController(HomeController::class);
@@ -48,7 +50,7 @@ final class HomeControllerTest extends AbstractControllerTestCase
         $this->assertEquals('', $result->getTemplate());
     }
 
-    public function testAccessibilityAction()
+    public function testAccessibilityAction(): void
     {
         /** @var HomeController $controller */
         $controller = $this->getController(HomeController::class);
@@ -60,7 +62,7 @@ final class HomeControllerTest extends AbstractControllerTestCase
         $this->assertEquals('', $result->getTemplate());
     }
 
-    public function testTermsAction()
+    public function testTermsAction(): void
     {
         /** @var HomeController $controller */
         $controller = $this->getController(HomeController::class);
@@ -72,7 +74,7 @@ final class HomeControllerTest extends AbstractControllerTestCase
         $this->assertEquals('', $result->getTemplate());
     }
 
-    public function testContactAction()
+    public function testContactAction(): void
     {
         /** @var HomeController $controller */
         $controller = $this->getController(HomeController::class);

--- a/service-front/module/Application/tests/Controller/General/PingControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/PingControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\General;
 
 use Application\Controller\General\PingController;
@@ -18,11 +20,11 @@ final class PingControllerTest extends MockeryTestCase
      * @var MockInterface|Status
      */
     private $status;
-    private $checkResultOk = [
+    private array $checkResultOk = [
         'status' => Constants::STATUS_PASS,
     ];
 
-    private function getController()
+    private function getController(): PingController
     {
         /** @var PingController $controller */
         $controller = new PingController();
@@ -34,7 +36,7 @@ final class PingControllerTest extends MockeryTestCase
         return $controller;
     }
 
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         $controller = $this->getController();
 
@@ -48,7 +50,7 @@ final class PingControllerTest extends MockeryTestCase
         $this->assertEquals($this->checkResultOk, $result->getVariable('status'));
     }
 
-    public function testJsonAction()
+    public function testJsonAction(): void
     {
         $controller = $this->getController();
 
@@ -62,7 +64,7 @@ final class PingControllerTest extends MockeryTestCase
         $this->assertEquals('1.2.3.4-test', $result->getVariable('tag'));
     }
 
-    public function testPingdomActionOk()
+    public function testPingdomActionOk(): void
     {
         $controller = $this->getController();
 
@@ -76,7 +78,7 @@ final class PingControllerTest extends MockeryTestCase
         $this->assertStringContainsString('<pingdom_http_custom_check><status>OK</status>', $result->getContent());
     }
 
-    public function testPingdomActionError()
+    public function testPingdomActionError(): void
     {
         $controller = $this->getController();
 

--- a/service-front/module/Application/tests/Controller/General/RegisterControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/RegisterControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\General;
 
 use Application\Controller\General\RegisterController;
@@ -20,16 +22,13 @@ use Mockery\MockInterface;
 final class RegisterControllerTest extends AbstractControllerTestCase
 {
     public const GA = 987654321987654321;
-    /**
-     * @var MockInterface|Registration
-     */
-    private $form;
+    private MockInterface|Registration $form;
     /**
      * @var MockInterface|MvcEvent
      */
     private $event;
 
-    private $postData = [
+    private array $postData = [
         'email' => 'unit@test.com',
         'password' => 'password'
     ];
@@ -43,7 +42,7 @@ final class RegisterControllerTest extends AbstractControllerTestCase
             ->withArgs(['Application\Form\User\Registration'])->andReturn($this->form);
     }
 
-    private function makeMockReferer($url)
+    private function makeMockReferer(string $url)
     {
         $uri = new Uri($url);
         $referer = Mockery::mock(Referer::class);
@@ -67,7 +66,7 @@ final class RegisterControllerTest extends AbstractControllerTestCase
         return $controller;
     }
 
-    public function testIndexActionRefererGovUk()
+    public function testIndexActionRefererGovUk(): void
     {
         $controller = $this->getController(RegisterController::class);
 
@@ -88,7 +87,7 @@ final class RegisterControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionAlreadyLoggedIn()
+    public function testIndexActionAlreadyLoggedIn(): void
     {
         $controller = $this->getController(RegisterController::class);
 
@@ -118,7 +117,7 @@ final class RegisterControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testIndexActionGet()
+    public function testIndexActionGet(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(RegisterController::class);
@@ -143,7 +142,7 @@ final class RegisterControllerTest extends AbstractControllerTestCase
     // this mirrors the case where the referer is not a valid URI, e.g.
     // if it is set to android-app://com.google.android.gm/ when clicking
     // a link in GMail; see LPAL-1151
-    public function testIndexActionBadReferer()
+    public function testIndexActionBadReferer(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(RegisterController::class);
@@ -169,7 +168,7 @@ final class RegisterControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('strictVars'));
     }
 
-    public function testIndexActionPostInvalid()
+    public function testIndexActionPostInvalid(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(RegisterController::class);
@@ -191,7 +190,7 @@ final class RegisterControllerTest extends AbstractControllerTestCase
         $this->assertEquals(false, $result->getVariable('strictVars'));
     }
 
-    public function testIndexActionPostError()
+    public function testIndexActionPostError(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(RegisterController::class);
@@ -216,12 +215,10 @@ final class RegisterControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Unit test error', $result->getVariable('error'));
     }
 
-    public function testIndexActionPostSuccess()
+    public function testIndexActionPostSuccess(): void
     {
         $this->setIdentity(null);
         $controller = $this->getController(RegisterController::class);
-
-        $response = new Response();
 
         $this->request->shouldReceive('getQuery')->withArgs(['_ga'])->andReturn(self::GA)->once();
 
@@ -255,7 +252,7 @@ final class RegisterControllerTest extends AbstractControllerTestCase
         $this->assertInstanceOf(ViewModel::class, $result);
     }
 
-    public function testConfirmActionNoToken()
+    public function testConfirmActionNoToken(): void
     {
         $controller = $this->getController(RegisterController::class);
 
@@ -268,7 +265,7 @@ final class RegisterControllerTest extends AbstractControllerTestCase
         $this->assertEquals('invalid-token', $result->getVariable('error'));
     }
 
-    public function testConfirmActionAccountDoesNotExist()
+    public function testConfirmActionAccountDoesNotExist(): void
     {
         $controller = $this->getController(RegisterController::class);
 
@@ -284,7 +281,7 @@ final class RegisterControllerTest extends AbstractControllerTestCase
         $this->assertEquals('account-missing', $result->getVariable('error'));
     }
 
-    public function testConfirmActionSuccess()
+    public function testConfirmActionSuccess(): void
     {
         $controller = $this->getController(RegisterController::class);
 

--- a/service-front/module/Application/tests/Controller/General/StatsControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/StatsControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\General;
 
 use Application\Controller\General\StatsController;
@@ -12,10 +14,7 @@ use Mockery\MockInterface;
 
 final class StatsControllerTest extends AbstractControllerTestCase
 {
-    /**
-     * @var MockInterface|StatsService
-     */
-    private $statsService;
+    private MockInterface|StatsService $statsService;
 
     public function setUp() : void
     {
@@ -35,7 +34,7 @@ final class StatsControllerTest extends AbstractControllerTestCase
         return $controller;
     }
 
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         /** @var StatsController $controller */
         $controller = $this->getController(StatsController::class);
@@ -52,7 +51,7 @@ final class StatsControllerTest extends AbstractControllerTestCase
         $this->assertEquals($this->getPreferencesInstructionsStats(), $result->getVariable('preferencesInstructions'));
     }
 
-    private function getApiStats()
+    private function getApiStats(): array
     {
         return [
             'generated'               => '01/02/2017 14:22:11',
@@ -64,7 +63,7 @@ final class StatsControllerTest extends AbstractControllerTestCase
         ];
     }
 
-    private function getLpaStats()
+    private function getLpaStats(): array
     {
         $start = new DateTime('first day of this month');
         $start->setTime(0, 0, 0);
@@ -84,7 +83,7 @@ final class StatsControllerTest extends AbstractControllerTestCase
             $end->modify("last day of -1 month");
         }
 
-        $stats = [
+        return [
             'all' => [
                 'started' => 2,
                 'created' => 2,
@@ -103,11 +102,9 @@ final class StatsControllerTest extends AbstractControllerTestCase
             ],
             'by-month' => $byMonth
         ];
-
-        return $stats;
     }
 
-    private function getAuthStats()
+    private function getAuthStats(): array
     {
         return [
             'total' => 1,
@@ -117,7 +114,7 @@ final class StatsControllerTest extends AbstractControllerTestCase
         ];
     }
 
-    private function getWhoAreYouStats()
+    private function getWhoAreYouStats(): array
     {
         $start = new DateTime('first day of this month');
         $start->setTime(0, 0, 0);
@@ -162,7 +159,7 @@ final class StatsControllerTest extends AbstractControllerTestCase
             $end->modify("last day of -1 month");
         }
 
-        $stats = [
+        return [
             'all' => [
                 'professional' => [
                     'count' => 1,
@@ -195,11 +192,12 @@ final class StatsControllerTest extends AbstractControllerTestCase
             ],
             'by-month' => $byMonth
         ];
-
-        return $stats;
     }
 
-    private function getCorrespondenceStats()
+    /**
+     * @return mixed[]
+     */
+    private function getCorrespondenceStats(): array
     {
         $start = new DateTime('first day of this month');
         $start->setTime(0, 0, 0);
@@ -225,7 +223,10 @@ final class StatsControllerTest extends AbstractControllerTestCase
         return $stats;
     }
 
-    private function getPreferencesInstructionsStats()
+    /**
+     * @return mixed[]
+     */
+    private function getPreferencesInstructionsStats(): array
     {
         $start = new DateTime('first day of this month');
         $start->setTime(0, 0, 0);

--- a/service-front/module/Application/tests/Controller/General/VerifyEmailAddressControllerTest.php
+++ b/service-front/module/Application/tests/Controller/General/VerifyEmailAddressControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller\General;
 
 use Application\Controller\General\VerifyEmailAddressController;
@@ -19,7 +21,7 @@ final class VerifyEmailAddressControllerTest extends AbstractControllerTestCase
         return $controller;
     }
 
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         /** @var VerifyEmailAddressController $controller */
         $controller = $this->getController(VerifyEmailAddressController::class);
@@ -32,7 +34,7 @@ final class VerifyEmailAddressControllerTest extends AbstractControllerTestCase
         $this->assertEquals('Placeholder page', $result->getVariable('content'));
     }
 
-    public function testVerifyActionInvalidToken()
+    public function testVerifyActionInvalidToken(): void
     {
         /** @var VerifyEmailAddressController $controller */
         $controller = $this->getController(VerifyEmailAddressController::class);
@@ -52,7 +54,7 @@ final class VerifyEmailAddressControllerTest extends AbstractControllerTestCase
         $this->assertEquals($response, $result);
     }
 
-    public function testVerifyActionValidToken()
+    public function testVerifyActionValidToken(): void
     {
         /** @var VerifyEmailAddressController $controller */
         $controller = $this->getController(VerifyEmailAddressController::class);

--- a/service-front/module/Application/tests/Controller/InvalidUser.php
+++ b/service-front/module/Application/tests/Controller/InvalidUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller;
 
 class InvalidUser
@@ -7,7 +9,7 @@ class InvalidUser
     public $name = 'Invalid';
     public $email = 'Invalid';
 
-    public function toArray()
+    public function toArray(): array
     {
         return get_object_vars($this);
     }

--- a/service-front/module/Application/tests/Controller/TestableAbstractAuthenticatedController.php
+++ b/service-front/module/Application/tests/Controller/TestableAbstractAuthenticatedController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller;
 
 use Application\Controller\AbstractAuthenticatedController;

--- a/service-front/module/Application/tests/Controller/TestableAbstractLpaActorController.php
+++ b/service-front/module/Application/tests/Controller/TestableAbstractLpaActorController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller;
 
 use Application\Controller\AbstractLpaActorController;

--- a/service-front/module/Application/tests/Controller/TestableAbstractLpaController.php
+++ b/service-front/module/Application/tests/Controller/TestableAbstractLpaController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Controller;
 
 use Application\Controller\AbstractLpaController;


### PR DESCRIPTION
Add stricter types to the service-front Controller tests to make them more likely to catch issues