### PR TITLE
pin precommit hooks, update baseline for hook digests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace # trims trailing whitespace.
       - id: check-added-large-files # prevents giant files from being committed.
@@ -20,14 +20,14 @@ repos:
       - id: end-of-file-fixer
         exclude: ".*/package-lock.json"
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.86.0
+    rev: d0e12caebb2ab0ee8bf98181c8bfe9702bca103d  # frozen: v1.105.0
     hooks:
       - id: terraform_fmt
       - id: terraform_tflint
         args:
         - --args=--recursive
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
+    rev: 68e8b45440415753fff70a312ece8da92ba85b4a  # frozen: v1.5.0
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
@@ -39,11 +39,11 @@ repos:
       entry: docker compose run --rm -T --no-deps phpcs
       files: \.(php)$
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: c6755bb741b6481d6b3d3bb563c83fa060db96c9  # frozen: 26.3.1
     hooks:
     - id: black
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.39.1
+    rev: aba7df358642862cbd44be4afe010013a77d009a  # frozen: v10.1.0
     hooks:
     - id: eslint
       files: service-front/assets/js|cypress/e2e/common
@@ -52,11 +52,11 @@ repos:
       -   eslint@9
       -   eslint-plugin-prettier@v5
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 40.32.7
+    rev: e25675f5d5bdcedb8a5ccb75b5f92c8ec0455cb6  # frozen: 43.132.1
     hooks:
       - id: renovate-config-validator
   - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: v1.0.0-rc.2
+    rev: f298c082154b2cb239fac06a4f452368e66e66dd  # frozen: v1.0.0-rc.4
     hooks:
       - id: go-imports # replaces go-fmt
       - id: go-mod-tidy

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -127,6 +123,57 @@
     }
   ],
   "results": {
+    ".pre-commit-config.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "26f89e75489173ffe046cc843b9a983e65020901",
+        "is_verified": false,
+        "line_number": 5
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "384557cbc10c11a779cbe5ce8fd9838d2adf434b",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "86242b7a7b67c1fd83514757a6b319602d648e94",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "39b340a897c67c216e634918d92280f0f09dc6db",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "68a36d55d08af775871f4c9dc0457b7fb894b257",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "e17e66247d13310185c7c752dca8754717961284",
+        "is_verified": false,
+        "line_number": 55
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "780351622914d813ee8b73df3a697d2ec075d1e8",
+        "is_verified": false,
+        "line_number": 59
+      }
+    ],
     "cypress/e2e/AttorneysPF.feature": [
       {
         "type": "Base64 High Entropy String",
@@ -684,24 +731,6 @@
         "line_number": 41
       }
     ],
-    "service-front/module/Application/tests/Controller/Authenticated/ChangePasswordControllerTest.php": [
-      {
-        "type": "Secret Keyword",
-        "filename": "service-front/module/Application/tests/Controller/Authenticated/ChangePasswordControllerTest.php",
-        "hashed_secret": "b44dda1dadd351948fcace1856ed97366e679239",
-        "is_verified": false,
-        "line_number": 19
-      }
-    ],
-    "service-front/module/Application/tests/Controller/General/AuthControllerTest.php": [
-      {
-        "type": "Secret Keyword",
-        "filename": "service-front/module/Application/tests/Controller/General/AuthControllerTest.php",
-        "hashed_secret": "5ad715aabe02e21ebc8315bd0cf20f0e436e916c",
-        "is_verified": false,
-        "line_number": 26
-      }
-    ],
     "service-front/module/Application/tests/Form/User/AboutYouTest.php": [
       {
         "type": "Hex High Entropy String",
@@ -877,15 +906,6 @@
         "line_number": 8
       }
     ],
-    "service-front/public/assets/v2/js/govuk-frontend.min.js": [
-      {
-        "type": "Secret Keyword",
-        "filename": "service-front/public/assets/v2/js/govuk-frontend.min.js",
-        "hashed_secret": "8474d065e6669d5fe84ea4a3ef814e128f554c85",
-        "is_verified": false,
-        "line_number": 1
-      }
-    ],
     "service-pdf/tests/fixtures/lpa-hw.json": [
       {
         "type": "Hex High Entropy String",
@@ -950,5 +970,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-15T14:46:04Z"
+  "generated_at": "2026-04-20T11:29:42Z"
 }


### PR DESCRIPTION
## Purpose

Pin hooks.

## Approach

- run `pre-commit autoupdate --freeze`
- review results to make sure they comply with dependency management rules
- update detect-secrets baseline