### PR TITLE
Fix destroy jobs

### DIFF
--- a/.github/workflows/workflow_destroy_on_merge.yml
+++ b/.github/workflows/workflow_destroy_on_merge.yml
@@ -63,7 +63,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           aws-region: eu-west-1
-          role-duration-seconds: 900
+          role-duration-seconds: 1800
           role-session-name: OPGLPADestroyEphemeralEnvironment
           role-to-assume: ${{ vars.OIDC_TERRAFORM_ROLE_DEVELOPMENT }}
 

--- a/.github/workflows/workflow_terraform_environment_cleanup.yml
+++ b/.github/workflows/workflow_terraform_environment_cleanup.yml
@@ -2,8 +2,8 @@ name: "[Workflow] Cleanup PR Workspaces"
 
 on:
   schedule:
-    # 6am and 6pm every day except Sundays
-    - cron: "0 6,18 * * 0-6"
+    # Run Hourly
+    - cron: "0 * * * *"
 
 permissions:
   actions: none


### PR DESCRIPTION
## Purpose

Destroy on PR close/merge was failing because it was taking longer than the session duration. The cleanup job was running too infrequently.

## Approach

- Extend session duration for destroy environment
- Run Workspace Cleanup hourly
