### PR TITLE
Remove laminas-api-tools/api-tools-api-problem from api-app

### DIFF
--- a/service-api/composer.json
+++ b/service-api/composer.json
@@ -19,7 +19,6 @@
         "laminas/laminas-mvc-i18n": "^2.0",
         "laminas/laminas-paginator": "^2.8",
         "lm-commons/lmc-rbac-mvc":"^3.0.2",
-        "laminas-api-tools/api-tools-api-problem": "^1.4",
         "php-http/guzzle7-adapter": "^1.0.0",
         "alphagov/notifications-php-client": "^5.0.0",
         "robmorgan/phinx": "^0.14.0",

--- a/service-api/composer.lock
+++ b/service-api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d092f382288fac8183024dabc795f30a",
+    "content-hash": "b55b3b8fa4f39e231da47bceb62f5ceb",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -1250,80 +1250,6 @@
                 }
             ],
             "time": "2025-08-23T21:21:41+00:00"
-        },
-        {
-            "name": "laminas-api-tools/api-tools-api-problem",
-            "version": "1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas-api-tools/api-tools-api-problem.git",
-                "reference": "ae6c8d3b063fc8adc3db6d8e5b80ffec2b4614d5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas-api-tools/api-tools-api-problem/zipball/ae6c8d3b063fc8adc3db6d8e5b80ffec2b4614d5",
-                "reference": "ae6c8d3b063fc8adc3db6d8e5b80ffec2b4614d5",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "laminas/laminas-eventmanager": "^2.6.3 || ^3.0.1",
-                "laminas/laminas-http": "^2.15.1",
-                "laminas/laminas-json": "^2.6.1 || ^3.0",
-                "laminas/laminas-mvc": "^2.7.15 || ^3.0.4",
-                "laminas/laminas-view": "^2.8.1",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
-            },
-            "replace": {
-                "zfcampus/zf-api-problem": "^1.3.0"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.27",
-                "psalm/plugin-phpunit": "^0.16.1",
-                "vimeo/psalm": "^4.30"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ApiTools\\ApiProblem"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\ApiTools\\ApiProblem\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Laminas Module providing API-Problem assets and rendering",
-            "homepage": "https://api-tools.getlaminas.org",
-            "keywords": [
-                "api-problem",
-                "api-tools",
-                "laminas",
-                "module",
-                "rest"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://api-tools.getlaminas.org/documentation",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas-api-tools/api-tools-api-problem/issues",
-                "rss": "https://github.com/laminas-api-tools/api-tools-api-problem/releases.atom",
-                "source": "https://github.com/laminas-api-tools/api-tools-api-problem"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2023-01-09T21:28:28+00:00"
         },
         {
             "name": "laminas/laminas-authentication",
@@ -3514,69 +3440,6 @@
                 }
             ],
             "time": "2025-08-07T08:55:27+00:00"
