### PR TITLE
Add build args to test runner services

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -220,7 +220,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "9f75b3e3dc93390c18a538f001b0f6f4e2d1f46b",
         "is_verified": false,
-        "line_number": 334
+        "line_number": 338
       }
     ],
     "docs/runbooks/seeding_non_live_environments/seeding_non-live_environments.md": [
@@ -950,5 +950,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-08T16:50:17Z"
+  "generated_at": "2026-04-14T13:57:54Z"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,6 +174,8 @@ services:
       context: ./
       dockerfile: service-front/docker/app/Dockerfile
       target: test-runner
+      args:
+        ENABLE_XDEBUG: "1"
 
   front-ssl:
     container_name: lpa-front-ssl
@@ -289,6 +291,8 @@ services:
       context: ./
       dockerfile: service-api/docker/app/Dockerfile
       target: test-runner
+      args:
+        ENABLE_XDEBUG: "1"
 
   # ---------------------------
   # Admin
@@ -357,6 +361,8 @@ services:
       context: ./
       dockerfile: service-admin/docker/app/Dockerfile
       target: test-runner
+      args:
+        ENABLE_XDEBUG: "1"
 
   admin-ssl:
     container_name: lpa-admin-ssl
@@ -420,6 +426,9 @@ services:
       context: ./
       dockerfile: service-pdf/docker/app/Dockerfile
       target: test-runner
+      args:
+        ENABLE_XDEBUG: "1"
+        VISUAL_TESTS: true
 
   # ---------------------------
   # Seeding


### PR DESCRIPTION
## Purpose

This ensures xdebug and imagick are installed where required so test runners can build and run their scripts correctly.

For LPAL-1983 #patch