### PR TITLE
LPAL-1681: POC mezzio-csrf implementation

### DIFF
--- a/.idea/opg-lpa.iml
+++ b/.idea/opg-lpa.iml
@@ -422,6 +422,7 @@
       <excludeFolder url="file://$MODULE_DIR$/service-admin/vendor/mezzio/mezzio-session-ext" />
       <excludeFolder url="file://$MODULE_DIR$/terraform/environment/.terraform" />
       <excludeFolder url="file://$MODULE_DIR$/service-front/vendor/ezyang/htmlpurifier" />
+      <excludeFolder url="file://$MODULE_DIR$/service-front/vendor/mezzio/mezzio-csrf" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -689,6 +689,7 @@
       <path value="$PROJECT_DIR$/shared/vendor/webmozart/path-util" />
       <path value="$PROJECT_DIR$/vendor/composer" />
       <path value="$PROJECT_DIR$/service-front/vendor/ezyang/htmlpurifier" />
+      <path value="$PROJECT_DIR$/service-front/vendor/mezzio/mezzio-csrf" />
     </include_path>
   </component>
   <component name="PhpInterpreters">

--- a/service-front/composer.json
+++ b/service-front/composer.json
@@ -28,6 +28,7 @@
         "laminas/laminas-mvc": "^3.2",
         "laminas/laminas-mvc-middleware": "2.5",
         "laminas/laminas-session": "^2.12.0",
+        "mezzio/mezzio-csrf": "^1.11",
         "mezzio/mezzio-session": "^1.17",
         "mezzio/mezzio-session-ext": "^1.21",
         "mezzio/mezzio-twigrenderer": "^2.18",

--- a/service-front/composer.lock
+++ b/service-front/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df0d7409a79907704263dff4d7280d51",
+    "content-hash": "0ec21324e9329c994e68e607087e97ea",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -3215,6 +3215,80 @@
                 }
             ],
             "time": "2025-08-07T08:55:27+00:00"
+        },
+        {
+            "name": "mezzio/mezzio-csrf",
+            "version": "1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mezzio/mezzio-csrf.git",
+                "reference": "e6eedfacc9dbbde2ca51b24a121b765f4331e8ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mezzio/mezzio-csrf/zipball/e6eedfacc9dbbde2ca51b24a121b765f4331e8ab",
+                "reference": "e6eedfacc9dbbde2ca51b24a121b765f4331e8ab",
+                "shasum": ""
+            },
+            "require": {
+                "mezzio/mezzio-session": "^1.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.0 || ^2.0",
+                "psr/http-server-middleware": "^1.0"
+            },
+            "conflict": {
+                "zendframework/zend-expressive-csrf": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "mezzio/mezzio-flash": "^1.9",
+                "phpunit/phpunit": "^11.5.42",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "suggest": {
+                "mezzio/mezzio-flash": "^1.0 To back CSRF tokens using flash messages"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Mezzio\\Csrf\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mezzio\\Csrf\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "CSRF token generation and validation for PSR-7 and PSR-15 applications using mezzio-session",
+            "homepage": "https://mezzio.dev",
+            "keywords": [
+                "csrf",
+                "laminas",
+                "mezzio",
+                "psr-15",
+                "psr-7",
+                "security",
+                "session"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.mezzio.dev/mezzio-csrf/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/mezzio-csrf/issues",
+                "rss": "https://github.com/mezzio/mezzio-csrf/releases.atom",
+                "source": "https://github.com/mezzio/mezzio-csrf"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-12T19:39:41+00:00"
         },
         {
             "name": "mezzio/mezzio-helpers",

--- a/service-front/module/Application/config/module.routes.php
+++ b/service-front/module/Application/config/module.routes.php
@@ -69,10 +69,13 @@ use Application\Listener\TermsAndConditionsListener;
 use Application\Listener\UserDetailsListener;
 use Application\Handler\ChangeEmailAddressHandler;
 use Application\Helper\RouteMiddlewareHelper;
+use Application\Middleware\CsrfValidationMiddleware;
 use Application\Middleware\LpaLoaderMiddleware;
+use Application\Middleware\MvcSessionBridgeMiddleware;
 use Laminas\Mvc\Middleware\PipeSpec;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Segment;
+use Mezzio\Csrf\CsrfMiddleware;
 
 return [
 
@@ -913,7 +916,11 @@ return [
                             'route'    => '/type',
                             'defaults' => [
                                 'controller' => PipeSpec::class,
-                                'middleware' => RouteMiddlewareHelper::addMiddleware(TypeHandler::class, []),
+                                'middleware' => RouteMiddlewareHelper::addMiddleware(
+                                    TypeHandler::class,
+                                    [],
+                                    [MvcSessionBridgeMiddleware::class, CsrfMiddleware::class, CsrfValidationMiddleware::class],
+                                ),
                             ],
                         ],
                     ],

--- a/service-front/module/Application/src/Handler/TypeHandler.php
+++ b/service-front/module/Application/src/Handler/TypeHandler.php
@@ -17,6 +17,7 @@ use MakeShared\DataModel\Lpa\Document\Document;
 use MakeShared\DataModel\Lpa\Document\Donor;
 use MakeShared\DataModel\Lpa\Lpa;
 use Application\Helper\MvcUrlHelper;
+use Application\Middleware\CsrfValidationMiddleware;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -49,8 +50,19 @@ class TypeHandler implements RequestHandlerInterface
 
         $currentRoute = (string) $request->getAttribute(RequestAttribute::CURRENT_ROUTE_NAME);
 
+        $csrfToken = $request->getAttribute(CsrfValidationMiddleware::TOKEN_ATTRIBUTE);
+
         /** @var TypeForm $form */
         $form = $this->formElementManager->get('Application\Form\Lpa\TypeForm');
+
+        // mezzio-csrf handles CSRF via CsrfValidationMiddleware; remove the form's
+        // built-in CSRF element so it doesn't interfere with form validation.
+        $csrfElement = $form->getCsrf();
+        if ($csrfElement !== null) {
+            $csrfName = $csrfElement->getName();
+            $form->remove($csrfName);
+            $form->getInputFilter()->remove($csrfName);
+        }
 
         $isChangeAllowed = true;
 
@@ -114,6 +126,7 @@ class TypeHandler implements RequestHandlerInterface
                     'cloneUrl'        => $cloneUrl,
                     'nextUrl'         => $nextUrl,
                     'isChangeAllowed' => $isChangeAllowed,
+                    'csrfToken'       => $csrfToken,
                 ]
             )
         );

