### PR TITLE
LPAL-1577 - add admin protections ruleset to waf

### DIFF
--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -132,9 +132,33 @@ resource "aws_wafv2_web_acl" "main" {
       sampled_requests_enabled   = true
     }
   }
+
+  rule {
+    name     = "AWS-AWSManagedRulesAdminProtectionRuleSet"
+    priority = 40
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAdminProtectionRuleSet"
+        vendor_name = "AWS"
+        # (1 unchanged attribute hidden)
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesAdminProtectionRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
   rule {
     name     = "AWS-AWSManagedRulesAmazonIpReputationList"
-    priority = 40
+    priority = 50
 
     override_action {
       none {}


### PR DESCRIPTION
## Purpose

Give some additional protections against inputs that compromise exposed admin software

Fixes LPAL-1577

## Approach

- add AWS Admin protections ruleset
- TODO: override for actual admin usage

## Learning

- https://docs.aws.amazon.com/waf/latest/developerguide/web-acl-processing-order.html
- https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-admin