### PR TITLE
LPA-3834 Refactor api tests to not use protected APIProblem methods

### DIFF
--- a/service-api/module/Application/tests/Library/ApiProblem/ValidationApiProblemTest.php
+++ b/service-api/module/Application/tests/Library/ApiProblem/ValidationApiProblemTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Library\ApiProblem;
 
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use MakeShared\DataModel\Validator\ValidatorResponseInterface;
 
-class ValidationApiProblemTest extends MockeryTestCase
+final class ValidationApiProblemTest extends MockeryTestCase
 {
     public function testConstructor(): void
     {
@@ -15,15 +17,15 @@ class ValidationApiProblemTest extends MockeryTestCase
 
         $validationApiProblem = new TestableValidationApiProblem($validatorResponse);
 
-        $this->assertEquals(400, $validationApiProblem->getStatus());
         $this->assertEquals(
-            'Your request could not be processed due to validation error',
-            $validationApiProblem->getDetail()
-        );
-        $this->assertEquals('Bad Request', $validationApiProblem->getTitle());
-        $this->assertEquals(
-            'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
-            $validationApiProblem->getType()
+            [
+                'validation' => [0 => 'some error'],
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error'
+            ],
+            $validationApiProblem->toArray()
         );
 
         print_r($validationApiProblem->getAdditionalDetails());

--- a/service-api/module/Application/tests/Model/Service/Applications/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Applications/ServiceTest.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\Applications;
 
+use Laminas\ApiTools\ApiProblem\ApiProblem;
 use RuntimeException;
 use ArrayIterator;
 use ArrayObject;
 use DateTime;
 use Application\Model\DataAccess\Repository\Application\ApplicationRepositoryInterface;
-use Application\Library\ApiProblem\ApiProblem;
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Library\MillisecondDateTime;
 use Application\Model\Service\Applications\Collection;
@@ -21,17 +23,9 @@ use MakeShared\DataModel\User\User;
 use MakeSharedTest\DataModel\FixturesData;
 use Mockery;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
-    /**
-     * @var MockInterface|ApplicationRepositoryInterface
-     */
-    private $applicationRepository;
-
-    /**
-     * @var TestableService
-     */
-    private $service;
+    private MockInterface|ApplicationRepositoryInterface $applicationRepository;
 
     protected function setUp(): void
     {
@@ -58,8 +52,15 @@ class ServiceTest extends AbstractServiceTestCase
         $entity = $service->fetch(-1, $user->getId());
 
         $this->assertTrue($entity instanceof ApiProblem);
-        $this->assertEquals(404, $entity->getStatus());
-        $this->assertEquals('Document -1 not found for user e551d8b14c408f7efb7358fb258f1b12', $entity->getDetail());
+        $this->assertEquals(
+            [
+                'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html',
+                'title' => 'Not Found',
+                'status' => 404,
+                'detail' => 'Document -1 not found for user e551d8b14c408f7efb7358fb258f1b12',
+            ],
+            $entity->toArray()
+        );
     }
 
     public function testFetchHwLpa()
@@ -195,19 +196,19 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->patch($lpa->toArray(), $lpa->getId(), $user->getId());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
         $this->assertEquals(
-            'Your request could not be processed due to validation error',
-            $validationError->getDetail()
+            [
+                'validation' => ['document.type' => [
+                    'value' => 'invalid',
+                    'messages' => ['allowed-values:property-and-financial,health-and-welfare']
+                ]],
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+            ],
+            $validationError->toArray()
         );
-        $this->assertEquals(
-            'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
-            $validationError->getType()
-        );
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('document.type', $validation));
     }
 
     public function testUpdateLpaValidationError()
@@ -439,8 +440,15 @@ class ServiceTest extends AbstractServiceTestCase
         $response = $service->delete(-1, $user->getId());
 
         $this->assertTrue($response instanceof ApiProblem);
-        $this->assertEquals(404, $response->getStatus());
-        $this->assertEquals('Document not found', $response->getDetail());
+        $this->assertEquals(
+            [
+                'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html',
+                'title' => 'Not Found',
+                'status' => 404,
+                'detail' => 'Document not found',
+            ],
+            $response->toArray()
+        );
     }
 
     public function testDelete()

