### PR TITLE
Remove laminas-crypt from service-api

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -227,8 +227,6 @@
       <path value="$PROJECT_DIR$/service-api/vendor/phar-io/manifest" />
       <path value="$PROJECT_DIR$/service-api/vendor/laminas/laminas-loader" />
       <path value="$PROJECT_DIR$/service-api/vendor/mockery/mockery" />
-      <path value="$PROJECT_DIR$/service-api/vendor/laminas/laminas-crypt" />
-      <path value="$PROJECT_DIR$/service-api/vendor/laminas/laminas-math" />
       <path value="$PROJECT_DIR$/service-api/vendor/laminas/laminas-paginator" />
       <path value="$PROJECT_DIR$/service-api/vendor/laminas/laminas-db" />
       <path value="$PROJECT_DIR$/service-api/vendor/laminas/laminas-stdlib" />

--- a/service-api/composer.json
+++ b/service-api/composer.json
@@ -12,7 +12,6 @@
         "laminas/laminas-authentication": "^2.8",
         "laminas/laminas-cache": "^3.1.2",
         "laminas/laminas-cache-storage-adapter-memory": "2.2.0",
-        "laminas/laminas-crypt": "^3.4",
         "laminas/laminas-filter": "^2.12.0",
         "monolog/monolog": "^3.9",
         "laminas/laminas-mvc": "^3.2",

--- a/service-api/composer.lock
+++ b/service-api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e6f99183247259e489ab3c0c8ff36fb",
+    "content-hash": "32d2d6a6719477fd04f69493c18238a2",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -1634,70 +1634,6 @@
             "time": "2024-12-05T14:32:05+00:00"
         },
         {
-            "name": "laminas/laminas-crypt",
-            "version": "3.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-crypt.git",
-                "reference": "ceab630494fc7a0d82ec39ad63947ef889a21be7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-crypt/zipball/ceab630494fc7a0d82ec39ad63947ef889a21be7",
-                "reference": "ceab630494fc7a0d82ec39ad63947ef889a21be7",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "laminas/laminas-math": "^3.4",
-                "laminas/laminas-stdlib": "^3.8",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
-                "psr/container": "^1.1"
-            },
-            "conflict": {
-                "zendframework/zend-crypt": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "^9.5.25"
-            },
-            "suggest": {
-                "ext-openssl": "Required for most features of Laminas\\Crypt"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Crypt\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Strong cryptography tools and password hashing",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "crypt",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-crypt/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-crypt/issues",
-                "rss": "https://github.com/laminas/laminas-crypt/releases.atom",
-                "source": "https://github.com/laminas/laminas-crypt"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "abandoned": true,
-            "time": "2024-07-15T09:11:42+00:00"
-        },
-        {
             "name": "laminas/laminas-db",
             "version": "2.20.0",
             "source": {
@@ -2333,74 +2269,6 @@
             ],
             "abandoned": true,
             "time": "2024-12-05T14:43:32+00:00"
-        },
-        {
-            "name": "laminas/laminas-math",
-            "version": "3.8.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-math.git",
-                "reference": "a9e54f68accf5f8a3e66dd01fc6b32180e520018"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-math/zipball/a9e54f68accf5f8a3e66dd01fc6b32180e520018",
-                "reference": "a9e54f68accf5f8a3e66dd01fc6b32180e520018",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "conflict": {
-                "zendframework/zend-math": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "~9.5.25"
-            },
-            "suggest": {
-                "ext-bcmath": "If using the bcmath functionality",
-                "ext-gmp": "If using the gmp functionality"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev",
-                    "dev-develop": "3.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Math\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Create cryptographically secure pseudo-random numbers, and manage big integers",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "math"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-math/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-math/issues",
-                "rss": "https://github.com/laminas/laminas-math/releases.atom",
-                "source": "https://github.com/laminas/laminas-math"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "abandoned": true,
-            "time": "2024-12-05T13:49:56+00:00"
         },
         {
             "name": "laminas/laminas-modulemanager",

--- a/service-api/module/Application/tests/Model/Service/Pdfs/ServiceTest.php
+++ b/service-api/module/Application/tests/Model/Service/Pdfs/ServiceTest.php
@@ -14,7 +14,6 @@ use Aws\Result;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\S3Client;
 use Aws\Sqs\SqsClient;
-use Laminas\Crypt\BlockCipher;
 use MakeSharedTest\DataModel\FixturesData;
 use Mockery;
 
@@ -289,15 +288,9 @@ final class ServiceTest extends AbstractServiceTestCase
 
         $user = FixturesData::getUser();
 
-        $encryptionConfig = $this->config['pdf']['encryption'];
-        $blockCipher = BlockCipher::factory('openssl', $encryptionConfig['options']);
-        $blockCipher->setKey($encryptionConfig['keys']['document']);
-        $blockCipher->setBinaryOutput(true);
-        $encryptedData = $blockCipher->encrypt('test');
-
         $s3Client = Mockery::mock(S3Client::class);
         $s3ResultBody = Mockery::mock();
-        $s3ResultBody->shouldReceive('getContents')->andReturn($encryptedData)->once();
+        $s3ResultBody->shouldReceive('getContents')->andReturn('<<pdf-file-contents>>')->once();
         $s3Result = new Result();
         $s3Result['Body'] = $s3ResultBody;
 
@@ -322,6 +315,7 @@ final class ServiceTest extends AbstractServiceTestCase
         $fileResponse = $service->fetch($lpa->getId(), 'lp1.pdf');
 
         $this->assertTrue($fileResponse instanceof FileResponse);
+        $this->assertEquals('<<pdf-file-contents>>', $fileResponse->getContent());
 
         $serviceBuilder->verify();
     }


### PR DESCRIPTION
## Purpose

It was used in a test to encrypt a string, but that's not necessary since the code under test doesn't do any decryption (it happens inside the library being mocked out).

This also removes laminas-math.

Fixes LPA-3838 #patch

## Approach

I updated the test to assert the response first, confirming no decryption was happening, then simplified the mocked data to not used laminas-crypt.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have added mandatory tags to terraformed resources, where possible
  * N/A
* [x] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
  * N/A
* [x] If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
  * N/A
* [x] The product team have tested these changes
  * N/A
