### PR TITLE
Complete dockerisation of PHPCS workflow

### DIFF
--- a/.github/workflows/analysis-phpcs.yml
+++ b/.github/workflows/analysis-phpcs.yml
@@ -17,21 +17,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      - name: Setup PHP
-        uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # 2.35.5
-        with:
-          php-version: 8.4
-          coverage: none # disable xdebug, pcov
-          tools: cs2pr
       - name: Run phpcs
         id: phpcs
-        env:
-          PHPCS_REPORT: checkstyle
-        run: make dc-phpcs-check > phpcs-report.xml
-      - name: Fix paths in PHPCS report
-        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
-        run: |
-          sed -i 's|name="/app/|name="|g' phpcs-report.xml
+        run: make dc-phpcs-check
       - name: Publish PHPCS as PR annotations
         if: ${{ always() && steps.phpcs.outcome == 'failure' }}
-        run: cs2pr ./phpcs-report.xml
+        run: docker compose run --rm --no-deps --entrypoint=vendor/bin/cs2pr phpcs /app/output/phpcs-report.xml

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ coverage-xml
 coverage-html
 .php-cs-fixer.cache
 shared/module/MakeShared/tests/autoload.php
-phpcs/config/
+phpcs/output/
 service-pdf/before.png
 service-pdf/after.png
 service-pdf/*.pdf

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,6 @@ COMPOSER_VERSION := "2.8.11"
 # Unique identifier for this version of the application
 APP_VERSION := $(shell echo -n `git rev-parse --short HEAD`)
 
-PHPCS_REPORT ?= full
-
 #COLORS
 YELLOW := $(shell tput -Txterm setaf 3)
 RESET  := $(shell tput -Txterm sgr0)
@@ -287,7 +285,7 @@ dc-phpcs-fix:
 
 dc-phpcs-check:
 	docker compose build phpcs
-	docker compose run --rm --no-deps --entrypoint "./vendor/bin/phpcs --standard=/app/config/phpcs.xml.dist" phpcs --report=${PHPCS_REPORT}
+	docker compose run --rm --no-deps --entrypoint "./vendor/bin/phpcs --standard=/app/config/phpcs.xml.dist" phpcs --basepath=/app --report=full --report-checkstyle=/app/output/phpcs-report.xml
 
 dc-clear-cache:
 	docker compose exec admin-app rm -f /app/tmp/config-cache-opg-lpa-admin.php

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -460,6 +460,7 @@ services:
       - ./service-pdf:/app/service-pdf
       - ./shared:/app/shared
       - ./phpcs.xml.dist:/app/config/phpcs.xml.dist
+      - ./phpcs/output:/app/output
 
   shared-test:
     image: lpa-shared-test

--- a/phpcs/composer.json
+++ b/phpcs/composer.json
@@ -6,8 +6,9 @@
         "php": "8.4.*"
     },
     "require-dev": {
-      "squizlabs/php_codesniffer": "^4.0",
-      "slevomat/coding-standard": "^8.0"
+        "slevomat/coding-standard": "^8.0",
+        "squizlabs/php_codesniffer": "^4.0",
+        "staabm/annotate-pull-request-from-checkstyle": "^1.0"
     },
     "config": {
         "allow-plugins": {

--- a/phpcs/composer.lock
+++ b/phpcs/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6544175b2e0515d39e5b2fd0391cad93",
+    "content-hash": "d2b6ee8aedd5c63e7cadd37f557548fa",
     "packages": [],
     "packages-dev": [
         {
@@ -294,6 +294,58 @@
                 }
             ],
             "time": "2025-11-10T16:43:36+00:00"
+        },
+        {
+            "name": "staabm/annotate-pull-request-from-checkstyle",
+            "version": "1.8.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/annotate-pull-request-from-checkstyle.git",
+                "reference": "5072e6827aab0a287528b971e6b8e986b20be41c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/annotate-pull-request-from-checkstyle/zipball/5072e6827aab0a287528b971e6b8e986b20be41c",
+                "reference": "5072e6827aab0a287528b971e6b8e986b20be41c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-libxml": "*",
+                "ext-simplexml": "*",
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16.1"
+            },
+            "bin": [
+                "cs2pr"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Staab"
+                }
+            ],
+            "keywords": [
+                "Github Actions",
+                "continous integration",
+                "dev"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/annotate-pull-request-from-checkstyle/issues",
+                "source": "https://github.com/staabm/annotate-pull-request-from-checkstyle/tree/1.8.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-17T05:20:34+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
## Purpose

Continue to remove `setup-php` whilst improving our test runners.

<img width="847" height="217" alt="image" src="https://github.com/user-attachments/assets/ce9c3f26-c7ce-4b99-aed6-55ac5c3548b1" />

Fixes LPAL-1983 #patch

## Approach

- Install `staabm/annotate-pull-request-from-checkstyle` to give us access to `cs2pr`
- Output an XML file on a volume mount
- Use `--basepath` to get relative paths rather than sed-ing the file
- Pass that file to `cs2pr`
- Tidy up some the phpcs container

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added mandatory tags to terraformed resources, where possible
* [ ] If I have a new OPG component dependency, I have updated the `metadata.json` with the repo location.
* [ ] The product team have tested these changes
