### PR TITLE
Remove hardcoded PHP versions strings from rennovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -263,7 +263,7 @@
       "labels": [
         "Dependencies",
         "Renovate",
-        "PHP 8.2"
+        "PHP"
       ],
       "matchManagers": [
         "composer"
@@ -290,7 +290,7 @@
       "labels": [
         "Dependencies",
         "Renovate",
-        "PHP 8.3"
+        "PHP"
       ],
       "matchManagers": [
         "composer"
@@ -317,7 +317,7 @@
       "labels": [
         "Dependencies",
         "Renovate",
-        "PHP 8.2"
+        "PHP"
       ],
       "matchManagers": [
         "composer"

--- a/renovate.json
+++ b/renovate.json
@@ -236,7 +236,7 @@
       "labels": [
         "Dependencies",
         "Renovate",
-        "PHP 8.2"
+        "PHP"
       ],
       "matchManagers": [
         "composer"

--- a/renovate.json
+++ b/renovate.json
@@ -145,7 +145,7 @@
         "No updates to postgres, redis, php or python docker images",
         "postgres: keep in sync with live",
         "redis: keep in sync with live",
-        "php: 8.2 upgrade needs to be managed manually"
+        "php: upgrade needs to be managed manually"
       ],
       "matchUpdateTypes": [
         "major",
@@ -200,16 +200,16 @@
     },
     {
       "description": [
-        "admin composer minor and patch updates (PHP 8.2, stable for 3 days)",
+        "admin composer minor and patch updates (PHP, stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "admin minor and patch updates (PHP 8.2)",
-      "groupSlug": "admin-minor-patch-updates-php82",
+      "groupName": "admin minor and patch updates (PHP)",
+      "groupSlug": "admin-minor-patch-updates-php",
       "labels": [
         "Dependencies",
         "Renovate",
-        "PHP 8.2"
+        "PHP"
       ],
       "matchManagers": [
         "composer"
@@ -227,12 +227,12 @@
     },
     {
       "description": [
-        "front composer minor and patch updates (PHP 8.2, stable for 3 days)",
+        "front composer minor and patch updates (PHP, stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "front minor and patch updates (PHP 8.2)",
-      "groupSlug": "front-minor-patch-updates-php82",
+      "groupName": "front minor and patch updates (PHP)",
+      "groupSlug": "front-minor-patch-updates-php",
       "labels": [
         "Dependencies",
         "Renovate",
@@ -254,12 +254,12 @@
     },
     {
       "description": [
-        "api composer minor and patch updates (PHP 8.2, stable for 3 days)",
+        "api composer minor and patch updates (PHP, stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "api minor and patch updates (PHP 8.2)",
-      "groupSlug": "api-minor-patch-updates-php82",
+      "groupName": "api minor and patch updates (PHP)",
+      "groupSlug": "api-minor-patch-updates-php",
       "labels": [
         "Dependencies",
         "Renovate",
@@ -281,12 +281,12 @@
     },
     {
       "description": [
-        "pdf composer minor and patch updates (PHP 8.3, stable for 3 days)",
+        "pdf composer minor and patch updates (PHP, stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "pdf minor and patch updates (PHP 8.3)",
-      "groupSlug": "pdf-minor-patch-updates-php81",
+      "groupName": "pdf minor and patch updates (PHP)",
+      "groupSlug": "pdf-minor-patch-updates-php",
       "labels": [
         "Dependencies",
         "Renovate",
@@ -308,12 +308,12 @@
     },
     {
       "description": [
-        "shared composer minor and patch updates (PHP 8.2, stable for 3 days)",
+        "shared composer minor and patch updates (PHP, stable for 3 days)",
         "These might be automerged once we're comfortable with Renovate"
       ],
       "automerge": false,
-      "groupName": "shared minor and patch updates (PHP 8.2)",
-      "groupSlug": "shared-minor-patch-updates-php82",
+      "groupName": "shared minor and patch updates (PHP)",
+      "groupSlug": "shared-minor-patch-updates-php",
       "labels": [
         "Dependencies",
         "Renovate",


### PR DESCRIPTION
## Purpose

It makes no sense to hard code PHP versions into the strings for rennovate PR names/branch names. It's enought to say they're PHP updates.

Hardcoding just means they fall out of date (as they are now)

## Checklist

* [x] I have performed a self-review of my own code
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added mandatory tags to terraformed resources, where possible
* If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* If I added a package.json or composer.json, I also made sure this is included in the script in `.github/workflows/dependabot-update.yml`
* The product team have tested these changes