--- a/service-front/module/Application/src/Helper/RouteMiddlewareHelper.php
+++ b/service-front/module/Application/src/Helper/RouteMiddlewareHelper.php
@@ -18,8 +18,9 @@ class RouteMiddlewareHelper
      *
      * @param string $handlerClass The handler to append at the end of the pipeline.
      * @param string[] $ignore Middleware classes to omit from the stack.
+     * @param string[] $extra Additional middleware classes to insert immediately before the handler.
      */
-    public static function addMiddleware(string $handlerClass, array $ignore): PipeSpec
+    public static function addMiddleware(string $handlerClass, array $ignore, array $extra = []): PipeSpec
     {
         $middlewares = array_diff([
             RouteMatchMiddleware::class,
@@ -29,6 +30,7 @@ class RouteMiddlewareHelper
             LpaLoaderMiddleware::class,
         ], $ignore);
 
+        array_push($middlewares, ...$extra);
         $middlewares[] = $handlerClass;
 
         return new PipeSpec(...$middlewares);

--- a/service-front/module/Application/src/Middleware/CsrfValidationMiddleware.php
+++ b/service-front/module/Application/src/Middleware/CsrfValidationMiddleware.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Laminas\Diactoros\Response\RedirectResponse;
+use Mezzio\Csrf\CsrfMiddleware;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class CsrfValidationMiddleware implements MiddlewareInterface
+{
+    public const TOKEN_ATTRIBUTE = 'csrfToken';
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $guard = $request->getAttribute(CsrfMiddleware::GUARD_ATTRIBUTE);
+
+        if (strtoupper($request->getMethod()) === RequestMethodInterface::METHOD_POST) {
+            $token = ($request->getParsedBody() ?? [])['__csrf'] ?? '';
+
+            if (!$guard->validateToken($token)) {
+                return new RedirectResponse($request->getUri()->getPath());
+            }
+        }
+
+        // Generate a fresh token and make it available to downstream handlers/templates
+        $request = $request->withAttribute(self::TOKEN_ATTRIBUTE, $guard->generateToken());
+
+        return $handler->handle($request);
+    }
+}