-        },
-        {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "eb0d96c708b92177a92bc2239543d3ed523452c6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/eb0d96c708b92177a92bc2239543d3ed523452c6",
-                "reference": "eb0d96c708b92177a92bc2239543d3ed523452c6",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^10.4",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "squizlabs/php_codesniffer": "^3.7.1",
-                "vimeo/psalm": "^5.16.0"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "support": {
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-                "source": "https://github.com/laminas/laminas-zendframework-bridge"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "abandoned": true,
-            "time": "2023-11-24T13:56:19+00:00"
         },
         {
             "name": "lm-commons/lmc-rbac-mvc",
@@ -8998,12 +8861,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.2 <8.3.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/service-api/module/Application/src/Controller/FeedbackController.php
+++ b/service-api/module/Application/src/Controller/FeedbackController.php
@@ -2,14 +2,14 @@
 
 namespace Application\Controller;
 
+use Application\Library\ApiProblem;
+use Application\Library\ApiProblemResponse;
 use DateTime;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Library\Http\Response\NoContent as NoContentResponse;
 use MakeShared\Logging\LoggerTrait;
 use Application\Model\Service\Feedback\Service as FeedbackService;
 use Laminas\Mvc\Controller\AbstractRestfulController;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
-use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 use LmcRbacMvc\Service\AuthorizationService;
 use Psr\Log\LoggerAwareInterface;
 

--- a/service-api/module/Application/src/Controller/StatsController.php
+++ b/service-api/module/Application/src/Controller/StatsController.php
@@ -2,11 +2,11 @@
 
 namespace Application\Controller;
 
+use Application\Library\ApiProblem;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Library\Http\Response\NoContent as NoContentResponse;
 use Application\Model\Service\Stats\Service;
 use Laminas\Mvc\Controller\AbstractRestfulController;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
 
 class StatsController extends AbstractRestfulController
 {

--- a/service-api/module/Application/src/Controller/StatusController.php
+++ b/service-api/module/Application/src/Controller/StatusController.php
@@ -14,7 +14,7 @@ use Application\Model\Service\ProcessingStatus\Service as ProcessingStatusServic
 use MakeShared\Logging\LoggerTrait;
 use Laminas\Mvc\Controller\AbstractRestfulController;
 use Laminas\Mvc\MvcEvent;
-use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
+use Application\Library\ApiProblemResponse;
 use LmcRbacMvc\Service\AuthorizationService;
 use Psr\Log\LoggerAwareInterface;
 

--- a/service-api/module/Application/src/Controller/Version2/Auth/AbstractAuthController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/AbstractAuthController.php
@@ -9,8 +9,8 @@ use MakeShared\Logging\LoggerTrait;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Mvc\Controller\AbstractRestfulController;
 use Laminas\Mvc\MvcEvent;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
-use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
+use Application\Library\ApiProblem;
+use Application\Library\ApiProblemResponse;
 use Psr\Log\LoggerAwareInterface;
 
 abstract class AbstractAuthController extends AbstractRestfulController implements LoggerAwareInterface

--- a/service-api/module/Application/src/Controller/Version2/Auth/AuthenticateController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/AuthenticateController.php
@@ -2,10 +2,10 @@
 
 namespace Application\Controller\Version2\Auth;
 
+use Application\Library\ApiProblem;
 use DateTime;
 use Application\Model\Service\AbstractService;
 use Laminas\View\Model\JsonModel;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
 use MakeShared\Logging\LoggerTrait;
 use MakeShared\Telemetry\TelemetryEventManager;
 use RuntimeException;

--- a/service-api/module/Application/src/Controller/Version2/Auth/EmailController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/EmailController.php
@@ -2,9 +2,9 @@
 
 namespace Application\Controller\Version2\Auth;
 
+use Application\Library\ApiProblem;
 use Application\Model\Service\Email\Service;
 use Laminas\View\Model\JsonModel;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
 use MakeShared\Logging\LoggerTrait;
 
 class EmailController extends AbstractAuthController

--- a/service-api/module/Application/src/Controller/Version2/Auth/PasswordController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/PasswordController.php
@@ -3,7 +3,7 @@
 namespace Application\Controller\Version2\Auth;
 
 use Application\Model\Service\Password\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use Laminas\View\Model\JsonModel;
 use DateTime;
 use MakeShared\Logging\LoggerTrait;

--- a/service-api/module/Application/src/Controller/Version2/Auth/UsersController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/UsersController.php
@@ -4,7 +4,7 @@ namespace Application\Controller\Version2\Auth;
 
 use Application\Model\Service\Users\Service;
 use Laminas\View\Model\JsonModel;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use MakeShared\Logging\LoggerTrait;
 
 class UsersController extends AbstractAuthController

--- a/service-api/module/Application/src/Controller/Version2/Lpa/AbstractLpaController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/AbstractLpaController.php
@@ -10,8 +10,8 @@ use Laminas\Mvc\Controller\AbstractRestfulController;
 use Laminas\Mvc\MvcEvent;
 use LmcRbacMvc\Exception\UnauthorizedException as LaminasUnauthorizedException;
 use LmcRbacMvc\Service\AuthorizationService;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
-use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
+use Application\Library\ApiProblem;
+use Application\Library\ApiProblemResponse;
 
 abstract class AbstractLpaController extends AbstractRestfulController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
@@ -8,7 +8,7 @@ use Application\Model\Service\Applications\Collection;
 use Application\Model\Service\Applications\Service;
 use Application\Model\Service\EntityInterface;
 use Laminas\Paginator\Paginator;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class ApplicationController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/CertificateProviderController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/CertificateProviderController.php
@@ -6,7 +6,7 @@ use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Library\Http\Response\NoContent as NoContentResponse;
 use Application\Model\Service\CertificateProvider\Service;
 use Application\Model\Service\EntityInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class CertificateProviderController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/CorrespondentController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/CorrespondentController.php
@@ -6,7 +6,7 @@ use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Library\Http\Response\NoContent as NoContentResponse;
 use Application\Model\Service\Correspondent\Service;
 use Application\Model\Service\EntityInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class CorrespondentController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/DonorController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/DonorController.php
@@ -5,7 +5,7 @@ namespace Application\Controller\Version2\Lpa;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Model\Service\Donor\Service;
 use Application\Model\Service\EntityInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class DonorController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/InstructionController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/InstructionController.php
@@ -5,7 +5,7 @@ namespace Application\Controller\Version2\Lpa;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Model\Service\EntityInterface;
 use Application\Model\Service\Instruction\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class InstructionController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/LockController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/LockController.php
@@ -5,7 +5,7 @@ namespace Application\Controller\Version2\Lpa;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Model\Service\EntityInterface;
 use Application\Model\Service\Lock\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class LockController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/NotifiedPeopleController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/NotifiedPeopleController.php
@@ -6,7 +6,7 @@ use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Library\Http\Response\NoContent as NoContentResponse;
 use Application\Model\Service\EntityInterface;
 use Application\Model\Service\NotifiedPeople\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class NotifiedPeopleController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/PaymentController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/PaymentController.php
@@ -5,7 +5,7 @@ namespace Application\Controller\Version2\Lpa;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Model\Service\EntityInterface;
 use Application\Model\Service\Payment\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class PaymentController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/PdfController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/PdfController.php
@@ -6,7 +6,7 @@ use Application\Library\Http\Response\File as FileResponse;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Library\Http\Response\NoContent as NoContentResponse;
 use Application\Model\Service\Pdfs\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class PdfController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/PreferenceController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/PreferenceController.php
@@ -5,7 +5,7 @@ namespace Application\Controller\Version2\Lpa;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Model\Service\EntityInterface;
 use Application\Model\Service\Preference\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class PreferenceController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/PrimaryAttorneyController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/PrimaryAttorneyController.php
@@ -6,7 +6,7 @@ use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Library\Http\Response\NoContent as NoContentResponse;
 use Application\Model\Service\AttorneysPrimary\Service;
 use Application\Model\Service\EntityInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class PrimaryAttorneyController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/PrimaryAttorneyDecisionsController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/PrimaryAttorneyDecisionsController.php
@@ -5,7 +5,7 @@ namespace Application\Controller\Version2\Lpa;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Model\Service\AttorneyDecisionsPrimary\Service;
 use Application\Model\Service\EntityInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class PrimaryAttorneyDecisionsController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/RepeatCaseNumberController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/RepeatCaseNumberController.php
@@ -6,7 +6,7 @@ use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Library\Http\Response\NoContent as NoContentResponse;
 use Application\Model\Service\EntityInterface;
 use Application\Model\Service\RepeatCaseNumber\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class RepeatCaseNumberController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/ReplacementAttorneyController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/ReplacementAttorneyController.php
@@ -6,7 +6,7 @@ use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Library\Http\Response\NoContent as NoContentResponse;
 use Application\Model\Service\AttorneysReplacement\Service;
 use Application\Model\Service\EntityInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class ReplacementAttorneyController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/ReplacementAttorneyDecisionsController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/ReplacementAttorneyDecisionsController.php
@@ -5,7 +5,7 @@ namespace Application\Controller\Version2\Lpa;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Model\Service\AttorneyDecisionsReplacement\Service;
 use Application\Model\Service\EntityInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class ReplacementAttorneyDecisionsController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/SeedController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/SeedController.php
@@ -6,7 +6,7 @@ use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Library\Http\Response\NoContent as NoContentResponse;
 use Application\Model\Service\EntityInterface;
 use Application\Model\Service\Seed\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class SeedController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/TypeController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/TypeController.php
@@ -5,7 +5,7 @@ namespace Application\Controller\Version2\Lpa;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Model\Service\EntityInterface;
 use Application\Model\Service\Type\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class TypeController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/UserController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/UserController.php
@@ -7,7 +7,7 @@ use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Library\Http\Response\NoContent as NoContentResponse;
 use Application\Model\Service\EntityInterface;
 use Application\Model\Service\Users\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class UserController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/WhoAreYouController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/WhoAreYouController.php
@@ -5,7 +5,7 @@ namespace Application\Controller\Version2\Lpa;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Model\Service\EntityInterface;
 use Application\Model\Service\WhoAreYou\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class WhoAreYouController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/WhoIsRegisteringController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/WhoIsRegisteringController.php
@@ -5,7 +5,7 @@ namespace Application\Controller\Version2\Lpa;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Model\Service\EntityInterface;
 use Application\Model\Service\WhoIsRegistering\Service;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 
 class WhoIsRegisteringController extends AbstractLpaController
 {

--- a/service-api/module/Application/src/Library/ApiProblem.php
+++ b/service-api/module/Application/src/Library/ApiProblem.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Library;
+
+use Exception;
+use Laminas\ApiTools\ApiProblem\Exception\InvalidArgumentException;
+use Laminas\ApiTools\ApiProblem\Exception\ProblemExceptionInterface;
+use Throwable;
+
+use function array_key_exists;
+use function array_keys;
+use function array_merge;
+use function count;
+use function get_class;
+use function in_array;
+use function is_numeric;
+use function sprintf;
+use function strtolower;
+use function trim;
+
+/**
+ * Object describing an API-Problem payload.
+ */
+class ApiProblem
+{
+    /**
+     * Content type for api problem response
+     */
+    public const CONTENT_TYPE = 'application/problem+json';
+
+    /**
+     * Additional details to include in report.
+     *
+     * @var array
+     */
+    protected $additionalDetails = [];
+
+    /**
+     * URL describing the problem type; defaults to HTTP status codes.
+     *
+     * @var string
+     */
+    protected $type = 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html';
+
+    /**
+     * Description of the specific problem.
+     *
+     * @var string|Exception|Throwable
+     */
+    protected $detail = '';
+
+    /**
+     * Whether or not to include a stack trace and previous
+     * exceptions when an exception is provided for the detail.
+     *
+     * @var bool
+     */
+    protected $detailIncludesStackTrace = false;
+
+    /**
+     * HTTP status for the error.
+     *
+     * @var int
+     */
+    protected $status;
+
+    /**
+     * Normalized property names for overloading.
+     *
+     * @var array
+     */
+    protected $normalizedProperties = [
+        'type'   => 'type',
+        'status' => 'status',
+        'title'  => 'title',
+        'detail' => 'detail',
+    ];
+
+    /**
+     * Status titles for common problems.
+     *
+     * @var array
+     */
+    protected $problemStatusTitles = [
+        // CLIENT ERROR
+        400 => 'Bad Request',
+        401 => 'Unauthorized',
+        402 => 'Payment Required',
+        403 => 'Forbidden',
+        404 => 'Not Found',
+        405 => 'Method Not Allowed',
+        406 => 'Not Acceptable',
+        407 => 'Proxy Authentication Required',
+        408 => 'Request Time-out',
+        409 => 'Conflict',
+        410 => 'Gone',
+        411 => 'Length Required',
+        412 => 'Precondition Failed',
+        413 => 'Request Entity Too Large',
+        414 => 'Request-URI Too Large',
+        415 => 'Unsupported Media Type',
+        416 => 'Requested range not satisfiable',
+        417 => 'Expectation Failed',
+        418 => 'I\'m a teapot',
+        422 => 'Unprocessable Entity',
+        423 => 'Locked',
+        424 => 'Failed Dependency',
+        425 => 'Unordered Collection',
+        426 => 'Upgrade Required',
+        428 => 'Precondition Required',
+        429 => 'Too Many Requests',
+        431 => 'Request Header Fields Too Large',
+        // SERVER ERROR
+        500 => 'Internal Server Error',
+        501 => 'Not Implemented',
+        502 => 'Bad Gateway',
+        503 => 'Service Unavailable',
+        504 => 'Gateway Time-out',
+        505 => 'HTTP Version not supported',
+        506 => 'Variant Also Negotiates',
+        507 => 'Insufficient Storage',
+        508 => 'Loop Detected',
+        511 => 'Network Authentication Required',
+    ];
+
+    /**
+     * Title of the error.
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * Create an instance using the provided information. If nothing is
+     * provided for the type field, the class default will be used;
+     * if the status matches any known, the title field will be selected
+     * from $problemStatusTitles as a result.
+     *
+     * @param int|string $status
+     * @param string|Exception|Throwable $detail
+     * @param string $type
+     * @param string $title
+     * @param array  $additional
+     */
+    public function __construct($status, $detail, $type = null, $title = null, array $additional = [])
+    {
+        if ($detail instanceof ProblemExceptionInterface) {
+            if (null === $type) {
+                $type = $detail->getType();
+            }
+            if (null === $title) {
+                $title = $detail->getTitle();
+            }
+            if (empty($additional)) {
+                $additional = $detail->getAdditionalDetails();
+            }
+        }
+
+        // Ensure a valid HTTP status
+        if (
+            ! is_numeric($status)
+            || ($status < 100)
+            || ($status > 599)
+        ) {
+            $status = 500;
+        }
+
+        $this->status = (int) $status;
+        $this->detail = $detail;
+        $this->title  = $title;
+
+        if (null !== $type) {
+            $this->type = $type;
+        }
+
+        $this->additionalDetails = $additional;
+    }
+
+    /**
+     * Retrieve properties.
+     *
+     * @param string $name
+     * @return mixed
+     * @throws InvalidArgumentException
+     */
+    public function __get($name)
+    {
+        $normalized = strtolower($name);
+        if (in_array($normalized, array_keys($this->normalizedProperties))) {
+            $prop = $this->normalizedProperties[$normalized];
+
+            return $this->{$prop};
+        }
+
+        if (isset($this->additionalDetails[$name])) {
+            return $this->additionalDetails[$name];
+        }
+
+        if (isset($this->additionalDetails[$normalized])) {
+            return $this->additionalDetails[$normalized];
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Invalid property name "%s"',
+            $name
+        ));
+    }
+
+    /**
+     * Cast to an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $problem = [
+            'type'   => $this->type,
+            'title'  => $this->getTitle(),
+            'status' => $this->getStatus(),
+            'detail' => $this->getDetail(),
+        ];
+        // Required fields should always overwrite additional fields
+        return array_merge($this->additionalDetails, $problem);
+    }
+
+    /**
+     * Set the flag indicating whether an exception detail should include a
+     * stack trace and previous exception information.
+     *
+     * @param bool $flag
+     * @return ApiProblem
+     */
+    public function setDetailIncludesStackTrace($flag)
+    {
+        $this->detailIncludesStackTrace = (bool) $flag;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the API-Problem detail.
+     *
+     * If an exception was provided, creates the detail message from it;
+     * otherwise, detail as provided is used.
+     *
+     * @return string
+     */
+    protected function getDetail()
+    {
+        if ($this->detail instanceof Throwable || $this->detail instanceof Exception) {
+            return $this->createDetailFromException();
+        }
+
+        return $this->detail;
+    }
+
+    /**
+     * Retrieve the API-Problem HTTP status code.
+     *
+     * If an exception was provided, creates the status code from it;
+     * otherwise, code as provided is used.
+     */
+    protected function getStatus(): int
+    {
+        if ($this->detail instanceof Throwable || $this->detail instanceof Exception) {
+            $this->status = (int) $this->createStatusFromException();
+        }
+
+        return $this->status;
+    }
+
+    /**
+     * Retrieve the title.
+     *
+     * If the default $type is used, and the $status is found in
+     * $problemStatusTitles, then use the matching title.
+     *
+     * If no title was provided, and the above conditions are not met, use the
+     * string 'Unknown'.
+     *
+     * Otherwise, use the title provided.
+     *
+     * @return string
+     */
+    protected function getTitle()
+    {
+        if (null !== $this->title) {
+            return $this->title;
+        }
+
+        if (
+            null === $this->title
+            && $this->type === 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html'
+            && array_key_exists($this->getStatus(), $this->problemStatusTitles)
+        ) {
+            return $this->problemStatusTitles[$this->status];
+        }
+
+        if ($this->detail instanceof Throwable) {
+            return get_class($this->detail);
+        }
+
+        if (null === $this->title) {
+            return 'Unknown';
+        }
+
+        return $this->title;
+    }
+
+    /**
+     * Create detail message from an exception.
+     *
+     * @return string
+     */
+    protected function createDetailFromException()
+    {
+        /** @var Exception|Throwable $e */
+        $e = $this->detail;
+
+        if (! $this->detailIncludesStackTrace) {
+            return $e->getMessage();
+        }
+
+        $message                          = trim($e->getMessage());
+        $this->additionalDetails['trace'] = $e->getTrace();
+
+        $previous = [];
+        $e        = $e->getPrevious();
+        while ($e) {
+            $previous[] = [
+                'code'    => (int) $e->getCode(),
+                'message' => trim($e->getMessage()),
+                'trace'   => $e->getTrace(),
+            ];
+            $e          = $e->getPrevious();
+        }
+        if (count($previous)) {
+            $this->additionalDetails['exception_stack'] = $previous;
+        }
+
+        return $message;
+    }
+
+    /**
+     * Create HTTP status from an exception.
+     *
+     * @return int|string
+     */
+    protected function createStatusFromException()
+    {
+        /** @var Exception|Throwable $e */
+        $e      = $this->detail;
+        $status = $e->getCode();
+
+        if ($status) {
+            return $status;
+        }
+
+        return 500;
+    }
+}

--- a/service-api/module/Application/src/Library/ApiProblem/ApiProblem.php
+++ b/service-api/module/Application/src/Library/ApiProblem/ApiProblem.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Application\Library\ApiProblem;
 
-use Laminas\ApiTools\ApiProblem\ApiProblem as LaminasApiProblem;
+use Application\Library\ApiProblem as LaminasApiProblem;
 
 /**
  * While this class superficially duplicates LaminasApiProblem, the difference

--- a/service-api/module/Application/src/Library/ApiProblemResponse.php
+++ b/service-api/module/Application/src/Library/ApiProblemResponse.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Library;
+
+use Laminas\Http\Headers;
+use Laminas\Http\Response;
+use function json_encode;
+use const JSON_PARTIAL_OUTPUT_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+
+/**
+ * Represents an ApiProblem response payload.
+ */
+class ApiProblemResponse extends Response
+{
+    /** @var ApiProblem */
+    protected $apiProblem;
+
+    /**
+     * Flags to use with json_encode.
+     *
+     * @var int
+     */
+    protected $jsonFlags;
+
+    public function __construct(ApiProblem $apiProblem)
+    {
+        $this->apiProblem = $apiProblem;
+        $this->setCustomStatusCode($apiProblem->status);
+
+        if ($apiProblem->title !== null) {
+            $this->setReasonPhrase($apiProblem->title);
+        }
+
+        $this->jsonFlags = JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR;
+    }
+
+    /**
+     * @return ApiProblem
+     */
+    public function getApiProblem()
+    {
+        return $this->apiProblem;
+    }
+
+    /**
+     * Retrieve the content.
+     *
+     * Serializes the composed ApiProblem instance to JSON.
+     *
+     * @return string
+     */
+    public function getContent()
+    {
+        return json_encode($this->apiProblem->toArray(), $this->jsonFlags);
+    }
+
+    /**
+     * Retrieve headers.
+     *
+     * Proxies to parent class, but then checks if we have an content-type
+     * header; if not, sets it, with a value of "application/problem+json".
+     *
+     * @return Headers
+     */
+    public function getHeaders()
+    {
+        $headers = parent::getHeaders();
+        if (! $headers->has('content-type')) {
+            $headers->addHeaderLine('content-type', ApiProblem::CONTENT_TYPE);
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Override reason phrase handling.
+     *
+     * If no corresponding reason phrase is available for the current status
+     * code, return "Unknown Error".
+     *
+     * @return string
+     */
+    public function getReasonPhrase()
+    {
+        if (! empty($this->reasonPhrase)) {
+            return $this->reasonPhrase;
+        }
+
+        if (isset($this->recommendedReasonPhrases[$this->statusCode])) {
+            return $this->recommendedReasonPhrases[$this->statusCode];
+        }
+
+        return 'Unknown Error';
+    }
+}

--- a/service-api/module/Application/src/Library/Authentication/AuthenticationListener.php
+++ b/service-api/module/Application/src/Library/Authentication/AuthenticationListener.php
@@ -6,8 +6,8 @@ use Application\Model\Service\Authentication\Service as AuthenticationService;
 use MakeShared\Logging\LoggerTrait;
 use Laminas\Authentication\Result as AuthenticationResult;
 use Laminas\Mvc\MvcEvent;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
-use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
+use Application\Library\ApiProblem;
+use Application\Library\ApiProblemResponse;
 use Psr\Log\LoggerAwareInterface;
 
 /**

--- a/service-api/module/Application/src/Module.php
+++ b/service-api/module/Application/src/Module.php
@@ -21,7 +21,7 @@ use Aws\Sqs\SqsClient;
 use Aws\Signature\SignatureV4;
 use Http\Adapter\Guzzle7\Client as Guzzle7Client;
 use Http\Client\HttpClient;
-use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
+use Application\Library\ApiProblemResponse;
 use Laminas\Authentication\AuthenticationService;
 use Laminas\Authentication\Storage\NonPersistent;
 use Laminas\Db\Adapter\Adapter as ZendDbAdapter;

--- a/service-api/module/Application/tests/Controller/FeedbackControllerTest.php
+++ b/service-api/module/Application/tests/Controller/FeedbackControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace ApplicationTest\Controller;
 
+use Application\Library\ApiProblemResponse;
 use DateTime;
 use Application\Controller\FeedbackController;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
@@ -11,7 +12,6 @@ use Laminas\Mvc\Controller\PluginManager;
 use LmcRbacMvc\Service\AuthorizationService;
 use Laminas\Mvc\Controller\Plugin\Params;
 use Application\Library\Http\Response\Json;
-use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 use Application\Library\Http\Response\NoContent;
 use Psr\Log\LoggerInterface;
 

--- a/service-api/module/Application/tests/Controller/StatsControllerTest.php
+++ b/service-api/module/Application/tests/Controller/StatsControllerTest.php
@@ -3,6 +3,7 @@
 namespace ApplicationTest\Controller;
 
 use Application\Controller\StatsController;
+use Application\Library\ApiProblem;
 use Application\Library\Http\Response\Json as JsonResponse;
 use Application\Library\Http\Response\NoContent as NoContentResponse;
 use Application\Model\Service\Stats\Service as StatsService;
@@ -10,7 +11,6 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
 use MakeShared\Logging\Logger;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
 
 class StatsControllerTest extends MockeryTestCase
 {

--- a/service-api/module/Application/tests/Controller/Version2/Auth/AuthenticateControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Auth/AuthenticateControllerTest.php
@@ -3,14 +3,14 @@
 namespace ApplicationTest\Controller\Version2\Auth;
 
 use Application\Controller\Version2\Auth\AuthenticateController;
+use Application\Library\ApiProblem;
+use Application\Library\ApiProblemResponse;
 use DateTime;
 use Mockery;
 use Laminas\Http\Header\HeaderInterface;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Router\RouteMatch;
 use Laminas\View\Model\JsonModel;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
-use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 
 class AuthenticateControllerTest extends AbstractAuthControllerTestCase
 {

--- a/service-api/module/Application/tests/Controller/Version2/Auth/EmailControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Auth/EmailControllerTest.php
@@ -3,11 +3,11 @@
 namespace ApplicationTest\Controller\Version2\Auth;
 
 use Application\Controller\Version2\Auth\EmailController;
+use Application\Library\ApiProblem;
 use Application\Model\DataAccess\Repository\User\UpdateEmailUsingTokenResponse;
 use Application\Model\DataAccess\Repository\User\UserInterface;
 use Application\Model\Service\Email\Service;
 use Laminas\View\Model\JsonModel;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Mockery;
 
 class EmailControllerTest extends AbstractAuthControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Auth/PasswordControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Auth/PasswordControllerTest.php
@@ -3,9 +3,9 @@
 namespace ApplicationTest\Controller\Version2\Auth;
 
 use Application\Controller\Version2\Auth\PasswordController;
+use Application\Library\ApiProblem;
 use Application\Model\Service\Password\Service;
 use Laminas\View\Model\JsonModel;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Mockery;
 
 class PasswordControllerTest extends AbstractAuthControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Auth/UsersControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Auth/UsersControllerTest.php
@@ -5,7 +5,7 @@ namespace ApplicationTest\Controller\Version2\Auth;
 use Application\Controller\Version2\Auth\UsersController;
 use Application\Model\Service\Users\Service;
 use Laminas\View\Model\JsonModel;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use Mockery;
 
 class UsersControllerTest extends AbstractAuthControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/AbstractLpaControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/AbstractLpaControllerTest.php
@@ -11,7 +11,7 @@ use Mockery\MockInterface;
 use Laminas\Http\Response;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Router\RouteMatch;
-use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
+use Application\Library\ApiProblemResponse;
 
 class AbstractLpaControllerTest extends AbstractControllerTestCase
 {

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/ApplicationControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/ApplicationControllerTest.php
@@ -8,7 +8,7 @@ use Application\Library\Http\Response\NoContent;
 use Application\Model\Service\Applications\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class ApplicationControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/CertificateProviderControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/CertificateProviderControllerTest.php
@@ -8,7 +8,7 @@ use Application\Library\Http\Response\NoContent;
 use Application\Model\Service\CertificateProvider\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class CertificateProviderControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/CorrespondentControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/CorrespondentControllerTest.php
@@ -8,7 +8,7 @@ use Application\Library\Http\Response\Json;
 use Application\Library\Http\Response\NoContent;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class CorrespondentControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/DonorControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/DonorControllerTest.php
@@ -7,7 +7,7 @@ use Application\Library\Http\Response\Json;
 use Application\Model\Service\Donor\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class DonorControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/InstructionControllerTests.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/InstructionControllerTests.php
@@ -7,7 +7,7 @@ use Application\Model\Service\Instruction\Service;
 use Application\Library\Http\Response\Json;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class InstructionControllerTests extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/LockControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/LockControllerTest.php
@@ -7,7 +7,7 @@ use Application\Model\Service\Lock\Service;
 use Application\Library\Http\Response\Json;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class LockControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/NotifiedPeopleControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/NotifiedPeopleControllerTest.php
@@ -8,7 +8,7 @@ use Application\Library\Http\Response\Json;
 use Application\Library\Http\Response\NoContent;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class NotifiedPeopleControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/PaymentControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/PaymentControllerTest.php
@@ -7,7 +7,7 @@ use Application\Library\Http\Response\Json;
 use Application\Model\Service\Payment\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class PaymentControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/PdfControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/PdfControllerTest.php
@@ -8,7 +8,7 @@ use Application\Library\Http\Response\NoContent;
 use Application\Model\Service\Pdfs\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class PdfControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/PreferenceControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/PreferenceControllerTest.php
@@ -7,7 +7,7 @@ use Application\Library\Http\Response\Json;
 use Application\Model\Service\Preference\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class PreferenceControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/PrimaryAttorneyControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/PrimaryAttorneyControllerTest.php
@@ -8,7 +8,7 @@ use Application\Library\Http\Response\NoContent;
 use Application\Model\Service\AttorneysPrimary\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class PrimaryAttorneyControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/PrimaryAttorneyDecisionsControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/PrimaryAttorneyDecisionsControllerTest.php
@@ -7,7 +7,7 @@ use Application\Library\Http\Response\Json;
 use Application\Model\Service\AttorneyDecisionsPrimary\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class PrimaryAttorneyDecisionsControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/RepeatCaseNumberControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/RepeatCaseNumberControllerTest.php
@@ -8,7 +8,7 @@ use Application\Library\Http\Response\NoContent;
 use Application\Model\Service\RepeatCaseNumber\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class RepeatCaseNumberControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/ReplacementAttorneyControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/ReplacementAttorneyControllerTest.php
@@ -8,7 +8,7 @@ use Application\Library\Http\Response\NoContent;
 use Application\Model\Service\AttorneysReplacement\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class ReplacementAttorneyControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/ReplacementAttorneyDecisionsControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/ReplacementAttorneyDecisionsControllerTest.php
@@ -7,7 +7,7 @@ use Application\Library\Http\Response\Json;
 use Application\Model\Service\AttorneyDecisionsReplacement\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class ReplacementAttorneyDecisionsControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/SeedControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/SeedControllerTest.php
@@ -8,7 +8,7 @@ use Application\Library\Http\Response\NoContent;
 use Application\Model\Service\Seed\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class SeedControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/TypeControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/TypeControllerTest.php
@@ -7,7 +7,7 @@ use Application\Library\Http\Response\Json;
 use Application\Model\Service\Type\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class TypeControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/UserControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/UserControllerTest.php
@@ -9,7 +9,7 @@ use Application\Library\Http\Response\NoContent;
 use Application\Model\Service\Users\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 use LmcRbacMvc\Service\AuthorizationService;
 

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/WhoAreYouControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/WhoAreYouControllerTest.php
@@ -7,7 +7,7 @@ use Application\Library\Http\Response\Json;
 use Application\Model\Service\WhoAreYou\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class WhoAreYouControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/WhoIsRegisteringControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/WhoIsRegisteringControllerTest.php
@@ -7,7 +7,7 @@ use Application\Library\Http\Response\Json;
 use Application\Model\Service\WhoIsRegistering\Service;
 use Mockery;
 use Mockery\MockInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Application\Library\ApiProblem;
 use LmcRbacMvc\Exception\UnauthorizedException;
 
 class WhoIsRegisteringControllerTest extends AbstractControllerTestCase

--- a/service-api/module/Application/tests/Library/Authentication/AuthenticationListenerTest.php
+++ b/service-api/module/Application/tests/Library/Authentication/AuthenticationListenerTest.php
@@ -16,7 +16,7 @@ use Laminas\Http\Request;
 use Laminas\Mvc\ApplicationInterface;
 use Laminas\Mvc\MvcEvent;
 use Laminas\ServiceManager\ServiceLocatorInterface;
-use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
+use Application\Library\ApiProblemResponse;
 use Psr\Log\LoggerInterface;
 
 class AuthenticationListenerTest extends MockeryTestCase

--- a/service-api/module/Application/tests/ModuleTest.php
+++ b/service-api/module/Application/tests/ModuleTest.php
@@ -3,7 +3,7 @@
 namespace ApplicationTest;
 
 use Application\Module;
-use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
+use Application\Library\ApiProblemResponse;
 use Laminas\Http\Headers;
 use Laminas\Http\Header\Accept as AcceptHeader;
 use Laminas\Http\Request as LaminasRequest;


### PR DESCRIPTION
- Remove laminas-api-tools/api-tools-api-problem
- Move a copy of Laminas ApiProblem and ApiProblemResponse into the codebase

## Purpose

_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes LPAL-####

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* [ ] The product team have tested these changes
