### PR TITLE
LPAL-2017 | Enabling cross-account-backup for Production

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -149,7 +149,7 @@
       "database": {
         "cluster_identifier": "api2-20260415",
         "aurora_cross_region_backup_enabled": true,
-        "cross_account_backup_enabled": false,
+        "cross_account_backup_enabled": true,
         "aurora_restore_testing_enabled": false,
         "enable_backup_vault_lock":  false,
         "daily_backup_deletion": 30,


### PR DESCRIPTION
## Purpose

Now that our DB has been re-encrypted with a CMK and cross account backup has been tested successfully for preproduction -  this can be enabled on Production. 


Fixes LPAL-2017
