### PR TITLE
LPAL-2017 | enabling cross account backup for prod

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -86,7 +86,7 @@
       "database": {
         "cluster_identifier": "api2-20260414",
         "aurora_cross_region_backup_enabled": true,
-        "cross_account_backup_enabled": false,
+        "cross_account_backup_enabled": true,
         "aurora_restore_testing_enabled": false,
         "enable_backup_vault_lock":  false,
         "daily_backup_deletion": 2,
@@ -149,7 +149,7 @@
       "database": {
         "cluster_identifier": "api2-20260415",
         "aurora_cross_region_backup_enabled": true,
-        "cross_account_backup_enabled": false,
+        "cross_account_backup_enabled": true,
         "aurora_restore_testing_enabled": false,
         "enable_backup_vault_lock":  false,
         "daily_backup_deletion": 30,

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -149,7 +149,7 @@
       "database": {
         "cluster_identifier": "api2-20260415",
         "aurora_cross_region_backup_enabled": true,
-        "cross_account_backup_enabled": true,
+        "cross_account_backup_enabled": false,
         "aurora_restore_testing_enabled": false,
         "enable_backup_vault_lock":  false,
         "daily_backup_deletion": 30,


### PR DESCRIPTION
## Purpose
Enabling cross account backup on production now that db has been encrypted with new cmk 

Fixes LPAL-2017


- enable on preprod first to test for 24 hours 
- then prod if successful 


## Learning

_
