### PR TITLE
LPAL-2019 bug fix - Preferences and instructions missing text when printing PDF

### DIFF
--- a/service-front/module/Application/src/Filter/StripTagsPreservingAngleBrackets.php
+++ b/service-front/module/Application/src/Filter/StripTagsPreservingAngleBrackets.php
@@ -45,6 +45,11 @@ class StripTagsPreservingAngleBrackets implements FilterInterface
         // Decode HTML entities back to literal characters so that
         // stored data contains "<" not "&lt;". Output escaping in
         // templates (Twig auto-escape, FormTextarea) handles XSS.
-        return html_entity_decode($purified, ENT_QUOTES, 'UTF-8');
+        $decoded = html_entity_decode($purified, ENT_QUOTES, 'UTF-8');
+
+        $decoded = str_replace("\r\n", "\n", $decoded);
+        $decoded = str_replace("\n", "\r\n", $decoded);
+
+        return $decoded;
     }
 }

--- a/service-front/module/Application/tests/Filter/StripTagsPreservingAngleBracketsTest.php
+++ b/service-front/module/Application/tests/Filter/StripTagsPreservingAngleBracketsTest.php
@@ -88,16 +88,24 @@ final class StripTagsPreservingAngleBracketsTest extends TestCase
         );
     }
 
-    public function testPreservesNewlines(): void
+    public function testNewlinesConvertedToCrLf(): void
     {
         $input = "Line one\nLine two\nLine three";
+        $expected = "Line one\r\nLine two\r\nLine three";
+        $this->assertEquals($expected, $this->filter->filter($input));
+    }
+
+    public function testCrLfPreserved(): void
+    {
+        $input = "Line one\r\nLine two\r\nLine three";
         $this->assertEquals($input, $this->filter->filter($input));
     }
 
     public function testPreservesTextAfterLoneAngleBracket(): void
     {
         $input = "Line one has a < sign\nLine two should still be here";
-        $this->assertEquals($input, $this->filter->filter($input));
+        $expected = "Line one has a < sign\r\nLine two should still be here";
+        $this->assertEquals($expected, $this->filter->filter($input));
     }
 
     public function testReturnsNonStringInputUnchanged(): void

--- a/shared/module/MakeShared/src/DataModel/Lpa/Formatter.php
+++ b/shared/module/MakeShared/src/DataModel/Lpa/Formatter.php
@@ -38,7 +38,10 @@ class Formatter
 
         $content = '';
 
-        foreach (explode("\r\n", trim($text)) as $contentLine) {
+        $text = str_replace("\r\n", "\n", trim($text));
+        $text = str_replace("\r", "\n", $text);
+
+        foreach (explode("\n", $text) as $contentLine) {
             $content .= wordwrap($contentLine, self::INSTRUCTIONS_PREFERENCES_ROW_WIDTH, "\r\n", false);
             $content .= "\r\n";
         }

--- a/shared/module/MakeShared/tests/DataModel/Lpa/FormatterTest.php
+++ b/shared/module/MakeShared/tests/DataModel/Lpa/FormatterTest.php
@@ -76,4 +76,17 @@ class FormatterTest extends TestCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    public function testFlattenInstructionsOrPreferencesWithLfOnlyNewlines()
+    {
+        $text = "Line one.\nLine two.\nLine three.";
+
+        $expected = "Line one.                                                                           \r\n" .
+                    "Line two.                                                                           \r\n" .
+                    "Line three.                                                                         ";
+
+        $actual = Formatter::flattenInstructionsOrPreferences($text);
+
+        $this->assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
LPAL-2019 

the HTMLPurifier normalises \r\n to \n, and the PDF formatter splits text on \r\n to calculate the line breaks and the continuation sheet overflow.
When the text was stored with \n only, the formatter treated the entire content as a single line, causing the text to be cut off

now restoring \r\n after htmlpurifier in the filter, and make the formatter handle any new line style (\r\n, \r, \n)