--- a/service-front/module/Application/src/Middleware/MvcSessionBridgeMiddleware.php
+++ b/service-front/module/Application/src/Middleware/MvcSessionBridgeMiddleware.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware;
+
+use Mezzio\Session\Session;
+use Mezzio\Session\SessionMiddleware;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Bridges the already-active laminas-mvc PHP session into a Mezzio SessionInterface,
+ * without attempting to start a new session or change the session ID.
+ *
+ * This replaces SessionMiddleware (and PhpSessionPersistence) for routes that are
+ * still dispatched through the laminas-mvc stack, where the PHP session has already
+ * been started before our PSR-15 pipeline runs. Using the standard SessionMiddleware
+ * in this context causes a PHP warning because PhpSessionPersistence tries to change
+ * the session ID on an already-active session.
+ *
+ * On the way in:  wraps $_SESSION in a Mezzio Session and injects it as a request attribute.
+ * On the way out: writes any changes back to $_SESSION.
+ */
+class MvcSessionBridgeMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (PHP_SESSION_ACTIVE !== session_status()) {
+            session_start();
+        }
+
+        $session = new Session($_SESSION, session_id());
+
+        $request = $request->withAttribute(SessionMiddleware::SESSION_ATTRIBUTE, $session);
+
+        $response = $handler->handle($request);
+
+        // Write changes back to the native PHP session
+        $_SESSION = $session->toArray();
+
+        return $response;
+    }
+}

--- a/service-front/module/Application/src/Module.php
+++ b/service-front/module/Application/src/Module.php
@@ -146,6 +146,8 @@ use Application\Listener\TrailingSlashRedirectListener;
 use Application\Listener\UserDetailsListener;
 use Application\Listener\ViewVariablesListener;
 use Application\Middleware\LpaLoaderMiddleware;
+use Application\Middleware\CsrfValidationMiddleware;
+use Application\Middleware\MvcSessionBridgeMiddleware;
 use Application\Middleware\RouteMatchMiddleware;
 use Application\Model\Service\ApiClient\Exception\ApiException;
 use Application\Model\Service\Authentication\Adapter\LpaAuthAdapter;
@@ -196,6 +198,8 @@ use MakeShared\DataModel\Lpa\Payment\Calculator;
 use MakeShared\Logging\LoggerFactory;
 use MakeShared\Telemetry\Exporter\ExporterFactory;
 use MakeShared\Telemetry\Tracer;
+use Mezzio\Csrf\CsrfMiddleware;
+use Mezzio\Csrf\SessionCsrfGuardFactory;
 use Mezzio\Session\Ext\PhpSessionPersistence;
 use Mezzio\Session\SessionMiddleware;
 use Mezzio\Template\TemplateRendererInterface;
@@ -378,6 +382,9 @@ class Module implements FormElementProviderInterface
                 },
                 SessionMiddleware::class => function () {
                     return new SessionMiddleware(new PhpSessionPersistence());
+                },
+                CsrfMiddleware::class => function () {
+                    return new CsrfMiddleware(new SessionCsrfGuardFactory());
                 },
                 'ExporterFactory'       => ReflectionBasedAbstractFactory::class,
 
@@ -569,6 +576,8 @@ class Module implements FormElementProviderInterface
                 },
 
                 RouteMatchMiddleware::class => InvokableFactory::class,
+                MvcSessionBridgeMiddleware::class => InvokableFactory::class,
+                CsrfValidationMiddleware::class => InvokableFactory::class,
 
                 RegisterHandler::class => RegisterHandlerFactory::class,
                 ResendActivationEmailHandler::class => ResendActivationEmailHandlerFactory::class,

--- a/service-front/module/Application/view/application/authenticated/lpa/type/index.twig
+++ b/service-front/module/Application/view/application/authenticated/lpa/type/index.twig
@@ -57,7 +57,7 @@
     {# begin form #}
     {{ form.prepare() ? '' }}
     {{ form().openTag( form )|raw }}
-        {{ formElement(form.getCsrf) }}
+        <input type="hidden" name="__csrf" value="{{ csrfToken }}">
 
         {# Error summary #}
         {{ macros.formErrorSummary(error,form) }}


### PR DESCRIPTION
## Purpose

There are a couple of additional things in place due to running a mezzio component inside laminas-mvc, but this seems to work OK, and if we're happy with it, we could update all our handlers to use this.

The question remains though, whether we will see the same intermittent issues with inconsistent validation errors that appeared to be linked to higher traffic validations writing to a session - it's difficult to simulate this when applying to a single handler.

Satisfies LPAL-1681.