--- a/service-api/module/Application/tests/Model/Service/AttorneyDecisionsPrimary/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/AttorneyDecisionsPrimary/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\AttorneyDecisionsPrimary;
 
 use RuntimeException;
@@ -9,7 +11,7 @@ use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\Decisions\PrimaryAttorneyDecisions;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {
@@ -29,13 +31,21 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), $decisions->toArray());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('how', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'how' => [
+                        'value' => 'invalid',
+                        'messages' => ['allowed-values:depends,jointly,single-attorney,jointly-attorney-severally'],
+                    ]
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -44,7 +54,7 @@ class ServiceTest extends AbstractServiceTestCase
     {
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 

--- a/service-api/module/Application/tests/Model/Service/AttorneyDecisionsReplacement/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/AttorneyDecisionsReplacement/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\AttorneyDecisionsReplacement;
 
 use RuntimeException;
@@ -9,7 +11,7 @@ use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\Decisions\ReplacementAttorneyDecisions;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {
@@ -29,13 +31,21 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), $decisions->toArray());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('how', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'how' => [
+                        'value' => 'invalid',
+                        'messages' => ['allowed-values:depends,jointly,single-attorney,jointly-attorney-severally']
+                    ],
+                ],
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -44,7 +54,7 @@ class ServiceTest extends AbstractServiceTestCase
     {
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 

--- a/service-api/module/Application/tests/Model/Service/AttorneysPrimary/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/AttorneysPrimary/ServiceTest.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\AttorneysPrimary;
 
+use Laminas\ApiTools\ApiProblem\ApiProblem;
 use RuntimeException;
-use Application\Library\ApiProblem\ApiProblem;
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\DataModelEntity;
 use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\Attorneys\Human;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testCreateInvalidType()
     {
@@ -49,15 +51,20 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->create($lpa->getId(), $attorney->toArray());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(3, count($validation));
-        $this->assertTrue(array_key_exists('address', $validation));
-        $this->assertTrue(array_key_exists('name', $validation));
-        $this->assertTrue(array_key_exists('dob', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'address' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'dob' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'name' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -95,8 +102,15 @@ class ServiceTest extends AbstractServiceTestCase
         $apiProblem = $service->update($lpa->getId(), null, -1);
 
         $this->assertTrue($apiProblem instanceof ApiProblem);
-        $this->assertEquals(404, $apiProblem->getStatus());
-        $this->assertEquals('Document not found', $apiProblem->getDetail());
+        $this->assertEquals(
+            [
+                'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html',
+                'title' => 'Not Found',
+                'status' => 404,
+                'detail' => 'Document not found',
+            ],
+            $apiProblem->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -138,15 +152,20 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), $attorney->toArray(), $lpa->getDocument()->getPrimaryAttorneys()[1]->id);
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(3, count($validation));
-        $this->assertTrue(array_key_exists('address', $validation));
-        $this->assertTrue(array_key_exists('name', $validation));
-        $this->assertTrue(array_key_exists('dob', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'dob' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'name' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'address' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -188,8 +207,15 @@ class ServiceTest extends AbstractServiceTestCase
         $apiProblem = $service->delete($lpa->getId(), -1);
 
         $this->assertTrue($apiProblem instanceof ApiProblem);
-        $this->assertEquals(404, $apiProblem->getStatus());
-        $this->assertEquals('Document not found', $apiProblem->getDetail());
+        $this->assertEquals(
+            [
+                'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html',
+                'title' => 'Not Found',
+                'status' => 404,
+                'detail' => 'Document not found',
+            ],
+            $apiProblem->toArray()
+        );
 
         $serviceBuilder->verify();
     }

--- a/service-api/module/Application/tests/Model/Service/AttorneysReplacement/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/AttorneysReplacement/ServiceTest.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\AttorneysReplacement;
 
+use Laminas\ApiTools\ApiProblem\ApiProblem;
 use RuntimeException;
-use Application\Library\ApiProblem\ApiProblem;
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\DataModelEntity;
 use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\Attorneys\Human;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testCreateInvalidType()
     {
@@ -49,15 +51,20 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->create($lpa->getId(), $attorney->toArray());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(3, count($validation));
-        $this->assertTrue(array_key_exists('address', $validation));
-        $this->assertTrue(array_key_exists('name', $validation));
-        $this->assertTrue(array_key_exists('dob', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'address' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'dob' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'name' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -95,8 +102,15 @@ class ServiceTest extends AbstractServiceTestCase
         $apiProblem = $service->update($lpa->getId(), null, -1);
 
         $this->assertTrue($apiProblem instanceof ApiProblem);
-        $this->assertEquals(404, $apiProblem->getStatus());
-        $this->assertEquals('Document not found', $apiProblem->getDetail());
+        $this->assertEquals(
+            [
+                'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html',
+                'title' => 'Not Found',
+                'status' => 404,
+                'detail' => 'Document not found',
+            ],
+            $apiProblem->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -138,15 +152,20 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), $attorney->toArray(), $lpa->getDocument()->getReplacementAttorneys()[1]->id);
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(3, count($validation));
-        $this->assertTrue(array_key_exists('address', $validation));
-        $this->assertTrue(array_key_exists('name', $validation));
-        $this->assertTrue(array_key_exists('dob', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'address' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'dob' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'name' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -188,8 +207,15 @@ class ServiceTest extends AbstractServiceTestCase
         $apiProblem = $service->delete($lpa->getId(), -1);
 
         $this->assertTrue($apiProblem instanceof ApiProblem);
-        $this->assertEquals(404, $apiProblem->getStatus());
-        $this->assertEquals('Document not found', $apiProblem->getDetail());
+        $this->assertEquals(
+            [
+                'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html',
+                'title' => 'Not Found',
+                'status' => 404,
+                'detail' => 'Document not found',
+            ],
+            $apiProblem->toArray()
+        );
 
         $serviceBuilder->verify();
     }

--- a/service-api/module/Application/tests/Model/Service/CertificateProvider/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/CertificateProvider/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\CertificateProvider;
 
 use RuntimeException;
@@ -9,7 +11,7 @@ use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\CertificateProvider;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {
@@ -28,14 +30,19 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), $certificateProvider->toArray());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(2, count($validation));
-        $this->assertTrue(array_key_exists('name', $validation));
-        $this->assertTrue(array_key_exists('address', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'address' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'name' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -44,7 +51,7 @@ class ServiceTest extends AbstractServiceTestCase
     {
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 
@@ -99,13 +106,18 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->delete($lpa->getId());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('whoIsRegistering', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'whoIsRegistering' => ['value' => '1,2', 'messages' => ['allowed-values:']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -114,7 +126,7 @@ class ServiceTest extends AbstractServiceTestCase
     {
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 

--- a/service-api/module/Application/tests/Model/Service/Correspondent/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Correspondent/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\Correspondent;
 
 use RuntimeException;
@@ -9,7 +11,7 @@ use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\Correspondence;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {
@@ -28,14 +30,23 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), $correspondent->toArray());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertTrue(array_key_exists('name/company', $validation));
-        $this->assertTrue(array_key_exists('who', $validation));
-        $this->assertTrue(array_key_exists('address', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'address' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'name/company' => [
+                        'value' => 'MakeShared\DataModel\Lpa\Document\Correspondence',
+                        'messages' => ['cannot-be-null']
+                    ],
+                    'who' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -44,7 +55,7 @@ class ServiceTest extends AbstractServiceTestCase
     {
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 
@@ -99,13 +110,21 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->delete($lpa->getId());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('whoIsRegistering', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'whoIsRegistering' => [
+                        'value' => '1,2',
+                        'messages' => ['allowed-values:']
+                    ],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -114,7 +133,7 @@ class ServiceTest extends AbstractServiceTestCase
     {
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 

--- a/service-api/module/Application/tests/Model/Service/Donor/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Donor/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\Donor;
 
 use RuntimeException;
@@ -9,7 +11,7 @@ use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Document\Donor;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {
@@ -28,16 +30,21 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), $donor->toArray());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(4, count($validation));
-        $this->assertTrue(array_key_exists('name', $validation));
-        $this->assertTrue(array_key_exists('address', $validation));
-        $this->assertTrue(array_key_exists('dob', $validation));
-        $this->assertTrue(array_key_exists('canSign', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'address' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'canSign' => ['value' => null, 'messages' => ['cannot-be-null']],
+                    'dob' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'name' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -46,7 +53,7 @@ class ServiceTest extends AbstractServiceTestCase
     {
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 

--- a/service-api/module/Application/tests/Model/Service/Instruction/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Instruction/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\Instruction;
 
 use RuntimeException;
@@ -8,7 +10,7 @@ use Application\Model\Service\Instruction\Entity;
 use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {
@@ -27,13 +29,21 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), []);
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('type', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'type' => [
+                        'value' => 'Invalid',
+                        'messages' => ['allowed-values:property-and-financial,health-and-welfare'],
+                    ],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -42,7 +52,7 @@ class ServiceTest extends AbstractServiceTestCase
     {
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 

--- a/service-api/module/Application/tests/Model/Service/NotifiedPeople/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/NotifiedPeople/ServiceTest.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\NotifiedPeople;
 
-use Application\Library\ApiProblem\ApiProblem;
 use Application\Library\ApiProblem\ValidationApiProblem;
 use Application\Model\Service\DataModelEntity;
 use ApplicationTest\Model\Service\AbstractServiceTestCase;
+use Laminas\ApiTools\ApiProblem\ApiProblem;
 use MakeShared\DataModel\Lpa\Document\NotifiedPerson;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testCreateValidationFailed()
     {
@@ -26,14 +28,19 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->create($lpa->getId(), $person->toArray());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(2, count($validation));
-        $this->assertTrue(array_key_exists('name', $validation));
-        $this->assertTrue(array_key_exists('address', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'address' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'name' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -75,8 +82,15 @@ class ServiceTest extends AbstractServiceTestCase
         $apiProblem = $service->update($lpa->getId(), null, -1);
 
         $this->assertTrue($apiProblem instanceof ApiProblem);
-        $this->assertEquals(404, $apiProblem->getStatus());
-        $this->assertEquals('Document not found', $apiProblem->getDetail());
+        $this->assertEquals(
+            [
+                'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html',
+                'title' => 'Not Found',
+                'status' => 404,
+                'detail' => 'Document not found',
+            ],
+            $apiProblem->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -96,14 +110,19 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), $person->toArray(), $lpa->getDocument()->getPeopleToNotify()[0]->id);
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(2, count($validation));
-        $this->assertTrue(array_key_exists('name', $validation));
-        $this->assertTrue(array_key_exists('address', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'address' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                    'name' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -145,8 +164,15 @@ class ServiceTest extends AbstractServiceTestCase
         $apiProblem = $service->delete($lpa->getId(), -1);
 
         $this->assertTrue($apiProblem instanceof ApiProblem);
-        $this->assertEquals(404, $apiProblem->getStatus());
-        $this->assertEquals('Document not found', $apiProblem->getDetail());
+        $this->assertEquals(
+            [
+                'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html',
+                'title' => 'Not Found',
+                'status' => 404,
+                'detail' => 'Document not found',
+            ],
+            $apiProblem->toArray()
+        );
 
         $serviceBuilder->verify();
     }

--- a/service-api/module/Application/tests/Model/Service/Payment/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Payment/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\Payment;
 
 use RuntimeException;
@@ -9,7 +11,7 @@ use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeShared\DataModel\Lpa\Payment\Payment;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {
@@ -29,13 +31,18 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), $payment->toArray());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('method', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'method' => ['value' => 'Invalid', 'messages' => ['allowed-values:card,cheque']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -44,7 +51,7 @@ class ServiceTest extends AbstractServiceTestCase
     {
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 

--- a/service-api/module/Application/tests/Model/Service/Preference/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Preference/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\Preference;
 
 use RuntimeException;
@@ -8,7 +10,7 @@ use Application\Model\Service\Preference\Entity;
 use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {
@@ -26,13 +28,21 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), []);
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('type', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'type' => [
+                        'value' => 'Invalid',
+                        'messages' => ['allowed-values:property-and-financial,health-and-welfare']
+                    ],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -41,7 +51,7 @@ class ServiceTest extends AbstractServiceTestCase
     {
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 

--- a/service-api/module/Application/tests/Model/Service/RepeatCaseNumber/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/RepeatCaseNumber/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\RepeatCaseNumber;
 
 use Application\Library\ApiProblem\ValidationApiProblem;
@@ -7,7 +9,7 @@ use Application\Model\Service\RepeatCaseNumber\Entity;
 use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {
@@ -23,13 +25,18 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), ['repeatCaseNumber' => 'Invalid']);
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('repeatCaseNumber', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'repeatCaseNumber' => ['value' => 'Invalid', 'messages' => ['expected-type:int']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -68,13 +75,18 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->delete($lpa->getId());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('document.whoIsRegistering', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'document.whoIsRegistering' => ['value' => '1,2', 'messages' => ['allowed-values:']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }

--- a/service-api/module/Application/tests/Model/Service/Type/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Type/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\Type;
 
 use RuntimeException;
@@ -8,7 +10,7 @@ use Application\Model\Service\Type\Entity;
 use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {
@@ -24,13 +26,18 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), ['type' => 'Invalid']);
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('type', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'type' => ['value' => 'Invalid', 'messages' => ['allowed-values:property-and-financial,health-and-welfare']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -39,7 +46,7 @@ class ServiceTest extends AbstractServiceTestCase
     {
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 

--- a/service-api/module/Application/tests/Model/Service/WhoAreYou/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/WhoAreYou/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\WhoAreYou;
 
 use RuntimeException;
@@ -12,7 +14,7 @@ use Mockery;
 use MakeShared\DataModel\WhoAreYou\WhoAreYou;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateAlreadyAnswered()
     {
@@ -51,13 +53,18 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), $whoAreYou->toArray());
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('who', $validation));
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'who' => ['value' => null, 'messages' => ['cannot-be-blank']],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -67,7 +74,7 @@ class ServiceTest extends AbstractServiceTestCase
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
         $lpa->setWhoAreYouAnswered(false);
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 

--- a/service-api/module/Application/tests/Model/Service/WhoIsRegistering/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/WhoIsRegistering/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest\Model\Service\WhoIsRegistering;
 
 use RuntimeException;
@@ -8,7 +10,7 @@ use Application\Model\Service\WhoIsRegistering\Entity;
 use ApplicationTest\Model\Service\AbstractServiceTestCase;
 use MakeSharedTest\DataModel\FixturesData;
 
-class ServiceTest extends AbstractServiceTestCase
+final class ServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateValidationFailed()
     {
@@ -26,13 +28,22 @@ class ServiceTest extends AbstractServiceTestCase
         $validationError = $service->update($lpa->getId(), []);
 
         $this->assertTrue($validationError instanceof ValidationApiProblem);
-        $this->assertEquals(400, $validationError->getStatus());
-        $this->assertEquals('Your request could not be processed due to validation error', $validationError->getDetail());
-        $this->assertEquals('https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md', $validationError->getType());
-        $this->assertEquals('Bad Request', $validationError->getTitle());
-        $validation = $validationError->validation;
-        $this->assertEquals(1, count($validation));
-        $this->assertTrue(array_key_exists('type', $validation));
+
+        $this->assertEquals(
+            [
+                'type' => 'https://github.com/ministryofjustice/opg-lpa-datamodels/blob/master/docs/validation.md',
+                'title' => 'Bad Request',
+                'status' => 400,
+                'detail' => 'Your request could not be processed due to validation error',
+                'validation' => [
+                    'type' => [
+                        'value' => 'Invalid',
+                        'messages' => ['allowed-values:property-and-financial,health-and-welfare']
+                    ],
+                ]
+            ],
+            $validationError->toArray()
+        );
 
         $serviceBuilder->verify();
     }
@@ -41,7 +52,7 @@ class ServiceTest extends AbstractServiceTestCase
     {
         //The bad id value on this user will fail validation
         $lpa = FixturesData::getHwLpa();
-        $lpa->setUser(3);
+        $lpa->setUser('3');
 
         $user = FixturesData::getUser();
 


### PR DESCRIPTION
This allows us to use the standard APIProblem class, rather than one that is only customised for test purposes