### PR TITLE
Lpal 2007 try mezzio now with mezzio

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="LaravelPint">
+    <laravel_pint_settings>
+      <laravel_pint_by_interpreter asDefaultInterpreter="true" interpreter_id="49d29832-bc24-4bae-8a82-2c3eb403a4b1">
+        <option name="timeout" value="30000" />
+      </laravel_pint_by_interpreter>
+    </laravel_pint_settings>
+  </component>
   <component name="MessDetector">
     <phpmd_settings>
       <phpmd_by_interpreter asDefaultInterpreter="true" interpreter_id="49d29832-bc24-4bae-8a82-2c3eb403a4b1" timeout="30000" />
@@ -17,7 +24,7 @@
   </component>
   <component name="PhpCSFixer">
     <phpcsfixer_settings>
-      <phpcs_fixer_by_interpreter asDefaultInterpreter="true" interpreter_id="088c6e8f-c48c-4fdd-b2ba-3c2d21a222d7" timeout="30000" />
+      <phpcs_fixer_by_interpreter asDefaultInterpreter="true" interpreter_id="49d29832-bc24-4bae-8a82-2c3eb403a4b1" timeout="30000" />
     </phpcsfixer_settings>
   </component>
   <component name="PhpCodeSniffer">

--- a/service-front/mezzio/.gitignore
+++ b/service-front/mezzio/.gitignore
@@ -1,0 +1,7 @@
+/.phpcs-cache
+/.psalm-cache
+/.phpunit.cache
+/clover.xml
+/coveralls-upload.json
+/phpunit.xml
+/vendor/

--- a/service-front/mezzio/.laminas-ci/pre-run.sh
+++ b/service-front/mezzio/.laminas-ci/pre-run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Due to the fact that we are disabling plugins when installing/updating/downgrading composer dependencies
+# we have to manually enable the coding standard here.
+composer enable-codestandard

--- a/service-front/mezzio/COPYRIGHT.md
+++ b/service-front/mezzio/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2020 Laminas Project a Series of LF Projects, LLC. (https://getlaminas.org/)

--- a/service-front/mezzio/LICENSE.md
+++ b/service-front/mezzio/LICENSE.md
@@ -1,0 +1,26 @@
+Copyright (c) 2020 Laminas Project a Series of LF Projects, LLC.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+- Neither the name of Laminas Foundation nor the names of its contributors may
+  be used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/service-front/mezzio/README.md
+++ b/service-front/mezzio/README.md
@@ -1,0 +1,159 @@
+# Mezzio Skeleton and Installer
+
+[![Build Status](https://github.com/mezzio/mezzio-skeleton/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/mezzio/mezzio-skeleton/actions/workflows/continuous-integration.yml)
+
+> ## 🇷🇺 Русским гражданам
+>
+> Мы, участники Laminas, родились и живем в разных странах. У многих из нас есть друзья, родственники и коллеги как в России, так и в Украине. Некоторые из нас родились в России. Некоторые из нас живут в России. У некоторых бабушки и дедушки сражались с фашистами во Второй мировой войне. Здесь никто не поддерживает фашизм.
+>
+> У одного из нас есть украинская родственница, которая спаслась из дома вместе с сыном. Поезд задержался из-за бомбежки на дороге впереди. У нас есть друзья, которые прячутся в бомбоубежищах. Мы с тревогой ждем весточки от них после воздушных налетов, которые беспорядочно наносят удары и попадают по больницам, школам, детским садам и домам. Мы не берем это из каких-либо СМИ. Мы наблюдаем это напрямую.
+>
+> Вы доверяете нам достаточно, чтоб использовать наши программы, и мы просим вас довериться нам вновь. Мы нуждаемся в помощи. Выходите и протестуйте против этой бесполезной войны. Остановите кровопролитие. Скажите "Нет войне!"
+>
+> ## 🇺🇸 To Citizens of Russia
+>
+> We at Laminas come from all over the world. Many of us have friends, family and colleagues in both Russia and Ukraine. Some of us were born in Russia. Some of us currently live in Russia. Some have grandparents who fought Nazis in World War II. Nobody here supports fascism.
+>
+> One team member has a Ukrainian relative who fled her home with her son. The train was delayed due to bombing on the road ahead. We have friends who are hiding in bomb shelters. We anxiously follow up on them after the air raids, which indiscriminately fire at hospitals, schools, kindergartens and houses. We're not taking this from any media. These are our actual experiences.
+>
+> You trust us enough to use our software. We ask that you trust us to say the truth on this. We need your help. Go out and protest this unnecessary war. Stop the bloodshed. Say "stop the war!"
+
+*Begin developing PSR-15 middleware applications in seconds!*
+
+[mezzio](https://github.com/mezzio/mezzio) builds on
+[laminas-stratigility](https://github.com/laminas/laminas-stratigility) to
+provide a minimalist PSR-15 middleware framework for PHP with routing, DI
+container, optional templating, and optional error handling capabilities.
+
+This installer will setup a skeleton application based on mezzio by
+choosing optional packages based on user input as demonstrated in the following
+screenshot:
+
+![screenshot-installer](https://user-images.githubusercontent.com/1011217/90332191-55d32200-dfbb-11ea-80c0-27a07ef5691a.png)
+
+The user selected packages are saved into `composer.json` so that everyone else
+working on the project have the same packages installed. Configuration files and
+templates are prepared for first use. The installer command is removed from
+`composer.json` after setup succeeded, and all installer related files are
+removed.
+
+## Getting Started
+
+Start your new Mezzio project with composer:
+
+```bash
+$ composer create-project mezzio/mezzio-skeleton <project-path>
+```
+
+After choosing and installing the packages you want, go to the
+`<project-path>` and start PHP's built-in web server to verify installation:
+
+```bash
+$ composer serve
+```
+
+You can then browse to http://localhost:8080.
+
+## Installing alternative packages
+
+There is a feature to install alternative packages: Instead of entering one of
+the selection **you can actually type the package name and version**.
+
+> ```text
+>   Which template engine do you want to use?
+>   [1] Plates
+>   [2] Twig
+>   [3] zend-view installs zend-servicemanager
+>   [n] None of the above
+>   Make your selection or type a composer package name and version (n): infw/pug:0.1
+>   - Searching for infw/pug:0.1
+>   - Adding package infw/pug (0.1)
+> ```
+
+That feature allows you to install any alternative package you want. It has its limitations though:
+
+* The alternative package must follow this format `namespace/package:1.0`. It needs the correct version.
+* Templates are not copied, but the ConfigProvider can be configured in such way that it uses the
+  default templates directly from the package itself.
+* This doesn't work for containers as the container.php file needs to be copied.
+
+## Troubleshooting
+
+If the installer fails during the ``composer create-project`` phase, please go
+through the following list before opening a new issue. Most issues we have seen
+so far can be solved by `self-update` and `clear-cache`.
+
+1. Be sure to work with the latest version of composer by running `composer self-update`.
+2. Try clearing Composer's cache by running `composer clear-cache`.
+
+If neither of the above help, you might face more serious issues:
+
+* Info about the [zlib_decode error](https://github.com/composer/composer/issues/4121).
+* Info and solutions for [composer degraded mode](https://getcomposer.org/doc/articles/troubleshooting.md#degraded-mode).
+
+## Application Development Mode Tool
+
+This skeleton comes with [laminas-development-mode](https://github.com/laminas/laminas-development-mode).
+It provides a composer script to allow you to enable and disable development mode.
+
+### To enable development mode
+
+**Note:** Do NOT run development mode on your production server!
+
+```bash
+$ composer development-enable
+```
+
+**Note:** Enabling development mode will also clear your configuration cache, to
+allow safely updating dependencies and ensuring any new configuration is picked
+up by your application.
+
+### To disable development mode
+
+```bash
+$ composer development-disable
+```
+
+### Development mode status
+
+```bash
+$ composer development-status
+```
+
+## Configuration caching
+
+By default, the skeleton will create a configuration cache in
+`data/config-cache.php`. When in development mode, the configuration cache is
+disabled, and switching in and out of development mode will remove the
+configuration cache.
+
+You may need to clear the configuration cache in production when deploying if
+you deploy to the same directory. You may do so using the following:
+
+```bash
+$ composer clear-config-cache
+```
+
+You may also change the location of the configuration cache itself by editing
+the `config/config.php` file and changing the `config_cache_path` entry of the
+local `$cacheConfig` variable.
+
+## Skeleton Development
+
+This section applies only if you cloned this repo with `git clone`, not when you
+installed mezzio with `composer create-project ...`.
+
+If you want to run tests against the installer, you need to clone this repo and
+setup all dependencies with composer.  Make sure you **prevent composer running
+scripts** with `--no-scripts`, otherwise it will remove the installer and all
+tests.
+
+```bash
+$ composer update --no-scripts
+$ composer test
+```
+
+Please note that the installer tests remove installed config files and templates
+before and after running the tests.
+
+Before contributing read [the contributing guide](https://github.com/mezzio/.github/blob/master/CONTRIBUTING.md).

--- a/service-front/mezzio/bin/clear-config-cache.php
+++ b/service-front/mezzio/bin/clear-config-cache.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+chdir(__DIR__ . '/../');
+
+require 'vendor/autoload.php';
+
+$config = include 'config/config.php';
+
+if (! isset($config['config_cache_path'])) {
+    echo "No configuration cache path found" . PHP_EOL;
+    exit(0);
+}
+
+if (! file_exists($config['config_cache_path'])) {
+    printf(
+        "Configured config cache file '%s' not found%s",
+        $config['config_cache_path'],
+        PHP_EOL
+    );
+    exit(0);
+}
+
+if (false === unlink($config['config_cache_path'])) {
+    printf(
+        "Error removing config cache file '%s'%s",
+        $config['config_cache_path'],
+        PHP_EOL
+    );
+    exit(1);
+}
+
+printf(
+    "Removed configured config cache file '%s'%s",
+    $config['config_cache_path'],
+    PHP_EOL
+);
+exit(0);

--- a/service-front/mezzio/composer.json
+++ b/service-front/mezzio/composer.json
@@ -1,0 +1,125 @@
+{
+    "name": "mezzio/mezzio-skeleton",
+    "description": "Laminas mezzio skeleton. Begin developing PSR-15 middleware applications in seconds!",
+    "type": "project",
+    "license": "BSD-3-Clause",
+    "keywords": [
+        "laminas",
+        "mezzio",
+        "skeleton",
+        "middleware",
+        "psr",
+        "psr-7",
+        "psr-11",
+        "psr-15"
+    ],
+    "homepage": "https://mezzio.dev",
+    "support": {
+        "docs": "https://docs.mezzio.dev/mezzio/",
+        "issues": "https://github.com/mezzio/mezzio-skeleton/issues",
+        "source": "https://github.com/mezzio/mezzio-skeleton",
+        "rss": "https://github.com/mezzio/mezzio-skeleton/releases.atom",
+        "chat": "https://laminas.dev/chat",
+        "forum": "https://discourse.laminas.dev"
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/package-versions-deprecated": true,
+            "laminas/laminas-component-installer": true
+        },
+        "platform": {
+            "php": "8.4.12",
+            "ext-intl": "1",
+            "ext-redis": "1"
+        }
+    },
+    "extra": {
+        "laminas": {
+            "component-whitelist": [
+                "mezzio/mezzio",
+                "mezzio/mezzio-helpers",
+                "mezzio/mezzio-router",
+                "laminas/laminas-httphandlerrunner",
+                "mezzio/mezzio-fastroute",
+                "mezzio/mezzio-twigrenderer"
+            ]
+        }
+    },
+    "require": {
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+        "composer/package-versions-deprecated": "^1.11.99.5",
+        "laminas/laminas-component-installer": "^2.6 || ^3.5",
+        "laminas/laminas-config-aggregator": "^1.18",
+        "laminas/laminas-diactoros": "^3.8.0",
+        "laminas/laminas-stdlib": "^3.21",
+        "mezzio/mezzio": "^3.23.1",
+        "mezzio/mezzio-helpers": "^5.20",
+        "laminas/laminas-servicemanager": "^3.22",
+        "mezzio/mezzio-fastroute": "^3.11.0",
+        "mezzio/mezzio-twigrenderer": "^2.15",
+        "laminas/laminas-form": "^3.0.2"
+    },
+    "require-dev": {
+        "laminas/laminas-coding-standard": "^3.1.0",
+        "laminas/laminas-development-mode": "^3.14.0",
+        "mezzio/mezzio-tooling": "^2.12.0",
+        "phpunit/phpunit": "^11.5.42",
+        "psalm/plugin-phpunit": "^0.19.5",
+        "roave/security-advisories": "dev-master",
+        "vimeo/psalm": "^6.13.1",
+        "filp/whoops": "^2.15.4"
+    },
+    "conflict": {
+        "amphp/dns": "<2.4.0",
+        "amphp/socket": "<2.3.1",
+        "php-di/php-di": "<7.0.9"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/App/src/",
+            "Application\\": "../module/Application/src/",
+            "MakeShared\\": "../../shared/module/MakeShared/src/",
+            "Alphagov\\Pay\\": "../module/Alphagov/Pay/src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "AppTest\\": "test/AppTest/"
+        }
+    },
+    "scripts": {
+        "post-create-project-cmd": [
+            "@development-enable"
+        ],
+        "post-install-cmd": "@clear-config-cache",
+        "post-update-cmd": "@clear-config-cache",
+        "development-disable": "laminas-development-mode disable",
+        "development-enable": "laminas-development-mode enable",
+        "development-status": "laminas-development-mode status",
+        "mezzio": "laminas --ansi",
+        "check": [
+            "@cs-check",
+            "@test"
+        ],
+        "clear-config-cache": "php bin/clear-config-cache.php",
+        "enable-codestandard": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
+        "cs-check": "phpcs",
+        "cs-fix": "phpcbf",
+        "serve": [
+            "Composer\\Config::disableProcessTimeout",
+            "php -S 0.0.0.0:8080 -t public/"
+        ],
+        "static-analysis": "psalm --stats",
+        "static-analysis-update-baseline": "psalm --stats --update-baseline",
+        "test": "phpunit --colors=always",
+        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
+    },
+    "scripts-descriptions": {
+        "clear-config-cache": "Clears merged config cache. Required for config changes to be applied.",
+        "static-analysis": "Run static analysis tool Psalm.",
+        "static-analysis-update-baseline": "Run static analysis tool Psalm and update baseline."
+    },
+    "repositories": []
+}

--- a/service-front/mezzio/composer.lock
+++ b/service-front/mezzio/composer.lock
@@ -1,0 +1,9051 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "58eb00b1cbd4a298a7f613d0553121d0",
+    "packages": [
+        {
+            "name": "brick/varexporter",
+            "version": "0.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/varexporter.git",
+                "reference": "af98bfc2b702a312abbcaff37656dbe419cec5bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/af98bfc2b702a312abbcaff37656dbe419cec5bc",
+                "reference": "af98bfc2b702a312abbcaff37656dbe419cec5bc",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^10.5",
+                "vimeo/psalm": "6.8.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\VarExporter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A powerful alternative to var_export(), which can export closures and objects without __set_state()",
+            "keywords": [
+                "var_export"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/varexporter/issues",
+                "source": "https://github.com/brick/varexporter/tree/0.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-20T17:42:39+00:00"
+        },
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
+                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-17T14:14:24+00:00"
+        },
+        {
+            "name": "fig/http-message-util",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message-util.git",
+                "reference": "9d94dc0154230ac39e5bf89398b324a86f63f765"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message-util/zipball/9d94dc0154230ac39e5bf89398b324a86f63f765",
+                "reference": "9d94dc0154230ac39e5bf89398b324a86f63f765",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "psr/http-message": "The package containing the PSR-7 interfaces"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fig\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Utility classes and constants for use with PSR-7 (psr/http-message)",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-message-util/issues",
+                "source": "https://github.com/php-fig/http-message-util/tree/1.1.5"
+            },
+            "time": "2020-11-24T22:02:12+00:00"
+        },
+        {
+            "name": "laminas/laminas-component-installer",
+            "version": "3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-component-installer.git",
+                "reference": "cd2baf076f8035edca93baef584835f2de1b9e0f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-component-installer/zipball/cd2baf076f8035edca93baef584835f2de1b9e0f",
+                "reference": "cd2baf076f8035edca93baef584835f2de1b9e0f",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.6",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "conflict": {
+                "zendframework/zend-component-installer": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^2.7.7",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "mikey179/vfsstream": "^1.6.11",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1",
+                "webmozart/assert": "^1.11.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Laminas\\ComponentInstaller\\ComponentInstaller"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ComponentInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Composer plugin for injecting modules and configuration providers into application configuration",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "component installer",
+                "composer",
+                "laminas",
+                "plugin"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-component-installer/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-component-installer/issues",
+                "rss": "https://github.com/laminas/laminas-component-installer/releases.atom",
+                "source": "https://github.com/laminas/laminas-component-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-16T19:54:21+00:00"
+        },
+        {
+            "name": "laminas/laminas-config-aggregator",
+            "version": "1.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-config-aggregator.git",
+                "reference": "612343ce135c340fc667da3615e50d865a86b4d9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-config-aggregator/zipball/612343ce135c340fc667da3615e50d865a86b4d9",
+                "reference": "612343ce135c340fc667da3615e50d865a86b4d9",
+                "shasum": ""
+            },
+            "require": {
+                "brick/varexporter": "^0.5.0 || ^0.4.0 || ^0.6.0",
+                "laminas/laminas-stdlib": "^3.18.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "webimpress/safe-writer": "^2.2.0"
+            },
+            "conflict": {
+                "nikic/php-parser": "<4.12",
+                "zendframework/zend-config-aggregator": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-config": "^3.10.1",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "suggest": {
+                "laminas/laminas-config": "Allows loading configuration from XML, INI, YAML, and JSON files",
+                "laminas/laminas-config-aggregator-modulemanager": "Allows loading configuration from laminas-mvc Module classes",
+                "laminas/laminas-config-aggregator-parameters": "Allows usage of templated parameters within your configuration"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ConfigAggregator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Lightweight library for collecting and merging configuration from different sources",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "config-aggregator",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-config-aggregator/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-config-aggregator/issues",
+                "rss": "https://github.com/laminas/laminas-config-aggregator/releases.atom",
+                "source": "https://github.com/laminas/laminas-config-aggregator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-14T19:57:01+00:00"
+        },
+        {
+            "name": "laminas/laminas-diactoros",
+            "version": "3.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-diactoros.git",
+                "reference": "60c182916b2749480895601649563970f3f12ec4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/60c182916b2749480895601649563970f3f12ec4",
+                "reference": "60c182916b2749480895601649563970f3f12ec4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "conflict": {
+                "amphp/amp": "<2.6.4"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "^1.0",
+                "psr/http-message-implementation": "^1.1 || ^2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "ext-dom": "*",
+                "ext-gd": "*",
+                "ext-libxml": "*",
+                "http-interop/http-factory-tests": "^2.2.0",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "php-http/psr7-integration-tests": "^1.4.0",
+                "phpunit/phpunit": "^10.5.36",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\Diactoros",
+                    "config-provider": "Laminas\\Diactoros\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions/create_uploaded_file.php",
+                    "src/functions/marshal_headers_from_sapi.php",
+                    "src/functions/marshal_method_from_sapi.php",
+                    "src/functions/marshal_protocol_version_from_sapi.php",
+                    "src/functions/normalize_server.php",
+                    "src/functions/normalize_uploaded_files.php",
+                    "src/functions/parse_cookie_header.php"
+                ],
+                "psr-4": {
+                    "Laminas\\Diactoros\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "PSR HTTP Message implementations",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "http",
+                "laminas",
+                "psr",
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-diactoros/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-diactoros/issues",
+                "rss": "https://github.com/laminas/laminas-diactoros/releases.atom",
+                "source": "https://github.com/laminas/laminas-diactoros"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-12T15:31:36+00:00"
+        },
+        {
+            "name": "laminas/laminas-escaper",
+            "version": "2.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-escaper.git",
+                "reference": "06f211dfffff18d91844c1f55250d5d13c007e18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/06f211dfffff18d91844c1f55250d5d13c007e18",
+                "reference": "06f211dfffff18d91844c1f55250d5d13c007e18",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-mbstring": "*",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "conflict": {
+                "zendframework/zend-escaper": "*"
+            },
+            "require-dev": {
+                "infection/infection": "^0.31.0",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "escaper",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-escaper/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-escaper/issues",
+                "rss": "https://github.com/laminas/laminas-escaper/releases.atom",
+                "source": "https://github.com/laminas/laminas-escaper"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-14T18:31:13+00:00"
+        },
+        {
+            "name": "laminas/laminas-filter",
+            "version": "2.42.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-filter.git",
+                "reference": "985d27bd42daf51b415ce1ee889e0978cc1e59ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/985d27bd42daf51b415ce1ee889e0978cc1e59ed",
+                "reference": "985d27bd42daf51b415ce1ee889e0978cc1e59ed",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "laminas/laminas-servicemanager": "^3.21.0",
+                "laminas/laminas-stdlib": "^3.19.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "conflict": {
+                "laminas/laminas-validator": "<2.10.1",
+                "zendframework/zend-filter": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.1",
+                "laminas/laminas-crypt": "^3.12",
+                "laminas/laminas-i18n": "^2.30.0",
+                "laminas/laminas-uri": "^2.13",
+                "pear/archive_tar": "^1.6.0",
+                "phpunit/phpunit": "^10.5.58",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/http-factory": "^1.1.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
+                "laminas/laminas-i18n": "Laminas\\I18n component for filters depending on i18n functionality",
+                "laminas/laminas-uri": "Laminas\\Uri component, for the UriNormalize filter",
+                "psr/http-factory-implementation": "psr/http-factory-implementation, for creating file upload instances when consuming PSR-7 in file upload filters"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Filter",
+                    "config-provider": "Laminas\\Filter\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Filter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Programmatically filter and normalize data and files",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "filter",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-filter/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-filter/issues",
+                "rss": "https://github.com/laminas/laminas-filter/releases.atom",
+                "source": "https://github.com/laminas/laminas-filter"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-13T15:44:52+00:00"
+        },
+        {
+            "name": "laminas/laminas-form",
+            "version": "3.24.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-form.git",
+                "reference": "92d46a8333ca428244cf8b647167477aefbbe891"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-form/zipball/92d46a8333ca428244cf8b647167477aefbbe891",
+                "reference": "92d46a8333ca428244cf8b647167477aefbbe891",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "laminas/laminas-escaper": "^2",
+                "laminas/laminas-filter": "^2",
+                "laminas/laminas-hydrator": "^4.16.0",
+                "laminas/laminas-inputfilter": "^2.32.0",
+                "laminas/laminas-servicemanager": "^3.22.1",
+                "laminas/laminas-stdlib": "^3.20.0",
+                "laminas/laminas-validator": "^2",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.1.2"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.14.0",
+                "laminas/laminas-captcha": "<2.16.0",
+                "laminas/laminas-eventmanager": "<3.10.0",
+                "laminas/laminas-i18n": "<2.21.0",
+                "laminas/laminas-recaptcha": "<3.6.0",
+                "laminas/laminas-servicemanager": "<3.20.0",
+                "laminas/laminas-view": "<2.27.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.14.3 || ^2.0.2",
+                "ext-gd": "*",
+                "ext-intl": "*",
+                "laminas/laminas-captcha": "^2.19",
+                "laminas/laminas-coding-standard": "^3.1.0",
+                "laminas/laminas-eventmanager": "^3.15.0",
+                "laminas/laminas-i18n": "^2.31.0",
+                "laminas/laminas-modulemanager": "^2.19.0",
+                "laminas/laminas-recaptcha": "^3.8",
+                "laminas/laminas-session": "^2.25.1",
+                "laminas/laminas-text": "^2.12.1",
+                "laminas/laminas-view": "^2.43",
+                "phpunit/phpunit": "^11.5.43",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "suggest": {
+                "doctrine/annotations": "^1.14, required to use laminas-form annotations support",
+                "laminas/laminas-captcha": "^2.16, required for using CAPTCHA form elements",
+                "laminas/laminas-eventmanager": "^3.10, required for laminas-form annotations support",
+                "laminas/laminas-i18n": "^2.21, required when using laminas-form view helpers",
+                "laminas/laminas-recaptcha": "^3.6, in order to use the ReCaptcha form element",
+                "laminas/laminas-servicemanager": "^3.20, required to use the form factories or provide services",
+                "laminas/laminas-view": "^2.27, required for using the laminas-form view helpers"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Form",
+                    "config-provider": "Laminas\\Form\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Form\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validate and display simple and complex forms, casting forms to business objects and vice versa",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "form",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-form/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-form/issues",
+                "rss": "https://github.com/laminas/laminas-form/releases.atom",
+                "source": "https://github.com/laminas/laminas-form"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2026-01-12T14:20:53+00:00"
+        },
+        {
+            "name": "laminas/laminas-httphandlerrunner",
+            "version": "2.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-httphandlerrunner.git",
+                "reference": "181eaeeb838ad3d80fbbcfb0657a46bc212bbd4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/181eaeeb838ad3d80fbbcfb0657a46bc212bbd4e",
+                "reference": "181eaeeb838ad3d80fbbcfb0657a46bc212bbd4e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/http-message-implementation": "^1.0 || ^2.0",
+                "psr/http-server-handler": "^1.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-diactoros": "^3.6.0",
+                "phpunit/phpunit": "^10.5.46",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.10.3"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Laminas\\HttpHandlerRunner\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\HttpHandlerRunner\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Execute PSR-15 RequestHandlerInterface instances and emit responses they generate.",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "components",
+                "laminas",
+                "mezzio",
+                "psr-15",
+                "psr-7"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-httphandlerrunner/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-httphandlerrunner/issues",
+                "rss": "https://github.com/laminas/laminas-httphandlerrunner/releases.atom",
+                "source": "https://github.com/laminas/laminas-httphandlerrunner"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-12T20:58:29+00:00"
+        },
+        {
+            "name": "laminas/laminas-hydrator",
+            "version": "4.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-hydrator.git",
+                "reference": "ab208d1b8a2dc4251182a6cd2d123ccbc56eda50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-hydrator/zipball/ab208d1b8a2dc4251182a6cd2d123ccbc56eda50",
+                "reference": "ab208d1b8a2dc4251182a6cd2d123ccbc56eda50",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^3.20",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "webmozart/assert": "^1.11 || ^2.0"
+            },
+            "conflict": {
+                "laminas/laminas-servicemanager": "<3.14.0",
+                "zendframework/zend-hydrator": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.0",
+                "laminas/laminas-eventmanager": "^3.13.1",
+                "laminas/laminas-modulemanager": "^2.16.0",
+                "laminas/laminas-serializer": "^2.17.0",
+                "laminas/laminas-servicemanager": "^3.24.0",
+                "phpbench/phpbench": "^1.3.1",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "suggest": {
+                "laminas/laminas-eventmanager": "^3.13, to support aggregate hydrator usage",
+                "laminas/laminas-serializer": "^2.17, to use the SerializableStrategy",
+                "laminas/laminas-servicemanager": "^3.22, to support hydrator plugin manager usage"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Hydrator",
+                    "config-provider": "Laminas\\Hydrator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Hydrator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Serialize objects to arrays, and vice versa",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "hydrator",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-hydrator/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-hydrator/issues",
+                "rss": "https://github.com/laminas/laminas-hydrator/releases.atom",
+                "source": "https://github.com/laminas/laminas-hydrator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2026-01-13T10:10:41+00:00"
+        },
+        {
+            "name": "laminas/laminas-inputfilter",
+            "version": "2.35.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-inputfilter.git",
+                "reference": "326d2dac38814f70902a3a9e0062f740d06f89c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-inputfilter/zipball/326d2dac38814f70902a3a9e0062f740d06f89c5",
+                "reference": "326d2dac38814f70902a3a9e0062f740d06f89c5",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-filter": "^2.19",
+                "laminas/laminas-servicemanager": "^3.21.0",
+                "laminas/laminas-stdlib": "^3.19",
+                "laminas/laminas-validator": "^2.60.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.1 || ^2.0"
+            },
+            "conflict": {
+                "zendframework/zend-inputfilter": "*"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "laminas/laminas-coding-standard": "^3.1.0",
+                "phpunit/phpunit": "^11.5.46",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "psr/http-message": "^2.0",
+                "vimeo/psalm": "^6.14.3"
+            },
+            "suggest": {
+                "psr/http-message-implementation": "PSR-7 is required if you wish to validate PSR-7 UploadedFileInterface payloads"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\InputFilter",
+                    "config-provider": "Laminas\\InputFilter\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\InputFilter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Normalize and validate input sets from the web, APIs, the CLI, and more, including files",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "inputfilter",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-inputfilter/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-inputfilter/issues",
+                "rss": "https://github.com/laminas/laminas-inputfilter/releases.atom",
+                "source": "https://github.com/laminas/laminas-inputfilter"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2026-01-10T15:07:43+00:00"
+        },
+        {
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "b172a0df568bf37ebdfb3658263156eefe3c1e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b172a0df568bf37ebdfb3658263156eefe3c1e8c",
+                "reference": "b172a0df568bf37ebdfb3658263156eefe3c1e8c",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^3.19",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "ext-psr": "*",
+                "laminas/laminas-code": "<4.10.0",
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11.99.5",
+                "friendsofphp/proxy-manager-lts": "^1.0.18",
+                "laminas/laminas-code": "^4.16.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-container-config-test": "^0.8",
+                "mikey179/vfsstream": "^1.6.12",
+                "phpbench/phpbench": "^1.4.1",
+                "phpunit/phpunit": "^10.5.58",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
+                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-servicemanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-14T09:03:51+00:00"
+        },
+        {
+            "name": "laminas/laminas-stdlib",
+            "version": "3.21.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-stdlib.git",
+                "reference": "b1c81514cfe158aadf724c42b34d3d0a8164c096"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/b1c81514cfe158aadf724c42b34d3d0a8164c096",
+                "reference": "b1c81514cfe158aadf724c42b34d3d0a8164c096",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "conflict": {
+                "zendframework/zend-stdlib": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.1.0",
+                "phpbench/phpbench": "^1.4.1",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "stdlib"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-stdlib/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-stdlib/issues",
+                "rss": "https://github.com/laminas/laminas-stdlib/releases.atom",
+                "source": "https://github.com/laminas/laminas-stdlib"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-11T18:13:12+00:00"
+        },
+        {
+            "name": "laminas/laminas-stratigility",
+            "version": "3.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-stratigility.git",
+                "reference": "d23d128a22f79a67e1f9682df4c51719e3553c9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-stratigility/zipball/d23d128a22f79a67e1f9682df4c51719e3553c9d",
+                "reference": "d23d128a22f79a67e1f9682df4c51719e3553c9d",
+                "shasum": ""
+            },
+            "require": {
+                "fig/http-message-util": "^1.1",
+                "laminas/laminas-escaper": "^2.10.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/http-server-middleware": "^1.0.2"
+            },
+            "conflict": {
+                "zendframework/zend-stratigility": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.1.0",
+                "laminas/laminas-diactoros": "^2.25 || ^3.8.0",
+                "phpunit/phpunit": "^10.5.58",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Stratigility; e.g., laminas/laminas-diactoros"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions/double-pass-middleware.php",
+                    "src/functions/host.php",
+                    "src/functions/middleware.php",
+                    "src/functions/path.php",
+                    "src/functions/double-pass-middleware.legacy.php",
+                    "src/functions/host.legacy.php",
+                    "src/functions/middleware.legacy.php",
+                    "src/functions/path.legacy.php"
+                ],
+                "psr-4": {
+                    "Laminas\\Stratigility\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "PSR-7 middleware foundation for building and dispatching middleware pipelines",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "http",
+                "laminas",
+                "middleware",
+                "psr-15",
+                "psr-7"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-stratigility/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-stratigility/issues",
+                "rss": "https://github.com/laminas/laminas-stratigility/releases.atom",
+                "source": "https://github.com/laminas/laminas-stratigility"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-11-12T05:23:21+00:00"
+        },
+        {
+            "name": "laminas/laminas-validator",
+            "version": "2.65.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-validator.git",
+                "reference": "f0767ca83e0dd91a6f8ccdd4f0887eb132c0ea49"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/f0767ca83e0dd91a6f8ccdd4f0887eb132c0ea49",
+                "reference": "f0767ca83e0dd91a6f8ccdd4f0887eb132c0ea49",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-servicemanager": "^3.21.0",
+                "laminas/laminas-stdlib": "^3.19",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/http-message": "^1.0.1 || ^2.0.0"
+            },
+            "conflict": {
+                "zendframework/zend-validator": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^2.5",
+                "laminas/laminas-db": "^2.20",
+                "laminas/laminas-filter": "^2.41.0",
+                "laminas/laminas-i18n": "^2.30.0",
+                "laminas/laminas-session": "^2.25.1",
+                "laminas/laminas-uri": "^2.13.0",
+                "phpunit/phpunit": "^10.5.58",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/http-client": "^1.0.3",
+                "psr/http-factory": "^1.1.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
+                "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
+                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
+                "laminas/laminas-i18n-resources": "Translations of validator messages",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
+                "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
+                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Validator",
+                    "config-provider": "Laminas\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "validator"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-validator/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-validator/issues",
+                "rss": "https://github.com/laminas/laminas-validator/releases.atom",
+                "source": "https://github.com/laminas/laminas-validator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-13T14:40:30+00:00"
+        },
+        {
+            "name": "mezzio/mezzio",
+            "version": "3.23.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mezzio/mezzio.git",
+                "reference": "988d39687683c9ae70d213c68c75c89965caad30"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mezzio/mezzio/zipball/988d39687683c9ae70d213c68c75c89965caad30",
+                "reference": "988d39687683c9ae70d213c68c75c89965caad30",
+                "shasum": ""
+            },
+            "require": {
+                "fig/http-message-util": "^1.1.5",
+                "laminas/laminas-httphandlerrunner": "^2.1",
+                "laminas/laminas-stratigility": "^3.5",
+                "mezzio/mezzio-router": "^3.15.0",
+                "mezzio/mezzio-template": "^2.2",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.0||^2.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0.1 || ^2.0.0",
+                "psr/http-server-middleware": "^1.0",
+                "webmozart/assert": "^1.11.0"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2.0",
+                "filp/whoops": "<2.14.4",
+                "laminas/laminas-diactoros": "<1.7.1",
+                "laminas/laminas-http": "<2.15.0",
+                "laminas/laminas-router": "<3.5.0",
+                "laminas/laminas-stdlib": "<3.6.0",
+                "zendframework/zend-expressive": "*"
+            },
+            "require-dev": {
+                "filp/whoops": "^2.18.4",
+                "laminas/laminas-coding-standard": "^3.1.0",
+                "laminas/laminas-diactoros": "^3.8.0",
+                "laminas/laminas-servicemanager": "^3.23.1",
+                "mezzio/mezzio-fastroute": "^3.14",
+                "mezzio/mezzio-laminasrouter": "^3.12",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "suggest": {
+                "filp/whoops": "^2.1 to use the Whoops error handler",
+                "laminas/laminas-auradi-config": "^2.0 to use Aura.Di dependency injection container",
+                "laminas/laminas-pimple-config": "^1.0 to use Pimple for dependency injection container",
+                "laminas/laminas-servicemanager": "^3.3 to use laminas-servicemanager for dependency injection",
+                "mezzio/mezzio-helpers": "^3.0 for its UrlHelper, ServerUrlHelper, and BodyParseMiddleware",
+                "mezzio/mezzio-tooling": "^1.0 for migration and development tools; require it with the --dev flag",
+                "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Mezzio; e.g., laminas/laminas-diactoros"
+            },
+            "bin": [
+                "bin/mezzio-tooling"
+            ],
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Mezzio\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/constants.php",
+                    "src/constants.legacy.php"
+                ],
+                "psr-4": {
+                    "Mezzio\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "PSR-15 Middleware Microframework",
+            "homepage": "https://mezzio.dev",
+            "keywords": [
+                "PSR-11",
+                "http",
+                "laminas",
+                "mezzio",
+                "middleware",
+                "psr",
+                "psr-15",
+                "psr-7"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.mezzio.dev/mezzio/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/mezzio/issues",
+                "rss": "https://github.com/mezzio/mezzio/releases.atom",
+                "source": "https://github.com/mezzio/mezzio"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-22T10:56:04+00:00"
+        },
+        {
+            "name": "mezzio/mezzio-fastroute",
+            "version": "3.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mezzio/mezzio-fastroute.git",
+                "reference": "00b1dd8560566d745a5a3a18582d1242ad51dd64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mezzio/mezzio-fastroute/zipball/00b1dd8560566d745a5a3a18582d1242ad51dd64",
+                "reference": "00b1dd8560566d745a5a3a18582d1242ad51dd64",
+                "shasum": ""
+            },
+            "require": {
+                "fig/http-message-util": "^1.1.2",
+                "laminas/laminas-stdlib": "^3.19.0",
+                "mezzio/mezzio-router": "^3.18 || ^4.0.1",
+                "nikic/fast-route": "^1.2",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.0 || ^2.0",
+                "psr/http-message": "^1.0.1 || ^2.0.0"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2.0",
+                "zendframework/zend-expressive-fastroute": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-diactoros": "^3.6.0",
+                "laminas/laminas-stratigility": "^4.2.0",
+                "mikey179/vfsstream": "^1.6.12",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Mezzio\\Router\\FastRouteRouter\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mezzio\\Router\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "FastRoute integration for Mezzio",
+            "homepage": "https://mezzio.dev",
+            "keywords": [
+                "FastRoute",
+                "http",
+                "laminas",
+                "mezzio",
+                "middleware",
+                "psr",
+                "psr-7"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.mezzio.dev/mezzio/features/router/fast-route/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/mezzio-fastroute/issues",
+                "rss": "https://github.com/mezzio/mezzio-fastroute/releases.atom",
+                "source": "https://github.com/mezzio/mezzio-fastroute"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-11T08:43:04+00:00"
+        },
+        {
+            "name": "mezzio/mezzio-helpers",
+            "version": "5.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mezzio/mezzio-helpers.git",
+                "reference": "a26ba04bd449d5cdb5ad38b17ce672365dbc9d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mezzio/mezzio-helpers/zipball/a26ba04bd449d5cdb5ad38b17ce672365dbc9d90",
+                "reference": "a26ba04bd449d5cdb5ad38b17ce672365dbc9d90",
+                "shasum": ""
+            },
+            "require": {
+                "mezzio/mezzio-router": "^3.18 || ^4.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.0 || ^2.0",
+                "psr/http-message": "^1.0.1 || ^2.0.0",
+                "psr/http-server-middleware": "^1.0"
+            },
+            "conflict": {
+                "amphp/amp": "<2.6.4",
+                "amphp/dns": "<2.1.2",
+                "amphp/socket": "<2.3.1",
+                "zendframework/zend-expressive-helpers": "*"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-diactoros": "^3.6",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "suggest": {
+                "ext-json": "If you wish to use the JsonStrategy with BodyParamsMiddleware"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Mezzio\\Helper\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mezzio\\Helper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Helper/Utility classes for Mezzio",
+            "homepage": "https://mezzio.dev",
+            "keywords": [
+                "http",
+                "laminas",
+                "mezzio",
+                "middleware",
+                "psr",
+                "psr-7"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.mezzio.dev/mezzio/features/helpers/intro/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/mezzio-helpers/issues",
+                "rss": "https://github.com/mezzio/mezzio-helpers/releases.atom",
+                "source": "https://github.com/mezzio/mezzio-helpers"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-11T08:40:34+00:00"
+        },
+        {
+            "name": "mezzio/mezzio-router",
+            "version": "3.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mezzio/mezzio-router.git",
+                "reference": "be4de58dc8822b4af653dc554f963b4cb1e23355"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/be4de58dc8822b4af653dc554f963b4cb1e23355",
+                "reference": "be4de58dc8822b4af653dc554f963b4cb1e23355",
+                "shasum": ""
+            },
+            "require": {
+                "fig/http-message-util": "^1.1.5",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.1.2 || ^2.0",
+                "psr/http-factory": "^1.0.2",
+                "psr/http-message": "^1.0.1 || ^2.0.0",
+                "psr/http-server-middleware": "^1.0.2",
+                "webmozart/assert": "^1.11 || ^2.0"
+            },
+            "conflict": {
+                "mezzio/mezzio": "<3.5",
+                "zendframework/zend-expressive-router": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-diactoros": "^3.6.0",
+                "laminas/laminas-servicemanager": "^4.4.0",
+                "laminas/laminas-stratigility": "^4.2.0",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "suggest": {
+                "mezzio/mezzio-aurarouter": "^3.0 to use the Aura.Router routing adapter",
+                "mezzio/mezzio-fastroute": "^3.0 to use the FastRoute routing adapter",
+                "mezzio/mezzio-laminasrouter": "^3.0 to use the laminas-router routing adapter"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Mezzio\\Router\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mezzio\\Router\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Router subcomponent for Mezzio",
+            "homepage": "https://mezzio.dev",
+            "keywords": [
+                "http",
+                "laminas",
+                "mezzio",
+                "middleware",
+                "psr",
+                "psr-7"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.mezzio.dev/mezzio/features/router/intro/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/mezzio-router/issues",
+                "rss": "https://github.com/mezzio/mezzio-router/releases.atom",
+                "source": "https://github.com/mezzio/mezzio-router"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2026-02-19T15:49:48+00:00"
+        },
+        {
+            "name": "mezzio/mezzio-template",
+            "version": "2.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mezzio/mezzio-template.git",
+                "reference": "ad72bb31036d0639a5c5a502af234217faf6932f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mezzio/mezzio-template/zipball/ad72bb31036d0639a5c5a502af234217faf6932f",
+                "reference": "ad72bb31036d0639a5c5a502af234217faf6932f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "conflict": {
+                "zendframework/zend-expressive-template": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "suggest": {
+                "mezzio/mezzio-laminasviewrenderer": "^2.0 to use the laminas-view PhpRenderer template renderer",
+                "mezzio/mezzio-platesrenderer": "^2.0 to use the Plates template renderer",
+                "mezzio/mezzio-twigrenderer": "^2.0 to use the Twig template renderer"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Mezzio\\Template\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Template subcomponent for Mezzio",
+            "homepage": "https://mezzio.dev",
+            "keywords": [
+                "laminas",
+                "mezzio",
+                "template"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.mezzio.dev/mezzio/features/template/intro/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/mezzio-template/issues",
+                "rss": "https://github.com/mezzio/mezzio-template/releases.atom",
+                "source": "https://github.com/mezzio/mezzio-template"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-11T08:45:28+00:00"
+        },
+        {
+            "name": "mezzio/mezzio-twigrenderer",
+            "version": "2.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mezzio/mezzio-twigrenderer.git",
+                "reference": "5e6e91cccd157fedb4717e2b0805ee3ca87f3965"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mezzio/mezzio-twigrenderer/zipball/5e6e91cccd157fedb4717e2b0805ee3ca87f3965",
+                "reference": "5e6e91cccd157fedb4717e2b0805ee3ca87f3965",
+                "shasum": ""
+            },
+            "require": {
+                "mezzio/mezzio-helpers": "^5.7",
+                "mezzio/mezzio-router": "^3.7",
+                "mezzio/mezzio-template": "^2.2",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.0 || ^2.0",
+                "twig/twig": "^3.14.0"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2.0",
+                "zendframework/zend-expressive-twigrenderer": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Mezzio\\Twig\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mezzio\\Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Twig integration for Mezzio",
+            "homepage": "https://mezzio.dev",
+            "keywords": [
+                "http",
+                "laminas",
+                "mezzio",
+                "middleware",
+                "psr",
+                "psr-7",
+                "twig"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.mezzio.dev/mezzio/features/template/twig/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/mezzio-twigrenderer/issues",
+                "rss": "https://github.com/mezzio/mezzio-twigrenderer/releases.atom",
+                "source": "https://github.com/mezzio/mezzio-twigrenderer"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-12T19:23:57+00:00"
+        },
+        {
+            "name": "nikic/fast-route",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/FastRoute.git",
+                "reference": "181d480e08d9476e61381e04a71b34dc0432e812"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/181d480e08d9476e61381e04a71b34dc0432e812",
+                "reference": "181d480e08d9476e61381e04a71b34dc0432e812",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35|~5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "FastRoute\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov",
+                    "email": "nikic@php.net"
+                }
+            ],
+            "description": "Fast request router for PHP",
+            "keywords": [
+                "router",
+                "routing"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/FastRoute/issues",
+                "source": "https://github.com/nikic/FastRoute/tree/master"
+            },
+            "time": "2018-02-13T20:26:39+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
+            },
+            "time": "2021-11-05T16:50:12+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/http-server-handler",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-handler.git",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "http-interop",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-server-handler/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:06:20+00:00"
+        },
+        {
+            "name": "psr/http-server-middleware",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-middleware.git",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/http-server-handler": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side middleware",
+            "keywords": [
+                "http",
+                "http-interop",
+                "middleware",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-server-middleware/issues",
+                "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
+            },
+            "time": "2023-04-11T06:14:47+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T17:25:58+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v3.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a6769aefb305efef849dc25c9fd1653358c148f0",
+                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
+                "psr/container": "^1.0|^2.0",
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "templating"
+            ],
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v3.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-17T21:31:11+00:00"
+        },
+        {
+            "name": "webimpress/safe-writer",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/safe-writer.git",
+                "reference": "9d37cc8bee20f7cb2f58f6e23e05097eab5072e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/safe-writer/zipball/9d37cc8bee20f7cb2f58f6e23e05097eab5072e6",
+                "reference": "9d37cc8bee20f7cb2f58f6e23e05097eab5072e6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.4",
+                "vimeo/psalm": "^4.7",
+                "webimpress/coding-standard": "^1.2.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev",
+                    "dev-develop": "2.3.x-dev",
+                    "dev-release-1.0": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webimpress\\SafeWriter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Tool to write files safely, to avoid race conditions",
+            "keywords": [
+                "concurrent write",
+                "file writer",
+                "race condition",
+                "safe writer",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/safe-writer/issues",
+                "source": "https://github.com/webimpress/safe-writer/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-04-19T16:34:45+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
+            },
+            "time": "2025-10-29T15:56:20+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "amphp/amp",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Future/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "https://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-27T21:42:00+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/parser": "^1.1",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2.3"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.22.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "https://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-16T17:10:27+00:00"
+        },
+        {
+            "name": "amphp/cache",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/cache.git",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/cache/zipball/46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Cache\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A fiber-aware cache API based on Amp and Revolt.",
+            "homepage": "https://amphp.org/cache",
+            "support": {
+                "issues": "https://github.com/amphp/cache/issues",
+                "source": "https://github.com/amphp/cache/tree/v2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-19T03:38:06+00:00"
+        },
+        {
+            "name": "amphp/dns",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/dns.git",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/dns/zipball/78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/parser": "^1",
+                "amphp/process": "^2",
+                "daverandom/libdns": "^2.0.2",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Dns\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Wright",
+                    "email": "addr@daverandom.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "Async DNS resolution for Amp.",
+            "homepage": "https://github.com/amphp/dns",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "client",
+                "dns",
+                "resolve"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/dns/issues",
+                "source": "https://github.com/amphp/dns/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-19T15:43:40+00:00"
+        },
+        {
+            "name": "amphp/parallel",
+            "version": "v2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parallel.git",
+                "reference": "296b521137a54d3a02425b464e5aee4c93db2c60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parallel/zipball/296b521137a54d3a02425b464e5aee4c93db2c60",
+                "reference": "296b521137a54d3a02425b464e5aee4c93db2c60",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/parser": "^1",
+                "amphp/pipeline": "^1",
+                "amphp/process": "^2",
+                "amphp/serialization": "^1",
+                "amphp/socket": "^2",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.18"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Context/functions.php",
+                    "src/Context/Internal/functions.php",
+                    "src/Ipc/functions.php",
+                    "src/Worker/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Parallel\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Parallel processing component for Amp.",
+            "homepage": "https://github.com/amphp/parallel",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrent",
+                "multi-processing",
+                "multi-threading"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parallel/issues",
+                "source": "https://github.com/amphp/parallel/tree/v2.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-15T06:23:42+00:00"
+        },
+        {
+            "name": "amphp/parser",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parser.git",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Parser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A generator parser to make streaming parsers simple.",
+            "homepage": "https://github.com/amphp/parser",
+            "keywords": [
+                "async",
+                "non-blocking",
+                "parser",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parser/issues",
+                "source": "https://github.com/amphp/parser/tree/v1.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-21T19:16:53+00:00"
+        },
+        {
+            "name": "amphp/pipeline",
+            "version": "v1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/pipeline.git",
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/7b52598c2e9105ebcddf247fc523161581930367",
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Pipeline\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Asynchronous iterators and operators.",
+            "homepage": "https://amphp.org/pipeline",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "iterator",
+                "non-blocking"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/pipeline/issues",
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-16T16:33:53+00:00"
+        },
+        {
+            "name": "amphp/process",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/process.git",
+                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/process/zipball/52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Process\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A fiber-aware process manager based on Amp and Revolt.",
+            "homepage": "https://amphp.org/process",
+            "support": {
+                "issues": "https://github.com/amphp/process/issues",
+                "source": "https://github.com/amphp/process/tree/v2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-19T03:13:44+00:00"
+        },
+        {
+            "name": "amphp/serialization",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/serialization.git",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "ext-json": "*",
+                "ext-zlib": "*",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Serialization\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Serialization tools for IPC and data storage in PHP.",
+            "homepage": "https://github.com/amphp/serialization",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "serialization",
+                "serialize"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/serialization/issues",
+                "source": "https://github.com/amphp/serialization/tree/v1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-05T15:59:53+00:00"
+        },
+        {
+            "name": "amphp/socket",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/socket.git",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/dadb63c5d3179fd83803e29dfeac27350e619314",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/dns": "^2",
+                "ext-openssl": "*",
+                "kelunik/certificate": "^1.1",
+                "league/uri": "^7",
+                "league/uri-interfaces": "^7",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "amphp/process": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php",
+                    "src/SocketAddress/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Socket\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@gmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Non-blocking socket connection / server implementations based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/socket",
+            "keywords": [
+                "amp",
+                "async",
+                "encryption",
+                "non-blocking",
+                "sockets",
+                "tcp",
+                "tls"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/socket/issues",
+                "source": "https://github.com/amphp/socket/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-19T15:09:56+00:00"
+        },
+        {
+            "name": "amphp/sync",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/sync.git",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/sync/zipball/217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Sync\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Non-blocking synchronization primitives for PHP based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/sync",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "mutex",
+                "semaphore",
+                "synchronization"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/sync/issues",
+                "source": "https://github.com/amphp/sync/tree/v2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-03T19:31:26+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "danog/advanced-json-rpc",
+            "version": "v3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/danog/php-advanced-json-rpc.git",
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/ae703ea7b4811797a10590b6078de05b3b33dd91",
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^5",
+                "php": ">=8.1",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0 || ^6"
+            },
+            "replace": {
+                "felixfbecker/php-advanced-json-rpc": "^3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                },
+                {
+                    "name": "Daniil Gentili",
+                    "email": "daniil@daniil.it"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/danog/php-advanced-json-rpc/issues",
+                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.3"
+            },
+            "time": "2026-01-12T21:07:10+00:00"
+        },
+        {
+            "name": "daverandom/libdns",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DaveRandom/LibDNS.git",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DaveRandom/LibDNS/zipball/b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "Required for IDN support"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "LibDNS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "DNS protocol implementation written in pure PHP",
+            "keywords": [
+                "dns"
+            ],
+            "support": {
+                "issues": "https://github.com/DaveRandom/LibDNS/issues",
+                "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
+            },
+            "time": "2024-04-12T12:12:48+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-11T04:32:07+00:00"
+        },
+        {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "v1.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "a9e113dbc7d849e35b8776da39edaf4313b7b6c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/a9e113dbc7d849e35b8776da39edaf4313b7b6c9",
+                "reference": "a9e113dbc7d849e35b8776da39edaf4313b7b6c9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.3"
+            },
+            "time": "2024-04-30T00:40:11+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
+            "name": "filp/whoops",
+            "version": "2.18.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/filp/whoops.git",
+                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/d2102955e48b9fd9ab24280a7ad12ed552752c4d",
+                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.8 || ^9.3.3",
+                "symfony/var-dumper": "^4.0 || ^5.0"
+            },
+            "suggest": {
+                "symfony/var-dumper": "Pretty print complex values better with var-dumper available",
+                "whoops/soap": "Formats errors as SOAP responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Whoops\\": "src/Whoops/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Filipe Dobreira",
+                    "homepage": "https://github.com/filp",
+                    "role": "Developer"
+                }
+            ],
+            "description": "php error handling for cool kids",
+            "homepage": "https://filp.github.io/whoops/",
+            "keywords": [
+                "error",
+                "exception",
+                "handling",
+                "library",
+                "throwable",
+                "whoops"
+            ],
+            "support": {
+                "issues": "https://github.com/filp/whoops/issues",
+                "source": "https://github.com/filp/whoops/tree/2.18.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/denis-sokolov",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-08T12:00:00+00:00"
+        },
+        {
+            "name": "kelunik/certificate",
+            "version": "v1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kelunik/certificate.git",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kelunik/certificate/zipball/7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^6 | 7 | ^8 | ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kelunik\\Certificate\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Access certificate details and transform between different formats.",
+            "keywords": [
+                "DER",
+                "certificate",
+                "certificates",
+                "openssl",
+                "pem",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/kelunik/certificate/issues",
+                "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
+            },
+            "time": "2023-02-03T21:26:53+00:00"
+        },
+        {
+            "name": "laminas/laminas-cli",
+            "version": "1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-cli.git",
+                "reference": "926a884548a5ff078128ffa3fe9381cd0a4ae8c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-cli/zipball/926a884548a5ff078128ffa3fe9381cd0a4ae8c4",
+                "reference": "926a884548a5ff078128ffa3fe9381cd0a4ae8c4",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.0.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/console": "^7.4 || ^8.0",
+                "symfony/event-dispatcher": "^7.4 || ^8.0",
+                "webmozart/assert": "^1.11 || ^2.1.5"
+            },
+            "conflict": {
+                "amphp/amp": "<2.6.4"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.1.0",
+                "laminas/laminas-mvc": "^3.8.0",
+                "laminas/laminas-servicemanager": "^3.24.0",
+                "mikey179/vfsstream": "2.0.x-dev",
+                "phpunit/phpunit": "^11.5.55",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.15.1"
+            },
+            "bin": [
+                "bin/laminas"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Cli\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Command-line interface for Laminas projects",
+            "keywords": [
+                "cli",
+                "command",
+                "console",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-cli/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/laminas-cli/issues",
+                "rss": "https://github.com/mezzio/laminas-cli/releases.atom",
+                "source": "https://github.com/mezzio/laminas-cli"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2026-03-10T09:04:36+00:00"
+        },
+        {
+            "name": "laminas/laminas-code",
+            "version": "4.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-code.git",
+                "reference": "40d61e2899ec17c5d08bbc0a2d586b3ca17ab9bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/40d61e2899ec17c5d08bbc0a2d586b3ca17ab9bd",
+                "reference": "40d61e2899ec17c5d08bbc0a2d586b3ca17ab9bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0.1",
+                "ext-phar": "*",
+                "laminas/laminas-coding-standard": "^3.0.0",
+                "laminas/laminas-stdlib": "^3.18.0",
+                "phpunit/phpunit": "^10.5.58",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.15.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "laminas/laminas-stdlib": "Laminas\\Stdlib component"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Extensions to the PHP Reflection API, static code scanning, and code generation",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "code",
+                "laminas",
+                "laminasframework"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-code/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-code/issues",
+                "rss": "https://github.com/laminas/laminas-code/releases.atom",
+                "source": "https://github.com/laminas/laminas-code"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-11-01T09:38:14+00:00"
+        },
+        {
+            "name": "laminas/laminas-coding-standard",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-coding-standard.git",
+                "reference": "d4412caba9ed16c93cdcf301759f5ee71f9d9aea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/d4412caba9ed16c93cdcf301759f5ee71f9d9aea",
+                "reference": "d4412caba9ed16c93cdcf301759f5ee71f9d9aea",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+                "php": "^7.4 || ^8.0",
+                "slevomat/coding-standard": "^8.15.0",
+                "squizlabs/php_codesniffer": "^3.10",
+                "webimpress/coding-standard": "^1.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas Coding Standard",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "Coding Standard",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-coding-standard/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-coding-standard/issues",
+                "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
+                "source": "https://github.com/laminas/laminas-coding-standard"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-05-13T08:37:04+00:00"
+        },
+        {
+            "name": "laminas/laminas-development-mode",
+            "version": "3.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-development-mode.git",
+                "reference": "87611d4d742dc314244dcbe4e173a2af11a7c0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-development-mode/zipball/87611d4d742dc314244dcbe4e173a2af11a7c0bc",
+                "reference": "87611d4d742dc314244dcbe4e173a2af11a7c0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "conflict": {
+                "zfcampus/zf-development-mode": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "mikey179/vfsstream": "^1.6.12",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
+            },
+            "bin": [
+                "bin/laminas-development-mode"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\DevelopmentMode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas development mode script",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "framework",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-development-mode/issues",
+                "rss": "https://github.com/laminas/laminas-development-mode/releases.atom",
+                "source": "https://github.com/laminas/laminas-development-mode"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-14T21:17:32+00:00"
+        },
+        {
+            "name": "league/uri",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "URN",
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc2141",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "rfc8141",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-15T20:22:25+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
+            "name": "mezzio/mezzio-tooling",
+            "version": "2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mezzio/mezzio-tooling.git",
+                "reference": "41e8242b27398d0511223d48bbd9efc97d6a2e40"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mezzio/mezzio-tooling/zipball/41e8242b27398d0511223d48bbd9efc97d6a2e40",
+                "reference": "41e8242b27398d0511223d48bbd9efc97d6a2e40",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laminas/laminas-cli": "^1.7.0",
+                "laminas/laminas-code": "^4.7.1",
+                "laminas/laminas-stdlib": "^3.15.0",
+                "laminas/laminas-stratigility": "^3.9.0",
+                "mezzio/mezzio": "^3.13.0",
+                "mezzio/mezzio-router": "^3.9.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.1",
+                "symfony/process": "^6.0.11"
+            },
+            "conflict": {
+                "amphp/amp": "<2.6.4",
+                "symfony/console": "<5.4.45",
+                "symfony/string": "<5.4.45"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-diactoros": "^3.3",
+                "mikey179/vfsstream": "^1.6.12",
+                "mockery/mockery": "^1.6.10",
+                "php-mock/php-mock-phpunit": "^2.9.0",
+                "phpdocumentor/reflection-docblock": "^5.3.0",
+                "phpunit/phpunit": "^10.5.35",
+                "psalm/plugin-mockery": "^0.11.0",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.17.0"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Mezzio\\Tooling\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mezzio\\Tooling\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Migration and development tooling for Mezzio",
+            "homepage": "https://mezzio.dev",
+            "keywords": [
+                "http",
+                "laminas",
+                "mezzio",
+                "middleware",
+                "psr",
+                "psr-7"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.mezzio.dev/mezzio/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/mezzio/mezzio-tooling/issues",
+                "rss": "https://github.com/mezzio/mezzio-tooling/releases.atom",
+                "source": "https://github.com/mezzio/mezzio-tooling"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-09-12T08:39:37+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/980674efdda65913492d29a8fd51c82270dd37bb",
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.5 || ~8.0 || ~9.0 || ~10.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.1"
+            },
+            "time": "2026-02-22T16:28:03+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
+            },
+            "time": "2026-03-18T20:49:53+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.46"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-24T07:01:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T13:52:54+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.55",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-18T12:37:06+00:00"
+        },
+        {
+            "name": "psalm/plugin-phpunit",
+            "version": "0.19.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
+                "reference": "143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc",
+                "reference": "143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "php": ">=8.1",
+                "vimeo/psalm": "dev-master || ^6.10.0"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.20.0",
+                "phpspec/prophecy-phpunit": "<2.3.0",
+                "phpunit/phpunit": "<8.5.1"
+            },
+            "require-dev": {
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psalm\\PhpUnitPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\PhpUnitPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "Psalm plugin for PHPUnit",
+            "support": {
+                "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.7"
+            },
+            "time": "2025-03-31T18:49:55+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "revolt/event-loop",
+            "version": "v1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.15"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
+            },
+            "time": "2025-08-27T21:33:23+00:00"
+        },
+        {
+            "name": "roave/security-advisories",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Roave/SecurityAdvisories.git",
+                "reference": "f41f65e527608a9a76cfbafd873756ed76c5452d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/f41f65e527608a9a76cfbafd873756ed76c5452d",
+                "reference": "f41f65e527608a9a76cfbafd873756ed76c5452d",
+                "shasum": ""
+            },
+            "conflict": {
+                "3f/pygmentize": "<1.2",
+                "adaptcms/adaptcms": "<=1.3",
+                "admidio/admidio": "<5.0.8",
+                "adodb/adodb-php": "<=5.22.9",
+                "aheinze/cockpit": "<2.2",
+                "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.07.2",
+                "aimeos/ai-admin-jsonadm": "<2020.10.13|>=2021.04.1,<2021.10.6|>=2022.04.1,<2022.10.3|>=2023.04.1,<2023.10.4|==2024.04.1",
+                "aimeos/ai-client-html": ">=2020.04.1,<2020.10.27|>=2021.04.1,<2021.10.22|>=2022.04.1,<2022.10.13|>=2023.04.1,<2023.10.15|>=2024.04.1,<2024.04.7",
+                "aimeos/ai-cms-grapesjs": ">=2021.04.1,<2021.10.8|>=2022.04.1,<2022.10.9|>=2023.04.1,<2023.10.15|>=2024.04.1,<2024.10.8|>=2025.04.1,<2025.10.2",
+                "aimeos/ai-controller-frontend": "<2020.10.15|>=2021.04.1,<2021.10.8|>=2022.04.1,<2022.10.8|>=2023.04.1,<2023.10.9|==2024.04.1",
+                "aimeos/aimeos-core": ">=2022.04.1,<2022.10.17|>=2023.04.1,<2023.10.17|>=2024.04.1,<2024.04.7",
+                "aimeos/aimeos-laravel": "==2021.10",
+                "aimeos/aimeos-typo3": "<19.10.12|>=20,<20.10.5",
+                "airesvsg/acf-to-rest-api": "<=3.1",
+                "akaunting/akaunting": "<2.1.13",
+                "akeneo/pim-community-dev": "<5.0.119|>=6,<6.0.53",
+                "alextselegidis/easyappointments": "<=1.5.2",
+                "alexusmai/laravel-file-manager": "<=3.3.1",
+                "algolia/algoliasearch-magento-2": "<=3.16.1|>=3.17.0.0-beta1,<=3.17.1",
+                "alt-design/alt-redirect": "<1.6.4",
+                "altcha-org/altcha": "<1.3.1",
+                "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
+                "amazing/media2click": ">=1,<1.3.3",
+                "ameos/ameos_tarteaucitron": "<1.2.23",
+                "amphp/artax": "<1.0.6|>=2,<2.0.6",
+                "amphp/http": "<=1.7.2|>=2,<=2.1",
+                "amphp/http-client": ">=4,<4.4",
+                "amphp/http-server": ">=2.0.0.0-RC1-dev,<2.1.10|>=3.0.0.0-beta1,<3.4.4",
+                "anchorcms/anchor-cms": "<=0.12.7",
+                "andreapollastri/cipi": "<=3.1.15",
+                "andrewhaine/silverstripe-form-capture": ">=0.2,<=0.2.3|>=1,<1.0.2|>=2,<2.2.5",
+                "aoe/restler": "<1.7.1",
+                "apache-solr-for-typo3/solr": "<2.8.3",
+                "apereo/phpcas": "<1.6",
+                "api-platform/core": "<3.4.17|>=4,<4.0.22|>=4.1,<4.1.5",
+                "api-platform/graphql": "<3.4.17|>=4,<4.0.22|>=4.1,<4.1.5",
+                "appwrite/server-ce": "<=1.2.1",
+                "arc/web": "<3",
+                "area17/twill": "<1.2.5|>=2,<2.5.3",
+                "artesaos/seotools": "<0.17.2",
+                "asymmetricrypt/asymmetricrypt": "<9.9.99",
+                "athlon1600/php-proxy": "<=5.1",
+                "athlon1600/php-proxy-app": "<=3",
+                "athlon1600/youtube-downloader": "<=4",
+                "aureuserp/aureuserp": "<1.3.0.0-beta1",
+                "austintoddj/canvas": "<=3.4.2",
+                "auth0/auth0-php": ">=3.3,<=8.18",
+                "auth0/login": "<=7.20",
+                "auth0/symfony": "<=5.7",
+                "auth0/wordpress": "<=5.5",
+                "automad/automad": "<2.0.0.0-alpha5",
+                "automattic/jetpack": "<9.8",
+                "awesome-support/awesome-support": "<=6.0.7",
+                "aws/aws-sdk-php": "<=3.371.3",
+                "ayacoo/redirect-tab": "<2.1.2|>=3,<3.1.7|>=4,<4.0.5",
+                "azuracast/azuracast": "<=0.23.3",
+                "b13/seo_basics": "<0.8.2",
+                "backdrop/backdrop": "<=1.32",
+                "backpack/crud": "<3.4.9",
+                "backpack/filemanager": "<2.0.2|>=3,<3.0.9",
+                "bacula-web/bacula-web": "<9.7.1",
+                "badaso/core": "<=2.9.11",
+                "bagisto/bagisto": "<2.3.10",
+                "barrelstrength/sprout-base-email": "<1.2.7",
+                "barrelstrength/sprout-forms": "<3.9",
+                "barryvdh/laravel-translation-manager": "<0.6.8",
+                "barzahlen/barzahlen-php": "<2.0.1",
+                "baserproject/basercms": "<=5.2.2",
+                "bassjobsen/bootstrap-3-typeahead": ">4.0.2",
+                "bbpress/bbpress": "<2.6.5",
+                "bcit-ci/codeigniter": "<3.1.3",
+                "bcosca/fatfree": "<3.7.2",
+                "bedita/bedita": "<4",
+                "bednee/cooluri": "<1.0.30",
+                "bigfork/silverstripe-form-capture": ">=3,<3.1.1",
+                "billz/raspap-webgui": "<3.3.6",
+                "binarytorch/larecipe": "<2.8.1",
+                "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
+                "blueimp/jquery-file-upload": "==6.4.4",
+                "bmarshall511/wordpress_zero_spam": "<5.2.13",
+                "bolt/bolt": "<3.7.2",
+                "bolt/core": "<=4.2",
+                "born05/craft-twofactorauthentication": "<3.3.4",
+                "bottelet/flarepoint": "<2.2.1",
+                "bref/bref": "<2.1.17",
+                "brightlocal/phpwhois": "<=4.2.5",
+                "brotkrueml/codehighlight": "<2.7",
+                "brotkrueml/schema": "<1.13.1|>=2,<2.5.1",
+                "brotkrueml/typo3-matomo-integration": "<1.3.2",
+                "buddypress/buddypress": "<7.2.1",
+                "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
+                "bvbmedia/multishop": "<2.0.39",
+                "bytefury/crater": "<6.0.2",
+                "cachethq/cachet": "<2.5.1",
+                "cadmium-org/cadmium-cms": "<=0.4.9",
+                "cakephp/cakephp": "<3.10.3|>=4,<4.0.10|>=4.1,<4.1.4|>=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10|>=5.2.10,<5.2.12|==5.3",
+                "cakephp/database": ">=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10",
+                "cardgate/magento2": "<2.0.33",
+                "cardgate/woocommerce": "<=3.1.15",
+                "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
+                "cart2quote/module-quotation-encoded": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
+                "cartalyst/sentry": "<=2.1.6",
+                "catfan/medoo": "<1.7.5",
+                "causal/oidc": "<4",
+                "cecil/cecil": "<7.47.1",
+                "centreon/centreon": "<22.10.15",
+                "cesargb/laravel-magiclink": ">=2,<2.25.1",
+                "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
+                "chriskacerguis/codeigniter-restserver": "<=2.7.1",
+                "chrome-php/chrome": "<1.14",
+                "ci4-cms-erp/ci4ms": "<=0.31.3",
+                "civicrm/civicrm-core": ">=4.2,<4.2.9|>=4.3,<4.3.3",
+                "ckeditor/ckeditor": "<4.25",
+                "clickstorm/cs-seo": ">=6,<6.8|>=7,<7.5|>=8,<8.4|>=9,<9.3",
+                "co-stack/fal_sftp": "<0.2.6",
+                "cockpit-hq/cockpit": "<2.13.5",
+                "code16/sharp": "<9.20",
+                "codeception/codeception": "<3.1.3|>=4,<4.1.22",
+                "codeigniter/framework": "<3.1.10",
+                "codeigniter4/framework": "<4.6.2",
+                "codeigniter4/shield": "<1.0.0.0-beta8",
+                "codiad/codiad": "<=2.8.4",
+                "codingms/additional-tca": ">=1.7,<1.15.17|>=1.16,<1.16.9",
+                "codingms/modules": "<4.3.11|>=5,<5.7.4|>=6,<6.4.2|>=7,<7.5.5",
+                "commerceteam/commerce": ">=0.9.6,<0.9.9",
+                "components/jquery": ">=1.0.3,<3.5",
+                "composer/composer": "<2.2.27|>=2.3,<2.9.6",
+                "concrete5/concrete5": "<9.4.8",
+                "concrete5/core": "<8.5.8|>=9,<9.1",
+                "contao-components/mediaelement": ">=2.14.2,<2.21.1",
+                "contao/comments-bundle": ">=2,<4.13.40|>=5.0.0.0-RC1-dev,<5.3.4",
+                "contao/contao": ">=3,<3.5.37|>=4,<4.4.56|>=4.5,<4.13.56|>=5,<5.3.38|>=5.4.0.0-RC1-dev,<5.6.1",
+                "contao/core": "<3.5.39",
+                "contao/core-bundle": "<4.13.57|>=5,<5.3.42|>=5.4,<5.6.5",
+                "contao/listing-bundle": ">=3,<=3.5.30|>=4,<4.4.8",
+                "contao/managed-edition": "<=1.5",
+                "coreshop/core-shop": "<4.1.9",
+                "corveda/phpsandbox": "<1.3.5",
+                "cosenary/instagram": "<=2.3",
+                "couleurcitron/tarteaucitron-wp": "<0.3",
+                "cpsit/typo3-mailqueue": "<0.4.5|>=0.5,<0.5.2",
+                "craftcms/aws-s3": ">=2.0.2,<=2.2.4",
+                "craftcms/azure-blob": ">=2.0.0.0-beta1,<=2.1",
+                "craftcms/cms": "<=4.17.8|>=5,<5.9.15",
+                "craftcms/commerce": ">=4,<4.11|>=5,<5.6",
+                "craftcms/composer": ">=4.0.0.0-RC1-dev,<=4.10|>=5.0.0.0-RC1-dev,<=5.5.1",
+                "craftcms/craft": ">=3.5,<=4.16.17|>=5.0.0.0-RC1-dev,<=5.8.21",
+                "craftcms/google-cloud": ">=2.0.0.0-beta1,<=2.2",
+                "craftcms/webhooks": ">=3,<3.2",
+                "croogo/croogo": "<=4.0.7",
+                "cuyz/valinor": "<0.12",
+                "czim/file-handling": "<1.5|>=2,<2.3",
+                "czproject/git-php": "<4.0.3",
+                "damienharper/auditor-bundle": "<5.2.6",
+                "dapphp/securimage": "<3.6.6",
+                "darylldoyle/safe-svg": "<1.9.10",
+                "datadog/dd-trace": ">=0.30,<0.30.2",
+                "datahihi1/tiny-env": "<1.0.3|>=1.0.9,<1.0.11",
+                "datatables/datatables": "<1.10.10",
+                "david-garcia/phpwhois": "<=4.3.1",
+                "dbrisinajumi/d2files": "<1",
+                "dcat/laravel-admin": "<=2.1.3|==2.2.0.0-beta|==2.2.2.0-beta",
+                "derhansen/fe_change_pwd": "<2.0.5|>=3,<3.0.3",
+                "derhansen/sf_event_mgt": "<4.3.1|>=5,<5.1.1|>=7,<7.4",
+                "desperado/xml-bundle": "<=0.1.7",
+                "dev-lancer/minecraft-motd-parser": "<=1.0.5",
+                "devcode-it/openstamanager": "<=2.10.1",
+                "devgroup/dotplant": "<2020.09.14-dev",
+                "digimix/wp-svg-upload": "<=1",
+                "directmailteam/direct-mail": "<6.0.3|>=7,<7.0.3|>=8,<9.5.2",
+                "directorytree/imapengine": "<1.22.3",
+                "dl/yag": "<3.0.1",
+                "dmk/webkitpdf": "<1.1.4",
+                "dnadesign/silverstripe-elemental": "<5.3.12",
+                "doctrine/annotations": "<1.2.7",
+                "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
+                "doctrine/common": "<2.4.3|>=2.5,<2.5.1",
+                "doctrine/dbal": ">=2,<2.0.8|>=2.1,<2.1.2|>=3,<3.1.4",
+                "doctrine/doctrine-bundle": "<1.5.2",
+                "doctrine/doctrine-module": "<0.7.2",
+                "doctrine/mongodb-odm": "<1.0.2",
+                "doctrine/mongodb-odm-bundle": "<3.0.1",
+                "doctrine/orm": ">=1,<1.2.4|>=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
+                "dolibarr/dolibarr": "<=22.0.4",
+                "dompdf/dompdf": "<2.0.4",
+                "doublethreedigital/guest-entries": "<3.1.2",
+                "dreamfactory/df-core": "<1.0.4",
+                "drupal-pattern-lab/unified-twig-extensions": "<=0.1",
+                "drupal/access_code": "<2.0.5",
+                "drupal/acquia_dam": "<1.1.5",
+                "drupal/admin_audit_trail": "<1.0.5",
+                "drupal/ai": "<1.0.5",
+                "drupal/alogin": "<2.0.6",
+                "drupal/cache_utility": "<1.2.1",
+                "drupal/civictheme": "<1.12",
+                "drupal/commerce_alphabank_redirect": "<1.0.3",
+                "drupal/commerce_eurobank_redirect": "<2.1.1",
+                "drupal/config_split": "<1.10|>=2,<2.0.2",
+                "drupal/core": ">=6,<6.38|>=7,<7.103|>=8,<10.4.9|>=10.5,<10.5.6|>=11,<11.1.9|>=11.2,<11.2.8",
+                "drupal/core-recommended": ">=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
+                "drupal/currency": "<3.5",
+                "drupal/drupal": ">=5,<5.11|>=6,<6.38|>=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
+                "drupal/email_tfa": "<2.0.6",
+                "drupal/formatter_suite": "<2.1",
+                "drupal/gdpr": "<3.0.1|>=3.1,<3.1.2",
+                "drupal/google_tag": "<1.8|>=2,<2.0.8",
+                "drupal/ignition": "<1.0.4",
+                "drupal/json_field": "<1.5",
+                "drupal/lightgallery": "<1.6",
+                "drupal/link_field_display_mode_formatter": "<1.6",
+                "drupal/matomo": "<1.24",
+                "drupal/oauth2_client": "<4.1.3",
+                "drupal/oauth2_server": "<2.1",
+                "drupal/obfuscate": "<2.0.1",
+                "drupal/plausible_tracking": "<1.0.2",
+                "drupal/quick_node_block": "<2",
+                "drupal/rapidoc_elements_field_formatter": "<1.0.1",
+                "drupal/reverse_proxy_header": "<1.1.2",
+                "drupal/simple_multistep": "<2",
+                "drupal/simple_oauth": ">=6,<6.0.7",
+                "drupal/spamspan": "<3.2.1",
+                "drupal/tfa": "<1.10",
+                "drupal/umami_analytics": "<1.0.1",
+                "duncanmcclean/guest-entries": "<3.1.2",
+                "dweeves/magmi": "<=0.7.24",
+                "ec-cube/ec-cube": "<2.4.4|>=2.11,<=2.17.1|>=3,<=3.0.18.0-patch4|>=4,<=4.3.1",
+                "ecodev/newsletter": "<=4",
+                "ectouch/ectouch": "<=2.7.2",
+                "egroupware/egroupware": "<23.1.20260113|>=26.0.20251208,<26.0.20260113",
+                "elefant/cms": "<2.0.7",
+                "elgg/elgg": "<3.3.24|>=4,<4.0.5",
+                "elijaa/phpmemcacheadmin": "<=1.3",
+                "elmsln/haxcms": "<11.0.14",
+                "encore/laravel-admin": "<=1.8.19",
+                "endroid/qr-code-bundle": "<3.4.2",
+                "enhavo/enhavo-app": "<=0.13.1",
+                "enshrined/svg-sanitize": "<0.22",
+                "erusev/parsedown": "<1.7.2",
+                "ether/logs": "<3.0.4",
+                "evolutioncms/evolution": "<=3.2.3",
+                "exceedone/exment": "<4.4.3|>=5,<5.0.3",
+                "exceedone/laravel-admin": "<2.2.3|==3",
+                "ezsystems/demobundle": ">=5.4,<5.4.6.1-dev",
+                "ezsystems/ez-support-tools": ">=2.2,<2.2.3",
+                "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1-dev",
+                "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1-dev|>=5.4,<5.4.11.1-dev|>=2017.12,<2017.12.0.1-dev",
+                "ezsystems/ezplatform": "<=1.13.6|>=2,<=2.5.24",
+                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<1.5.29|>=2.3,<2.3.39|>=3.3,<3.3.39",
+                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1|>=5.3.0.0-beta1,<5.3.5",
+                "ezsystems/ezplatform-graphql": ">=1.0.0.0-RC1-dev,<1.0.13|>=2.0.0.0-beta1,<2.3.12",
+                "ezsystems/ezplatform-http-cache": "<2.3.16",
+                "ezsystems/ezplatform-kernel": "<=1.2.5|>=1.3,<1.3.35",
+                "ezsystems/ezplatform-rest": ">=1.2,<=1.2.2|>=1.3,<1.3.8",
+                "ezsystems/ezplatform-richtext": ">=2.3,<2.3.26|>=3.3,<3.3.40",
+                "ezsystems/ezplatform-solr-search-engine": ">=1.7,<1.7.12|>=2,<2.0.2|>=3.3,<3.3.15",
+                "ezsystems/ezplatform-user": ">=1,<1.0.1",
+                "ezsystems/ezpublish-kernel": "<=6.13.8.1|>=7,<7.5.31",
+                "ezsystems/ezpublish-legacy": "<=2017.12.7.3|>=2018.6,<=2019.03.5.1",
+                "ezsystems/platform-ui-assets-bundle": ">=4.2,<4.2.3",
+                "ezsystems/repository-forms": ">=2.3,<2.3.2.1-dev|>=2.5,<2.5.15",
+                "ezyang/htmlpurifier": "<=4.2",
+                "facade/ignition": "<1.16.15|>=2,<2.4.2|>=2.5,<2.5.2",
+                "facturascripts/facturascripts": "<2025.81",
+                "fastly/magento2": "<1.2.26",
+                "feehi/cms": "<=2.1.1",
+                "feehi/feehicms": "<=2.1.1",
+                "fenom/fenom": "<=2.12.1",
+                "filament/actions": ">=3.2,<3.2.123",
+                "filament/filament": ">=4,<4.3.1",
+                "filament/infolists": ">=3,<3.2.115",
+                "filament/tables": ">=3,<3.2.115|>=4,<4.8.5|>=5,<5.3.5",
+                "filegator/filegator": "<7.8",
+                "filp/whoops": "<2.1.13",
+                "fineuploader/php-traditional-server": "<=1.2.2",
+                "firebase/php-jwt": "<7",
+                "fisharebest/webtrees": "<=2.1.18",
+                "fixpunkt/fp-masterquiz": "<2.2.1|>=3,<3.5.2",
+                "fixpunkt/fp-newsletter": "<1.1.1|>=1.2,<2.1.2|>=2.2,<3.2.6",
+                "flarum/core": "<1.8.10",
+                "flarum/flarum": "<0.1.0.0-beta8",
+                "flarum/framework": "<1.8.10",
+                "flarum/mentions": "<1.6.3",
+                "flarum/nicknames": "<1.8.3",
+                "flarum/sticky": ">=0.1.0.0-beta14,<=0.1.0.0-beta15",
+                "flarum/tags": "<=0.1.0.0-beta13",
+                "floriangaerber/magnesium": "<0.3.1",
+                "fluidtypo3/vhs": "<5.1.1",
+                "fof/byobu": ">=0.3.0.0-beta2,<1.1.7",
+                "fof/pretty-mail": "<=1.1.2",
+                "fof/upload": "<1.2.3",
+                "foodcoopshop/foodcoopshop": ">=3.2,<3.6.1",
+                "fooman/tcpdf": "<6.2.22",
+                "forkcms/forkcms": "<5.11.1",
+                "fossar/tcpdf-parser": "<6.2.22",
+                "francoisjacquet/rosariosis": "<=11.5.1",
+                "frappant/frp-form-answers": "<3.1.2|>=4,<4.0.2",
+                "friendsofsymfony/oauth2-php": "<1.3",
+                "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
+                "friendsofsymfony/user-bundle": ">=1,<1.3.5",
+                "friendsofsymfony1/swiftmailer": ">=4,<5.4.13|>=6,<6.2.5",
+                "friendsofsymfony1/symfony1": ">=1.1,<1.5.19",
+                "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
+                "friendsoftypo3/openid": ">=4.5,<4.5.31|>=4.7,<4.7.16|>=6,<6.0.11|>=6.1,<6.1.6",
+                "froala/wysiwyg-editor": "<=4.3",
+                "frosh/adminer-platform": "<2.2.1",
+                "froxlor/froxlor": "<2.3.6",
+                "frozennode/administrator": "<=5.0.12",
+                "fuel/core": "<1.8.1",
+                "funadmin/funadmin": "<=7.1.0.0-RC4",
+                "gaoming13/wechat-php-sdk": "<=1.10.2",
+                "genix/cms": "<=1.1.11",
+                "georgringer/news": "<1.3.3",
+                "geshi/geshi": "<=1.0.9.1",
+                "getformwork/formwork": "<=2.3.3",
+                "getgrav/grav": "<1.11.0.0-beta1",
+                "getkirby/cms": "<=5.2.1",
+                "getkirby/kirby": "<3.9.8.3-dev|>=3.10,<3.10.1.2-dev|>=4,<4.7.1",
+                "getkirby/panel": "<2.5.14",
+                "getkirby/starterkit": "<=3.7.0.2",
+                "gilacms/gila": "<=1.15.4",
+                "gleez/cms": "<=1.3|==2",
+                "globalpayments/php-sdk": "<2",
+                "goalgorilla/open_social": "<12.3.11|>=12.4,<12.4.10|>=13.0.0.0-alpha1,<13.0.0.0-alpha11",
+                "gogentooss/samlbase": "<1.2.7",
+                "goodoneuz/pay-uz": "<=2.2.24",
+                "google/protobuf": "<4.33.6",
+                "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
+                "gp247/core": "<1.1.24",
+                "gree/jose": "<2.2.1",
+                "gregwar/rst": "<1.0.3",
+                "grumpydictator/firefly-iii": "<6.1.17|>=6.4.23,<=6.5",
+                "gugoan/economizzer": "<=0.9.0.0-beta1",
+                "guzzlehttp/guzzle": "<6.5.8|>=7,<7.4.5",
+                "guzzlehttp/oauth-subscriber": "<0.8.1",
+                "guzzlehttp/psr7": "<1.9.1|>=2,<2.4.5",
+                "haffner/jh_captcha": "<=2.1.3|>=3,<=3.0.2",
+                "handcraftedinthealps/goodby-csv": "<1.4.3",
+                "harvesthq/chosen": "<1.8.7",
+                "helloxz/imgurl": "<=2.31",
+                "hhxsv5/laravel-s": "<3.7.36",
+                "hillelcoren/invoice-ninja": "<5.3.35",
+                "himiklab/yii2-jqgrid-widget": "<1.0.8",
+                "hjue/justwriting": "<=1",
+                "hov/jobfair": "<1.0.13|>=2,<2.0.2",
+                "httpsoft/http-message": "<1.0.12",
+                "hybridauth/hybridauth": "<=3.12.2",
+                "hyn/multi-tenant": ">=5.6,<5.7.2",
+                "ibexa/admin-ui": ">=4.2,<4.2.3|>=4.6,<4.6.25|>=5,<5.0.3",
+                "ibexa/admin-ui-assets": ">=4.6.0.0-alpha1,<4.6.21",
+                "ibexa/core": ">=4,<4.0.7|>=4.1,<4.1.4|>=4.2,<4.2.3|>=4.5,<4.5.6|>=4.6,<4.6.2",
+                "ibexa/fieldtype-richtext": ">=4.6,<4.6.25|>=5,<5.0.3",
+                "ibexa/graphql": ">=2.5,<2.5.31|>=3.3,<3.3.28|>=4.2,<4.2.3",
+                "ibexa/http-cache": ">=4.6,<4.6.14",
+                "ibexa/post-install": "<1.0.16|>=4.6,<4.6.14",
+                "ibexa/solr": ">=4.5,<4.5.4",
+                "ibexa/user": ">=4,<4.4.3|>=5,<5.0.4",
+                "icecoder/icecoder": "<=8.1",
+                "idno/known": "<1.6.4",
+                "ilicmiljan/secure-props": ">=1.2,<1.2.2",
+                "illuminate/auth": "<5.5.10",
+                "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<6.18.31|>=7,<7.22.4",
+                "illuminate/database": "<6.20.26|>=7,<7.30.5|>=8,<8.40",
+                "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
+                "illuminate/view": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
+                "imdbphp/imdbphp": "<=5.1.1",
+                "impresscms/impresscms": "<=1.4.5",
+                "impresspages/impresspages": "<1.0.13",
+                "in2code/femanager": "<6.4.2|>=7,<7.5.3|>=8,<8.3.1",
+                "in2code/ipandlanguageredirect": "<5.1.2",
+                "in2code/lux": "<17.6.1|>=18,<24.0.2",
+                "in2code/powermail": "<7.5.1|>=8,<8.5.1|>=9,<10.9.1|>=11,<12.5.3|==13",
+                "innologi/typo3-appointments": "<2.0.6",
+                "intelliants/subrion": "<4.2.2",
+                "inter-mediator/inter-mediator": "==5.5",
+                "invoiceninja/invoiceninja": "<5.13.4",
+                "ipl/web": "<0.10.1",
+                "islandora/crayfish": "<4.1",
+                "islandora/islandora": ">=2,<2.4.1",
+                "ivankristianto/phpwhois": "<=4.3",
+                "j0k3r/graby": "<=2.5",
+                "jackalope/jackalope-doctrine-dbal": "<1.7.4",
+                "jambagecom/div2007": "<0.10.2",
+                "james-heinrich/getid3": "<1.9.21",
+                "james-heinrich/phpthumb": "<=1.7.23",
+                "jasig/phpcas": "<1.3.3",
+                "jbartels/wec-map": "<3.0.3",
+                "jcbrand/converse.js": "<3.3.3",
+                "joedolson/my-calendar": "<3.7.7",
+                "joelbutcher/socialstream": "<5.6|>=6,<6.2",
+                "johnbillion/query-monitor": "<3.20.4",
+                "johnbillion/wp-crontrol": "<1.16.2|>=1.17,<1.19.2",
+                "joomla/application": "<1.0.13",
+                "joomla/archive": "<1.1.12|>=2,<2.0.1",
+                "joomla/database": ">=1,<2.2|>=3,<3.4",
+                "joomla/filesystem": "<1.6.2|>=2,<2.0.1",
+                "joomla/filter": "<2.0.6|>=3,<3.0.5|==4",
+                "joomla/framework": "<1.5.7|>=2.5.4,<=3.8.12",
+                "joomla/input": ">=2,<2.0.2",
+                "joomla/joomla-cms": "<3.9.12|>=4,<4.4.13|>=5,<5.2.6",
+                "joomla/joomla-platform": "<1.5.4",
+                "joomla/session": "<1.3.1",
+                "joyqi/hyper-down": "<=2.4.27",
+                "jsdecena/laracom": "<2.0.9",
+                "jsmitty12/phpwhois": "<5.1",
+                "juzaweb/cms": "<=3.4.2",
+                "jweiland/events2": "<8.3.8|>=9,<9.0.6",
+                "jweiland/kk-downloader": "<1.2.2",
+                "kantorge/yaffa": "<=2",
+                "kazist/phpwhois": "<=4.2.6",
+                "kelvinmo/simplejwt": "<=1.1",
+                "kelvinmo/simplexrd": "<3.1.1",
+                "kevinpapst/kimai2": "<1.16.7",
+                "khodakhah/nodcms": "<=3.4.1",
+                "kimai/kimai": "<=2.53",
+                "kitodo/presentation": "<3.2.3|>=3.3,<3.3.4",
+                "klaviyo/magento2-extension": ">=1,<3",
+                "knplabs/knp-snappy": "<=1.4.2",
+                "kohana/core": "<3.3.3",
+                "koillection/koillection": "<1.6.12",
+                "krayin/laravel-crm": "<=2.2",
+                "kreait/firebase-php": ">=3.2,<3.8.1",
+                "kumbiaphp/kumbiapp": "<=1.1.1",
+                "la-haute-societe/tcpdf": "<6.2.22",
+                "laminas/laminas-diactoros": "<2.18.1|==2.19|==2.20|==2.21|==2.22|==2.23|>=2.24,<2.24.2|>=2.25,<2.25.2",
+                "laminas/laminas-form": "<2.17.1|>=3,<3.0.2|>=3.1,<3.1.1",
+                "laminas/laminas-http": "<2.14.2",
+                "lara-zeus/artemis": ">=1,<=1.0.6",
+                "lara-zeus/dynamic-dashboard": ">=3,<=3.0.1",
+                "laravel/fortify": "<1.11.1",
+                "laravel/framework": "<10.48.29|>=11,<11.44.1|>=12,<12.1.1",
+                "laravel/laravel": ">=5.4,<5.4.22",
+                "laravel/passport": ">=13,<13.7.1",
+                "laravel/pulse": "<1.3.1",
+                "laravel/reverb": "<1.7",
+                "laravel/socialite": ">=1,<2.0.10",
+                "latte/latte": "<2.10.8",
+                "lavalite/cms": "<=10.1",
+                "lavitto/typo3-form-to-database": "<2.2.5|>=3,<3.2.2|>=4,<4.2.3|>=5,<5.0.2",
+                "lcobucci/jwt": ">=3.4,<3.4.6|>=4,<4.0.4|>=4.1,<4.1.5",
+                "league/commonmark": "<=2.8.1",
+                "league/flysystem": "<1.1.4|>=2,<2.1.1",
+                "league/oauth2-server": ">=8.3.2,<8.4.2|>=8.5,<8.5.3",
+                "leantime/leantime": "<3.3",
+                "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
+                "libreform/libreform": ">=2,<=2.0.8",
+                "librenms/librenms": "<26.3",
+                "liftkit/database": "<2.13.2",
+                "lightsaml/lightsaml": "<1.3.5",
+                "limesurvey/limesurvey": "<6.15.4",
+                "livehelperchat/livehelperchat": "<=3.91",
+                "livewire-filemanager/filemanager": "<=1.0.4",
+                "livewire/livewire": "<2.12.7|>=3.0.0.0-beta1,<3.6.4",
+                "livewire/volt": "<1.7",
+                "lms/routes": "<2.1.1",
+                "localizationteam/l10nmgr": "<7.4|>=8,<8.7|>=9,<9.2",
+                "lomkit/laravel-rest-api": "<2.13",
+                "luracast/restler": "<3.1",
+                "luyadev/yii-helpers": "<1.2.1",
+                "macropay-solutions/laravel-crud-wizard-free": "<3.4.17",
+                "maestroerror/php-heic-to-jpg": "<1.0.5",
+                "magento/community-edition": "<2.4.6.0-patch13|>=2.4.7.0-beta1,<2.4.7.0-patch8|>=2.4.8.0-beta1,<2.4.8.0-patch3|>=2.4.9.0-alpha1,<2.4.9.0-alpha3|==2.4.9",
+                "magento/core": "<=1.9.4.5",
+                "magento/magento1ce": "<1.9.4.3-dev",
+                "magento/magento1ee": ">=1,<1.14.4.3-dev",
+                "magento/product-community-edition": "<2.4.4.0-patch9|>=2.4.5,<2.4.5.0-patch8|>=2.4.6,<2.4.6.0-patch6|>=2.4.7,<2.4.7.0-patch1",
+                "magento/project-community-edition": "<=2.0.2",
+                "magneto/core": "<1.9.4.4-dev",
+                "mahocommerce/maho": "<25.9",
+                "maikuolan/phpmussel": ">=1,<1.6",
+                "mainwp/mainwp": "<=4.4.3.3",
+                "manogi/nova-tiptap": "<=3.2.6",
+                "mantisbt/mantisbt": "<2.28.1",
+                "marcwillmann/turn": "<0.3.3",
+                "markhuot/craftql": "<=1.3.7",
+                "marshmallow/nova-tiptap": "<5.7",
+                "matomo/matomo": "<1.11",
+                "matyhtf/framework": "<3.0.6",
+                "mautic/core": "<5.2.10|>=6,<6.0.8|>=7.0.0.0-alpha,<7.0.1",
+                "mautic/core-lib": ">=1.0.0.0-beta,<4.4.13|>=5.0.0.0-alpha,<5.1.1",
+                "mautic/grapes-js-builder-bundle": ">=4,<4.4.18|>=5,<5.2.9|>=6,<6.0.7",
+                "maximebf/debugbar": "<1.19",
+                "mdanter/ecc": "<2",
+                "mediawiki/abuse-filter": "<1.39.9|>=1.40,<1.41.3|>=1.42,<1.42.2",
+                "mediawiki/cargo": "<3.8.3",
+                "mediawiki/core": "<1.39.5|==1.40",
+                "mediawiki/data-transfer": ">=1.39,<1.39.11|>=1.41,<1.41.3|>=1.42,<1.42.2",
+                "mediawiki/matomo": "<2.4.3",
+                "mediawiki/semantic-media-wiki": "<4.0.2",
+                "mehrwert/phpmyadmin": "<3.2",
+                "melisplatform/melis-asset-manager": "<5.0.1",
+                "melisplatform/melis-cms": "<5.3.4",
+                "melisplatform/melis-cms-slider": "<5.3.1",
+                "melisplatform/melis-core": "<5.3.11",
+                "melisplatform/melis-front": "<5.0.1",
+                "mezzio/mezzio-swoole": "<3.7|>=4,<4.3",
+                "mgallegos/laravel-jqgrid": "<=1.3",
+                "microsoft/microsoft-graph": ">=1.16,<1.109.1|>=2,<2.0.1",
+                "microsoft/microsoft-graph-beta": "<2.0.1",
+                "microsoft/microsoft-graph-core": "<2.0.2",
+                "microweber/microweber": "<2.0.20",
+                "mikehaertl/php-shellcommand": "<1.6.1",
+                "mineadmin/mineadmin": "<=3.0.9",
+                "miniorange/miniorange-saml": "<1.4.3",
+                "miraheze/ts-portal": "<=33",
+                "mittwald/typo3_forum": "<1.2.1",
+                "mobiledetect/mobiledetectlib": "<2.8.32",
+                "modx/revolution": "<=3.1",
+                "mojo42/jirafeau": "<4.4",
+                "mongodb/mongodb": ">=1,<1.9.2",
+                "mongodb/mongodb-extension": "<1.21.2",
+                "monolog/monolog": ">=1.8,<1.12",
+                "moodle/moodle": "<4.5.9|>=5.0.0.0-beta,<5.0.5|>=5.1.0.0-beta,<5.1.2",
+                "moonshine/moonshine": "<=3.12.5",
+                "mos/cimage": "<0.7.19",
+                "movim/moxl": ">=0.8,<=0.10",
+                "movingbytes/social-network": "<=1.2.1",
+                "mpdf/mpdf": "<=7.1.7",
+                "munkireport/comment": "<4",
+                "munkireport/managedinstalls": "<2.6",
+                "munkireport/munki_facts": "<1.5",
+                "munkireport/reportdata": "<3.5",
+                "munkireport/softwareupdate": "<1.6",
+                "mustache/mustache": ">=2,<2.14.1",
+                "mwdelaney/wp-enable-svg": "<=0.2",
+                "namshi/jose": "<2.2",
+                "nasirkhan/laravel-starter": "<11.11",
+                "nategood/httpful": "<1",
+                "neoan3-apps/template": "<1.1.1",
+                "neorazorx/facturascripts": "<2022.04",
+                "neos/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
+                "neos/form": ">=1.2,<4.3.3|>=5,<5.0.9|>=5.1,<5.1.3",
+                "neos/media-browser": "<7.3.19|>=8,<8.0.16|>=8.1,<8.1.11|>=8.2,<8.2.11|>=8.3,<8.3.9",
+                "neos/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<5.3.10|>=7,<7.0.9|>=7.1,<7.1.7|>=7.2,<7.2.6|>=7.3,<7.3.4|>=8,<8.0.2",
+                "neos/swiftmailer": "<5.4.5",
+                "nesbot/carbon": "<2.72.6|>=3,<3.8.4",
+                "netcarver/textile": "<=4.1.2",
+                "netgen/tagsbundle": ">=3.4,<3.4.11|>=4,<4.0.15",
+                "nette/application": ">=2,<2.0.19|>=2.1,<2.1.13|>=2.2,<2.2.10|>=2.3,<2.3.14|>=2.4,<2.4.16|>=3,<3.0.6",
+                "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
+                "neuron-core/neuron-ai": "<=2.8.11",
+                "nilsteampassnet/teampass": "<3.1.3.1-dev",
+                "nitsan/ns-backup": "<13.0.1",
+                "nonfiction/nterchange": "<4.1.1",
+                "notrinos/notrinos-erp": "<=0.7",
+                "noumo/easyii": "<=0.9",
+                "novaksolutions/infusionsoft-php-sdk": "<1",
+                "novosga/novosga": "<=2.2.12",
+                "nukeviet/nukeviet": "<4.5.02",
+                "nyholm/psr7": "<1.6.1",
+                "nystudio107/craft-seomatic": "<3.4.12",
+                "nzedb/nzedb": "<0.8",
+                "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
+                "october/backend": "<1.1.2",
+                "october/cms": "<1.0.469|==1.0.469|==1.0.471|==1.1.1",
+                "october/october": "<3.7.14|>=4,<4.1.10",
+                "october/rain": "<=3.7.13|>=4,<=4.1.9",
+                "october/system": "<3.7.16|>=4,<4.1.16",
+                "oliverklee/phpunit": "<3.5.15",
+                "omeka/omeka-s": "<4.0.3",
+                "onelogin/php-saml": "<2.21.1|>=3,<3.8.1|>=4,<4.3.1",
+                "oneup/uploader-bundle": ">=1,<1.9.3|>=2,<2.1.5",
+                "open-web-analytics/open-web-analytics": "<1.8.1",
+                "opencart/opencart": ">=0",
+                "openid/php-openid": "<2.3",
+                "openmage/magento-lts": "<20.17",
+                "opensolutions/vimbadmin": "<=3.0.15",
+                "opensource-workshop/connect-cms": "<1.41.1|>=2,<2.41.1",
+                "orchid/platform": ">=8,<14.43",
+                "oro/calendar-bundle": ">=4.2,<=4.2.6|>=5,<=5.0.6|>=5.1,<5.1.1",
+                "oro/commerce": ">=4.1,<5.0.11|>=5.1,<5.1.1",
+                "oro/crm": ">=1.7,<1.7.4|>=3.1,<4.1.17|>=4.2,<4.2.7",
+                "oro/crm-call-bundle": ">=4.2,<=4.2.5|>=5,<5.0.4|>=5.1,<5.1.1",
+                "oro/customer-portal": ">=4.1,<=4.1.13|>=4.2,<=4.2.10|>=5,<=5.0.11|>=5.1,<=5.1.3",
+                "oro/platform": ">=1.7,<1.7.4|>=3.1,<3.1.29|>=4.1,<4.1.17|>=4.2,<=4.2.10|>=5,<=5.0.12|>=5.1,<=5.1.3",
+                "oveleon/contao-cookiebar": "<1.16.3|>=2,<2.1.3",
+                "oxid-esales/oxideshop-ce": "<=7.0.5",
+                "oxid-esales/paymorrow-module": ">=1,<1.0.2|>=2,<2.0.1",
+                "packbackbooks/lti-1-3-php-library": "<5",
+                "padraic/humbug_get_contents": "<1.1.2",
+                "pagarme/pagarme-php": "<3",
+                "pagekit/pagekit": "<=1.0.18",
+                "paragonie/ecc": "<2.0.1",
+                "paragonie/random_compat": "<2",
+                "paragonie/sodium_compat": "<1.24|>=2,<2.5",
+                "passbolt/passbolt_api": "<4.6.2",
+                "paypal/adaptivepayments-sdk-php": "<=3.9.2",
+                "paypal/invoice-sdk-php": "<=3.9",
+                "paypal/merchant-sdk-php": "<3.12",
+                "paypal/permissions-sdk-php": "<=3.9.1",
+                "pear/archive_tar": "<1.4.14",
+                "pear/auth": "<1.2.4",
+                "pear/crypt_gpg": "<1.6.7",
+                "pear/http_request2": "<2.7",
+                "pear/pear": "<=1.10.1",
+                "pegasus/google-for-jobs": "<1.5.1|>=2,<2.1.1",
+                "personnummer/personnummer": "<3.0.2",
+                "ph7software/ph7builder": "<=17.9.1",
+                "phanan/koel": "<5.1.4",
+                "phenx/php-svg-lib": "<0.5.2",
+                "php-censor/php-censor": "<2.0.13|>=2.1,<2.1.5",
+                "php-mod/curl": "<2.3.2",
+                "phpbb/phpbb": "<3.3.11",
+                "phpems/phpems": ">=6,<=6.1.3",
+                "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
+                "phpmailer/phpmailer": "<6.5",
+                "phpmussel/phpmussel": ">=1,<1.6",
+                "phpmyadmin/phpmyadmin": "<5.2.2",
+                "phpmyfaq/phpmyfaq": "<=4.1",
+                "phpoffice/common": "<0.2.9",
+                "phpoffice/math": "<=0.2",
+                "phpoffice/phpexcel": "<=1.8.2",
+                "phpoffice/phpspreadsheet": "<1.30|>=2,<2.1.12|>=2.2,<2.4|>=3,<3.10|>=4,<5",
+                "phppgadmin/phppgadmin": "<=7.13",
+                "phpseclib/phpseclib": "<2.0.53|>=3,<3.0.51",
+                "phpservermon/phpservermon": "<3.6",
+                "phpsysinfo/phpsysinfo": "<3.4.3",
+                "phpunit/phpunit": "<8.5.52|>=9,<9.6.33|>=10,<10.5.62|>=11,<11.5.50|>=12,<12.5.8|>=12.5.21,<12.5.22|>=13.1.5,<13.1.6",
+                "phpwhois/phpwhois": "<=4.2.5",
+                "phpxmlrpc/extras": "<0.6.1",
+                "phpxmlrpc/phpxmlrpc": "<4.9.2",
+                "phraseanet/phraseanet": "==4.0.3",
+                "pi/pi": "<=2.5",
+                "pimcore/admin-ui-classic-bundle": "<=1.7.15|>=2.0.0.0-RC1-dev,<=2.2.2",
+                "pimcore/customer-management-framework-bundle": "<4.2.1",
+                "pimcore/data-hub": "<1.2.4",
+                "pimcore/data-importer": "<1.8.9|>=1.9,<1.9.3",
+                "pimcore/demo": "<10.3",
+                "pimcore/ecommerce-framework-bundle": "<1.0.10",
+                "pimcore/perspective-editor": "<1.5.1",
+                "pimcore/pimcore": "<=11.5.14.1|>=12,<12.3.3",
+                "pimcore/web2print-tools-bundle": "<=5.2.1|>=6.0.0.0-RC1-dev,<=6.1",
+                "piwik/piwik": "<1.11",
+                "pixelfed/pixelfed": "<0.12.5",
+                "plotly/plotly.js": "<2.25.2",
+                "pocketmine/bedrock-protocol": "<8.0.2",
+                "pocketmine/pocketmine-mp": "<5.42.1",
+                "pocketmine/raklib": ">=0.14,<0.14.6|>=0.15,<0.15.1",
+                "pressbooks/pressbooks": "<5.18",
+                "prestashop/autoupgrade": ">=4,<4.10.1",
+                "prestashop/blockreassurance": "<=5.1.3",
+                "prestashop/blockwishlist": ">=2,<2.1.1",
+                "prestashop/contactform": ">=1.0.1,<4.3",
+                "prestashop/gamification": "<2.3.2",
+                "prestashop/prestashop": "<8.2.5|>=9.0.0.0-alpha1,<9.1",
+                "prestashop/productcomments": "<5.0.2",
+                "prestashop/ps_checkout": "<4.4.1|>=5,<5.0.5",
+                "prestashop/ps_contactinfo": "<=3.3.2",
+                "prestashop/ps_emailsubscription": "<2.6.1",
+                "prestashop/ps_facetedsearch": "<3.4.1",
+                "prestashop/ps_linklist": "<3.1",
+                "privatebin/privatebin": "<1.4|>=1.5,<1.7.4|>=1.7.7,<2.0.3",
+                "processwire/processwire": "<=3.0.255",
+                "propel/propel": ">=2.0.0.0-alpha1,<=2.0.0.0-alpha7",
+                "propel/propel1": ">=1,<=1.7.1",
+                "psy/psysh": "<=0.11.22|>=0.12,<=0.12.18",
+                "pterodactyl/panel": "<1.12.1",
+                "ptheofan/yii2-statemachine": ">=2.0.0.0-RC1-dev,<=2",
+                "ptrofimov/beanstalk_console": "<1.7.14",
+                "pubnub/pubnub": "<6.1",
+                "punktde/pt_extbase": "<1.5.1",
+                "pusher/pusher-php-server": "<2.2.1",
+                "putyourlightson/craft-sprig": ">=2,<2.15.2|>=3,<3.7.2",
+                "pwweb/laravel-core": "<=0.3.6.0-beta",
+                "pxlrbt/filament-excel": "<1.1.14|>=2.0.0.0-alpha,<2.3.3",
+                "pyrocms/pyrocms": "<=3.9.1",
+                "qcubed/qcubed": "<=3.1.1",
+                "quickapps/cms": "<=2.0.0.0-beta2",
+                "rainlab/blog-plugin": "<1.4.1",
+                "rainlab/debugbar-plugin": "<3.1",
+                "rainlab/user-plugin": "<=1.4.5",
+                "ralffreit/mfa-email": "<1.0.7|==2",
+                "rankmath/seo-by-rank-math": "<=1.0.95",
+                "rap2hpoutre/laravel-log-viewer": "<0.13",
+                "react/http": ">=0.7,<1.9",
+                "really-simple-plugins/complianz-gdpr": "<6.4.2",
+                "redaxo/source": "<5.21",
+                "remdex/livehelperchat": "<4.29",
+                "renolit/reint-downloadmanager": "<4.0.2|>=5,<5.0.1",
+                "reportico-web/reportico": "<=8.1",
+                "rhukster/dom-sanitizer": "<1.0.10",
+                "rmccue/requests": ">=1.6,<1.8",
+                "roadiz/documents": "<2.3.42|>=2.4,<2.5.44|>=2.6,<2.6.28|>=2.7,<2.7.9",
+                "robrichards/xmlseclibs": "<3.1.5",
+                "roots/soil": "<4.1",
+                "roundcube/roundcubemail": "<1.5.10|>=1.6,<1.6.11|>=1.7.0.0-beta,<1.7.0.0-RC5-dev",
+                "rudloff/alltube": "<3.0.3",
+                "rudloff/rtmpdump-bin": "<=2.3.1",
+                "s-cart/core": "<=9.0.5",
+                "s-cart/s-cart": "<6.9",
+                "s9y/serendipity": "<2.6",
+                "sabberworm/php-css-parser": ">=1,<1.0.1|>=2,<2.0.1|>=3,<3.0.1|>=4,<4.0.1|>=5,<5.0.9|>=5.1,<5.1.3|>=5.2,<5.2.1|>=6,<6.0.2|>=7,<7.0.4|>=8,<8.0.1|>=8.1,<8.1.1|>=8.2,<8.2.1|>=8.3,<8.3.1",
+                "sabre/dav": ">=1.6,<1.7.11|>=1.8,<1.8.9",
+                "saloonphp/saloon": "<4",
+                "samwilson/unlinked-wikibase": "<1.42",
+                "scheb/two-factor-bundle": "<3.26|>=4,<4.11",
+                "sensiolabs/connect": "<4.2.3",
+                "serluck/phpwhois": "<=4.2.6",
+                "setasign/fpdi": "<2.6.4",
+                "sfroemken/url_redirect": "<=1.2.1",
+                "sheng/yiicms": "<1.2.1",
+                "shopware/core": "<6.6.10.15-dev|>=6.7,<6.7.8.1-dev",
+                "shopware/platform": "<6.6.10.15-dev|>=6.7,<6.7.8.1-dev",
+                "shopware/production": "<=6.3.5.2",
+                "shopware/shopware": "<=5.7.17|>=6.4.6,<6.6.10.10-dev|>=6.7,<6.7.6.1-dev",
+                "shopware/storefront": "<6.6.10.10-dev|>=6.7,<6.7.5.1-dev",
+                "shopxo/shopxo": "<=6.4",
+                "showdoc/showdoc": "<2.10.4",
+                "shuchkin/simplexlsx": ">=1.0.12,<1.1.13",
+                "silverstripe-australia/advancedreports": ">=1,<=2",
+                "silverstripe/admin": "<1.13.19|>=2,<2.1.8",
+                "silverstripe/assets": "<2.4.5|>=3,<3.1.3",
+                "silverstripe/cms": "<4.11.3",
+                "silverstripe/comments": ">=1.3,<3.1.1",
+                "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
+                "silverstripe/framework": "<5.3.23",
+                "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.8.2|>=4,<4.3.7|>=5,<5.1.3",
+                "silverstripe/hybridsessions": ">=1,<2.4.1|>=2.5,<2.5.1",
+                "silverstripe/recipe-cms": ">=4.5,<4.5.3",
+                "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
+                "silverstripe/reports": "<5.2.3",
+                "silverstripe/restfulserver": ">=1,<1.0.9|>=2,<2.0.4|>=2.1,<2.1.2",
+                "silverstripe/silverstripe-omnipay": "<2.5.2|>=3,<3.0.2|>=3.1,<3.1.4|>=3.2,<3.2.1",
+                "silverstripe/subsites": ">=2,<2.6.1",
+                "silverstripe/taxonomy": ">=1.3,<1.3.1|>=2,<2.0.1",
+                "silverstripe/userforms": "<3|>=5,<5.4.2",
+                "silverstripe/versioned-admin": ">=1,<1.11.1",
+                "simogeo/filemanager": "<=2.5",
+                "simple-updates/phpwhois": "<=1",
+                "simplesamlphp/saml2": "<=4.16.15|>=5.0.0.0-alpha1,<=5.0.0.0-alpha19",
+                "simplesamlphp/saml2-legacy": "<=4.16.15",
+                "simplesamlphp/simplesamlphp": "<1.18.6",
+                "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
+                "simplesamlphp/simplesamlphp-module-openid": "<1",
+                "simplesamlphp/simplesamlphp-module-openidprovider": "<0.9",
+                "simplesamlphp/xml-common": "<1.20",
+                "simplesamlphp/xml-security": "<1.13.9|>=2,<2.3.1",
+                "simplito/elliptic-php": "<1.0.6",
+                "sitegeist/fluid-components": "<3.5",
+                "sjbr/sr-feuser-register": "<2.6.2|>=5.1,<12.5",
+                "sjbr/sr-freecap": "<2.4.6|>=2.5,<2.5.3",
+                "sjbr/static-info-tables": "<2.3.1",
+                "slim/psr7": "<1.4.1|>=1.5,<1.5.1|>=1.6,<1.6.1",
+                "slim/slim": "<2.6",
+                "slub/slub-events": "<3.0.3",
+                "smarty/smarty": "<4.5.3|>=5,<5.1.1",
+                "snipe/snipe-it": "<8.3.7",
+                "socalnick/scn-social-auth": "<1.15.2",
+                "socialiteproviders/steam": "<1.1",
+                "solspace/craft-freeform": "<4.1.29|>=5,<=5.14.6",
+                "soosyze/soosyze": "<=2",
+                "spatie/browsershot": "<5.0.5",
+                "spatie/image-optimizer": "<1.7.3",
+                "spencer14420/sp-php-email-handler": "<1",
+                "spipu/html2pdf": "<5.2.8",
+                "spiral/roadrunner": "<2025.1",
+                "spoon/library": "<1.4.1",
+                "spoonity/tcpdf": "<6.2.22",
+                "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
+                "ssddanbrown/bookstack": "<24.05.1",
+                "starcitizentools/citizen-skin": ">=1.9.4,<3.9",
+                "starcitizentools/short-description": ">=4,<4.0.1",
+                "starcitizentools/tabber-neue": ">=1.9.1,<2.7.2|>=3,<3.1.1",
+                "starcitizenwiki/embedvideo": "<=4",
+                "statamic/cms": "<5.73.20|>=6,<6.13",
+                "stormpath/sdk": "<9.9.99",
+                "studio-42/elfinder": "<2.1.67",
+                "studiomitte/friendlycaptcha": "<0.1.4",
+                "subhh/libconnect": "<7.0.8|>=8,<8.1",
+                "sukohi/surpass": "<1",
+                "sulu/form-bundle": ">=2,<2.5.3",
+                "sulu/sulu": "<2.6.22|>=3,<3.0.5",
+                "sumocoders/framework-user-bundle": "<1.4",
+                "superbig/craft-audit": "<3.0.2",
+                "svewap/a21glossary": "<=0.4.10",
+                "swag/paypal": "<5.4.4",
+                "swiftmailer/swiftmailer": "<6.2.5",
+                "swiftyedit/swiftyedit": "<1.2",
+                "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
+                "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
+                "sylius/grid-bundle": "<1.10.1",
+                "sylius/paypal-plugin": "<1.6.2|>=1.7,<1.7.2|>=2,<2.0.2",
+                "sylius/resource-bundle": ">=1,<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
+                "sylius/sylius": "<1.9.12|>=1.10,<1.10.16|>=1.11,<1.11.17|>=1.12,<=1.12.22|>=1.13,<=1.13.14|>=1.14,<=1.14.17|>=2,<=2.0.15|>=2.1,<=2.1.11|>=2.2,<=2.2.2",
+                "symbiote/silverstripe-multivaluefield": ">=3,<3.1",
+                "symbiote/silverstripe-queuedjobs": ">=3,<3.0.2|>=3.1,<3.1.4|>=4,<4.0.7|>=4.1,<4.1.2|>=4.2,<4.2.4|>=4.3,<4.3.3|>=4.4,<4.4.3|>=4.5,<4.5.1|>=4.6,<4.6.4",
+                "symbiote/silverstripe-seed": "<6.0.3",
+                "symbiote/silverstripe-versionedfiles": "<=2.0.3",
+                "symfont/process": ">=0",
+                "symfony/cache": ">=3.1,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
+                "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/error-handler": ">=4.4,<4.4.4|>=5,<5.0.4",
+                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
+                "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7|>=5.3.14,<5.3.15|>=5.4.3,<5.4.4|>=6.0.3,<6.0.4",
+                "symfony/http-client": ">=4.3,<5.4.47|>=6,<6.4.15|>=7,<7.1.8",
+                "symfony/http-foundation": "<5.4.50|>=6,<6.4.29|>=7,<7.3.7",
+                "symfony/http-kernel": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6",
+                "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+                "symfony/maker-bundle": ">=1.27,<1.29.2|>=1.30,<1.31.1",
+                "symfony/mime": ">=4.3,<4.3.8",
+                "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/polyfill": ">=1,<1.10",
+                "symfony/polyfill-php55": ">=1,<1.10",
+                "symfony/process": "<5.4.51|>=6,<6.4.33|>=7,<7.1.7|>=7.3,<7.3.11|>=7.4,<7.4.5|>=8,<8.0.5",
+                "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/routing": ">=2,<2.0.19",
+                "symfony/runtime": ">=5.3,<5.4.46|>=6,<6.4.14|>=7,<7.1.7",
+                "symfony/security": ">=2,<2.7.51|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.8",
+                "symfony/security-bundle": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.4.10|>=7,<7.0.10|>=7.1,<7.1.3",
+                "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.9",
+                "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+                "symfony/security-guard": ">=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8",
+                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7|>=5.1,<5.2.8|>=5.3,<5.4.47|>=6,<6.4.15|>=7,<7.1.8",
+                "symfony/serializer": ">=2,<2.0.11|>=4.1,<4.4.35|>=5,<5.3.12",
+                "symfony/symfony": "<5.4.51|>=6,<6.4.33|>=7,<7.3.11|>=7.4,<7.4.5|>=8,<8.0.5",
+                "symfony/translation": ">=2,<2.0.17",
+                "symfony/twig-bridge": ">=2,<4.4.51|>=5,<5.4.31|>=6,<6.3.8",
+                "symfony/ux-autocomplete": "<2.11.2",
+                "symfony/ux-live-component": "<2.25.1",
+                "symfony/ux-twig-component": "<2.25.1",
+                "symfony/validator": "<5.4.43|>=6,<6.4.11|>=7,<7.1.4",
+                "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
+                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
+                "symfony/webhook": ">=6.3,<6.3.8",
+                "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7|>=2.2.0.0-beta1,<2.2.0.0-beta2",
+                "symphonycms/symphony-2": "<2.6.4",
+                "t3/dce": "<0.11.5|>=2.2,<2.6.2",
+                "t3g/svg-sanitizer": "<1.0.3",
+                "t3s/content-consent": "<1.0.3|>=2,<2.0.2",
+                "tastyigniter/tastyigniter": "<4",
+                "tcg/voyager": "<=1.8",
+                "tecnickcom/tc-lib-pdf-font": "<2.6.4",
+                "tecnickcom/tcpdf": "<6.8",
+                "terminal42/contao-tablelookupwizard": "<3.3.5",
+                "thelia/backoffice-default-template": ">=2.1,<2.1.2",
+                "thelia/thelia": ">=2.1,<2.1.3",
+                "theonedemon/phpwhois": "<=4.2.5",
+                "thinkcmf/thinkcmf": "<6.0.8",
+                "thorsten/phpmyfaq": "<4.1.1",
+                "tikiwiki/tiki-manager": "<=17.1",
+                "timber/timber": ">=0.16.6,<1.23.1|>=1.24,<1.24.1|>=2,<2.1",
+                "tinymce/tinymce": "<7.2",
+                "tinymighty/wiki-seo": "<1.2.2",
+                "titon/framework": "<9.9.99",
+                "tltneon/lgsl": "<7",
+                "tobiasbg/tablepress": "<=2.0.0.0-RC1",
+                "topthink/framework": "<6.0.17|>=6.1,<=8.0.4",
+                "topthink/think": "<=6.1.1",
+                "topthink/thinkphp": "<=3.2.3|>=6.1.3,<=8.0.4",
+                "torrentpier/torrentpier": "<=2.8.8",
+                "tpwd/ke_search": "<4.0.3|>=4.1,<4.6.6|>=5,<5.0.2",
+                "tribalsystems/zenario": "<=9.7.61188",
+                "truckersmp/phpwhois": "<=4.3.1",
+                "ttskch/pagination-service-provider": "<1",
+                "twbs/bootstrap": "<3.4.1|>=4,<4.3.1",
+                "twig/twig": "<3.11.2|>=3.12,<3.14.1|>=3.16,<3.19",
+                "typicms/core": "<16.1.7",
+                "typo3/cms": "<9.5.29|>=10,<10.4.35|>=11,<11.5.23|>=12,<12.2",
+                "typo3/cms-backend": "<4.1.14|>=4.2,<4.2.15|>=4.3,<4.3.7|>=4.4,<4.4.4|>=7,<=7.6.50|>=8,<=8.7.39|>=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
+                "typo3/cms-belog": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
+                "typo3/cms-beuser": ">=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
+                "typo3/cms-core": "<=8.7.56|>=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
+                "typo3/cms-dashboard": ">=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
+                "typo3/cms-extbase": "<6.2.24|>=7,<7.6.8|==8.1.1",
+                "typo3/cms-extensionmanager": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
+                "typo3/cms-felogin": ">=4.2,<4.2.3",
+                "typo3/cms-fluid": "<4.3.4|>=4.4,<4.4.1",
+                "typo3/cms-form": ">=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
+                "typo3/cms-frontend": "<4.3.9|>=4.4,<4.4.5",
+                "typo3/cms-indexed-search": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
+                "typo3/cms-install": "<4.1.14|>=4.2,<4.2.16|>=4.3,<4.3.9|>=4.4,<4.4.5|>=12.2,<12.4.8|==13.4.2",
+                "typo3/cms-lowlevel": ">=11,<=11.5.41",
+                "typo3/cms-recordlist": ">=11,<11.5.48",
+                "typo3/cms-recycler": ">=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
+                "typo3/cms-redirects": ">=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
+                "typo3/cms-rte-ckeditor": ">=9.5,<9.5.42|>=10,<10.4.39|>=11,<11.5.30",
+                "typo3/cms-scheduler": ">=11,<=11.5.41",
+                "typo3/cms-setup": ">=9,<=9.5.50|>=10,<=10.4.49|>=11,<=11.5.43|>=12,<=12.4.30|>=13,<=13.4.11",
+                "typo3/cms-webhooks": ">=12,<=12.4.30|>=13,<=13.4.11",
+                "typo3/cms-workspaces": ">=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
+                "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
+                "typo3/html-sanitizer": ">=1,<=1.5.2|>=2,<=2.1.3",
+                "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.3.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
+                "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
+                "typo3/swiftmailer": ">=4.1,<4.1.99|>=5.4,<5.4.5",
+                "typo3fluid/fluid": ">=2,<2.0.8|>=2.1,<2.1.7|>=2.2,<2.2.4|>=2.3,<2.3.7|>=2.4,<2.4.4|>=2.5,<2.5.11|>=2.6,<2.6.10",
+                "ua-parser/uap-php": "<3.8",
+                "uasoft-indonesia/badaso": "<=2.9.7",
+                "unisharp/laravel-filemanager": "<2.9.1",
+                "universal-omega/dynamic-page-list3": "<3.6.4",
+                "unopim/unopim": "<=0.3",
+                "userfrosting/userfrosting": ">=0.3.1,<4.6.3",
+                "usmanhalalit/pixie": "<1.0.3|>=2,<2.0.2",
+                "uvdesk/community-skeleton": "<=1.1.1",
+                "uvdesk/core-framework": "<=1.1.1",
+                "vanilla/safecurl": "<0.9.2",
+                "verbb/comments": "<1.5.5",
+                "verbb/formie": "<=2.1.43",
+                "verbb/image-resizer": "<2.0.9",
+                "verbb/knock-knock": "<1.2.8",
+                "verot/class.upload.php": "<=2.1.6",
+                "vertexvaar/falsftp": "<0.2.6",
+                "villagedefrance/opencart-overclocked": "<=1.11.1",
+                "vova07/yii2-fileapi-widget": "<0.1.9",
+                "vrana/adminer": "<5.4.2",
+                "vufind/vufind": ">=2,<9.1.1",
+                "waldhacker/hcaptcha": "<2.1.2",
+                "wallabag/tcpdf": "<6.2.22",
+                "wallabag/wallabag": "<2.6.11",
+                "wanglelecc/laracms": "<=1.0.3",
+                "wapplersystems/a21glossary": "<=0.4.10",
+                "web-auth/webauthn-framework": ">=3.3,<3.3.4|>=4.5,<4.9|>=5.2,<5.2.4",
+                "web-auth/webauthn-lib": ">=4.5,<4.9|>=5.2,<5.2.4",
+                "web-auth/webauthn-symfony-bundle": ">=5.2,<5.2.4",
+                "web-feet/coastercms": "==5.5",
+                "web-tp3/wec_map": "<3.0.3",
+                "webbuilders-group/silverstripe-kapost-bridge": "<0.4",
+                "webcoast/deferred-image-processing": "<1.0.2",
+                "webklex/laravel-imap": "<5.3",
+                "webklex/php-imap": "<5.3",
+                "webonyx/graphql-php": "<=15.31.4",
+                "webpa/webpa": "<3.1.2",
+                "webreinvent/vaahcms": "<=2.3.1",
+                "wikibase/wikibase": "<=1.39.3",
+                "wikimedia/parsoid": "<0.12.2",
+                "willdurand/js-translation-bundle": "<2.1.1",
+                "winter/wn-backend-module": "<1.2.12",
+                "winter/wn-cms-module": "<=1.2.9",
+                "winter/wn-dusk-plugin": "<2.1",
+                "winter/wn-system-module": "<1.2.4",
+                "wintercms/winter": "<=1.2.3",
+                "wireui/wireui": "<1.19.3|>=2,<2.1.3",
+                "woocommerce/woocommerce": "<6.6|>=8.8,<8.8.5|>=8.9,<8.9.3",
+                "wp-cli/wp-cli": ">=0.12,<2.5",
+                "wp-graphql/wp-graphql": "<=1.14.5",
+                "wp-premium/gravityforms": "<2.4.21",
+                "wpanel/wpanel4-cms": "<=4.3.1",
+                "wpcloud/wp-stateless": "<3.2",
+                "wpglobus/wpglobus": "<=1.9.6",
+                "wpmetabox/meta-box": "<5.11.2",
+                "wwbn/avideo": "<=29",
+                "xataface/xataface": "<3",
+                "xpressengine/xpressengine": "<3.0.15",
+                "yab/quarx": "<2.4.5",
+                "yansongda/pay": "<=3.7.19",
+                "yeswiki/yeswiki": "<=4.6",
+                "yetiforce/yetiforce-crm": "<6.5",
+                "yidashi/yii2cmf": "<=2",
+                "yii2mod/yii2-cms": "<1.9.2",
+                "yiisoft/yii": "<1.1.31",
+                "yiisoft/yii2": "<2.0.52",
+                "yiisoft/yii2-authclient": "<2.2.15",
+                "yiisoft/yii2-bootstrap": "<2.0.4",
+                "yiisoft/yii2-dev": "<=2.0.45",
+                "yiisoft/yii2-elasticsearch": "<2.0.5",
+                "yiisoft/yii2-gii": "<=2.2.4",
+                "yiisoft/yii2-jui": "<2.0.4",
+                "yiisoft/yii2-redis": "<2.0.20",
+                "yikesinc/yikes-inc-easy-mailchimp-extender": "<6.8.6",
+                "yoast-seo-for-typo3/yoast_seo": "<7.2.3",
+                "yoast/duplicate-post": "<=4.5",
+                "yourls/yourls": "<=1.10.2",
+                "yuan1994/tpadmin": "<=1.3.12",
+                "yungifez/skuul": "<=2.6.5",
+                "z-push/z-push-dev": "<2.7.6",
+                "zencart/zencart": "<=1.5.7.0-beta",
+                "zendesk/zendesk_api_client_php": "<2.2.11",
+                "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
+                "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-db": "<2.2.10|>=2.3,<2.3.5",
+                "zendframework/zend-developer-tools": ">=1.2.2,<1.2.3",
+                "zendframework/zend-diactoros": "<1.8.4",
+                "zendframework/zend-feed": "<2.10.3",
+                "zendframework/zend-form": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-http": "<2.8.1",
+                "zendframework/zend-json": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zend-ldap": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.8|>=2.3,<2.3.3",
+                "zendframework/zend-mail": "<2.4.11|>=2.5,<2.7.2",
+                "zendframework/zend-navigation": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-session": ">=2,<2.2.9|>=2.3,<2.3.4",
+                "zendframework/zend-validator": ">=2.3,<2.3.6",
+                "zendframework/zend-view": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-xmlrpc": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zendframework": "<=3",
+                "zendframework/zendframework1": "<1.12.20",
+                "zendframework/zendopenid": "<2.0.2",
+                "zendframework/zendrest": "<2.0.2",
+                "zendframework/zendservice-amazon": "<2.0.3",
+                "zendframework/zendservice-api": "<1",
+                "zendframework/zendservice-audioscrobbler": "<2.0.2",
+                "zendframework/zendservice-nirvanix": "<2.0.2",
+                "zendframework/zendservice-slideshare": "<2.0.2",
+                "zendframework/zendservice-technorati": "<2.0.2",
+                "zendframework/zendservice-windowsazure": "<2.0.2",
+                "zendframework/zendxml": ">=1,<1.0.1",
+                "zenstruck/collection": "<0.2.1",
+                "zetacomponents/mail": "<1.8.2",
+                "zf-commons/zfc-user": "<1.2.2",
+                "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
+                "zfr/zfr-oauth2-server-module": "<0.1.2",
+                "zoujingli/thinkadmin": "<=6.1.53",
+                "zumba/json-serializer": "<3.2.3"
+            },
+            "type": "metapackage",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "role": "maintainer"
+                },
+                {
+                    "name": "Ilya Tribusean",
+                    "email": "slash3b@gmail.com",
+                    "role": "maintainer"
+                }
+            ],
+            "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
+            "keywords": [
+                "dev"
+            ],
+            "support": {
+                "issues": "https://github.com/Roave/SecurityAdvisories/issues",
+                "source": "https://github.com/Roave/SecurityAdvisories/tree/latest"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/roave/security-advisories",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-21T17:25:01+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:26:40+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "1dd80bf3b93692bedb21a6623c496887fad05fec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/1dd80bf3b93692bedb21a6623c496887fad05fec",
+                "reference": "1dd80bf3b93692bedb21a6623c496887fad05fec",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.1.2",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpdoc-parser": "^2.3.0",
+                "squizlabs/php_codesniffer": "^3.13.4"
+            },
+            "require-dev": {
+                "phing/phing": "3.0.1|3.1.0",
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/phpstan": "2.1.24",
+                "phpstan/phpstan-deprecation-rules": "2.0.3",
+                "phpstan/phpstan-phpunit": "2.0.7",
+                "phpstan/phpstan-strict-rules": "2.0.6",
+                "phpunit/phpunit": "9.6.8|10.5.48|11.4.4|11.5.36|12.3.10"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.22.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-13T08:53:30+00:00"
+        },
+        {
+            "name": "spatie/array-to-xml",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/array-to-xml.git",
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/88b2f3852a922dd73177a68938f8eb2ec70c7224",
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2",
+                "pestphp/pest": "^1.21",
+                "spatie/pest-plugin-snapshots": "^1.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ArrayToXml\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://freek.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Convert an array to xml",
+            "homepage": "https://github.com/spatie/array-to-xml",
+            "keywords": [
+                "array",
+                "convert",
+                "xml"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/array-to-xml/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-15T09:00:41+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^7.2|^8.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T13:54:39+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "f57b899fa736fd71121168ef268f23c206083f0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f57b899fa736fd71121168ef268f23c206083f0a",
+                "reference": "f57b899fa736fd71121168ef268f23c206083f0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T13:54:39+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
+                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "58b9790d12f9670b7f53a1c1738febd3108970a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/58b9790d12f9670b7f53a1c1738febd3108970a5",
+                "reference": "58b9790d12f9670b7f53a1c1738febd3108970a5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php84",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T18:47:49+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v6.4.33",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c46e854e79b52d07666e43924a20cb6dc546644e",
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v6.4.33"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-23T16:02:12+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T11:30:57+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "114ac57257d75df748eda23dd003878080b8e688"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/114ac57257d75df748eda23dd003878080b8e688",
+                "reference": "114ac57257d75df748eda23dd003878080b8e688",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.33",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "vimeo/psalm",
+            "version": "6.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/parallel": "^2.3",
+                "composer-runtime-api": "^2",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^2.0 || ^3.0",
+                "danog/advanced-json-rpc": "^3.1",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/language-server-protocol": "^1.5.3",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
+                "netresearch/jsonmapper": "^5.0",
+                "nikic/php-parser": "^5.0.0",
+                "php": "~8.1.31 || ~8.2.27 || ~8.3.16 || ~8.4.3 || ~8.5.0",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
+                "symfony/console": "^6.0 || ^7.0 || ^8.0",
+                "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3 || ^8.0",
+                "symfony/polyfill-php84": "^1.31.0"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "amphp/phpunit-util": "^3",
+                "bamarni/composer-bin-plugin": "^1.4",
+                "brianium/paratest": "^6.9",
+                "danog/class-finder": "^0.4.8",
+                "dg/bypass-finals": "^1.5",
+                "ext-curl": "*",
+                "mockery/mockery": "^1.5",
+                "nunomaduro/mock-final-classes": "^1.1",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpdoc-parser": "^1.6",
+                "phpunit/phpunit": "^9.6",
+                "psalm/plugin-mockery": "^1.1",
+                "psalm/plugin-phpunit": "^0.19",
+                "slevomat/coding-standard": "^8.4",
+                "squizlabs/php_codesniffer": "^3.6",
+                "symfony/process": "^6.0 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "ext-curl": "In order to send data to shepherd",
+                "ext-igbinary": "^2.0.5 is required, used to serialize caching data"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalm-review",
+                "psalter"
+            ],
+            "type": "project",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-4.x": "4.x-dev",
+                    "dev-5.x": "5.x-dev",
+                    "dev-6.x": "6.x-dev",
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                },
+                {
+                    "name": "Daniil Gentili",
+                    "email": "daniil@daniil.it"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://psalm.dev/docs",
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm"
+            },
+            "time": "2026-03-19T10:56:09+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "6f6a1a90bd9e18fc8bee0660dd1d1ce68cf9fc53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/6f6a1a90bd9e18fc8bee0660dd1d1ce68cf9fc53",
+                "reference": "6f6a1a90bd9e18fc8bee0660dd1d1ce68cf9fc53",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.10.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6.15"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-16T06:55:17+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "roave/security-advisories": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+    },
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.4.12",
+        "ext-intl": "1",
+        "ext-redis": "1"
+    },
+    "plugin-api-version": "2.6.0"
+}

--- a/service-front/mezzio/config/.gitignore
+++ b/service-front/mezzio/config/.gitignore
@@ -1,0 +1,1 @@
+development.config.php

--- a/service-front/mezzio/config/autoload/.gitignore
+++ b/service-front/mezzio/config/autoload/.gitignore
@@ -1,0 +1,2 @@
+local.php
+*.local.php

--- a/service-front/mezzio/config/autoload/application.global.php
+++ b/service-front/mezzio/config/autoload/application.global.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Application-level configuration for the Mezzio app.
+ *
+ * Migrated from module/Application/config/module.config.php.
+ * MVC-specific keys (view_manager, view_helpers) are intentionally omitted —
+ * Twig handles rendering in this app and those keys have no effect in Mezzio.
+ */
+
+declare(strict_types=1);
+
+return [
+    // Email template paths used by the mail transport service.
+    // Migrated from module.config.php email_view_manager.
+    'email_view_manager' => [
+        'template_path_stack' => [
+            'emails' => __DIR__ . '/../../../../module/Application/view/email',
+        ],
+    ],
+];

--- a/service-front/mezzio/config/autoload/dependencies.global.php
+++ b/service-front/mezzio/config/autoload/dependencies.global.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // Provides application-wide services.
+    // We recommend using fully-qualified class names whenever possible as
+    // service names.
+    'dependencies' => [
+        // Use 'aliases' to alias a service name to another service. The
+        // key is the alias name, the value is the service to which it points.
+        'aliases' => [
+            // Fully\Qualified\ClassOrInterfaceName::class => Fully\Qualified\ClassName::class,
+        ],
+        // Use 'invokables' for constructor-less services, or services that do
+        // not require arguments to the constructor. Map a service name to the
+        // class name.
+        'invokables' => [
+            // Fully\Qualified\InterfaceName::class => Fully\Qualified\ClassName::class,
+        ],
+        // Use 'factories' for services provided by callbacks/factory classes.
+        'factories' => [
+            // Fully\Qualified\ClassName::class => Fully\Qualified\FactoryName::class,
+        ],
+    ],
+];

--- a/service-front/mezzio/config/autoload/development.local.php.dist
+++ b/service-front/mezzio/config/autoload/development.local.php.dist
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:disable PSR12.Files.FileHeader.IncorrectOrder
+
+/**
+ * Development-only configuration.
+ *
+ * Put settings you want enabled when under development mode in this file, and
+ * check it into your repository.
+ *
+ * Developers on your team will then automatically enable them by calling on
+ * `composer development-enable`.
+ */
+
+use Mezzio\Container;
+use Mezzio\Middleware\ErrorResponseGenerator;
+
+return [
+    'dependencies' => [
+        'factories' => [
+            ErrorResponseGenerator::class => Container\WhoopsErrorResponseGeneratorFactory::class,
+            'Mezzio\Whoops'               => Container\WhoopsFactory::class,
+            'Mezzio\WhoopsPageHandler'    => Container\WhoopsPageHandlerFactory::class,
+        ],
+    ],
+    'whoops'       => [
+        'json_exceptions' => [
+            'display'    => true,
+            'show_trace' => true,
+            'ajax_only'  => true,
+        ],
+    ],
+];

--- a/service-front/mezzio/config/autoload/local.php.dist
+++ b/service-front/mezzio/config/autoload/local.php.dist
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Local configuration.
+ *
+ * Copy this file to `local.php` and change its settings as required.
+ * `local.php` is ignored by git and safe to use for local and sensitive data like usernames and passwords.
+ */
+
+declare(strict_types=1);
+
+return [
+];

--- a/service-front/mezzio/config/autoload/mezzio.global.php
+++ b/service-front/mezzio/config/autoload/mezzio.global.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Laminas\ConfigAggregator\ConfigAggregator;
+
+return [
+    // Toggle the configuration cache. Set this to boolean false, or remove the
+    // directive, to disable configuration caching. Toggling development mode
+    // will also disable it by default; clear the configuration cache using
+    // `composer clear-config-cache`.
+    ConfigAggregator::ENABLE_CACHE => true,
+
+    // Enable debugging; typically used to provide debugging information within templates.
+    'debug'  => false,
+    'mezzio' => [
+        // Provide templates for the error handling middleware to use when
+        // generating responses.
+        'error_handler' => [
+            'template_404'   => 'error::404',
+            'template_error' => 'error::error',
+        ],
+    ],
+];

--- a/service-front/mezzio/config/config.php
+++ b/service-front/mezzio/config/config.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Laminas\ConfigAggregator\ArrayProvider;
+use Laminas\ConfigAggregator\ConfigAggregator;
+use Laminas\ConfigAggregator\PhpFileProvider;
+
+// To enable or disable caching, set the `ConfigAggregator::ENABLE_CACHE` boolean in
+// `config/autoload/local.php`.
+$cacheConfig = [
+    'config_cache_path' => 'data/cache/config-cache.php',
+];
+
+$aggregator = new ConfigAggregator([
+    \Mezzio\Twig\ConfigProvider::class,
+    \Mezzio\Tooling\ConfigProvider::class,
+    \Mezzio\Router\FastRouteRouter\ConfigProvider::class,
+    \Laminas\HttpHandlerRunner\ConfigProvider::class,
+    // Include cache configuration
+    new ArrayProvider($cacheConfig),
+    \Mezzio\Helper\ConfigProvider::class,
+    \Mezzio\ConfigProvider::class,
+    \Mezzio\Router\ConfigProvider::class,
+    \Laminas\Diactoros\ConfigProvider::class,
+
+    // Swoole config to overwrite some services (if installed)
+    class_exists(\Mezzio\Swoole\ConfigProvider::class)
+        ? \Mezzio\Swoole\ConfigProvider::class
+        : function (): array {
+            return [];
+        },
+
+    // Default App module config
+    \Laminas\Form\ConfigProvider::class,
+    Application\ConfigProvider::class,
+    App\ConfigProvider::class,
+
+    // Load application config in a pre-defined order in such a way that local settings
+    // overwrite global settings. (Loaded as first to last):
+    //   - `global.php`
+    //   - `*.global.php`
+    //   - `local.php`
+    //   - `*.local.php`
+    new PhpFileProvider(realpath(__DIR__) . '/autoload/{{,*.}global,{,*.}local}.php'),
+
+    // Load development config if it exists
+    new PhpFileProvider(realpath(__DIR__) . '/development.config.php'),
+], $cacheConfig['config_cache_path']);
+
+return $aggregator->getMergedConfig();

--- a/service-front/mezzio/config/container.php
+++ b/service-front/mezzio/config/container.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Laminas\ServiceManager\ServiceManager;
+
+// Load configuration
+$config = require __DIR__ . '/config.php';
+
+$dependencies                       = $config['dependencies'];
+$dependencies['services']['config'] = $config;
+
+// Build container
+return new ServiceManager($dependencies);

--- a/service-front/mezzio/config/development.config.php.dist
+++ b/service-front/mezzio/config/development.config.php.dist
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * File required to allow enablement of development mode.
+ *
+ * For use with the laminas-development-mode tool.
+ *
+ * Usage:
+ *  $ composer development-disable
+ *  $ composer development-enable
+ *  $ composer development-status
+ *
+ * DO NOT MODIFY THIS FILE.
+ *
+ * Provide your own development-mode settings by editing the file
+ * `config/autoload/development.local.php.dist`.
+ *
+ * Because this file is aggregated last, it simply ensures:
+ *
+ * - The `debug` flag is _enabled_.
+ * - Configuration caching is _disabled_.
+ */
+
+declare(strict_types=1);
+
+use Laminas\ConfigAggregator\ConfigAggregator;
+
+return [
+    'debug'                        => true,
+    ConfigAggregator::ENABLE_CACHE => false,
+];

--- a/service-front/mezzio/config/pipeline.php
+++ b/service-front/mezzio/config/pipeline.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Global middleware pipeline.
+ *
+ * Order is significant. Each entry maps to a concern that was previously
+ * handled inside Module::onBootstrap() in the Laminas MVC app.
+ *
+ * AuthenticationMiddleware, UserDetailsMiddleware, TermsAndConditionsMiddleware,
+ * and LpaLoaderMiddleware are NOT piped globally here — they are applied
+ * per-route in routes.php via $factory->pipeline(...).
+ */
+
+declare(strict_types=1);
+
+use Application\Middleware\RequestLoggingMiddleware;
+use Application\Middleware\SessionBootstrapMiddleware;
+use Application\Middleware\TrailingSlashMiddleware;
+use Laminas\Stratigility\Middleware\ErrorHandler;
+use Mezzio\Application;
+use Mezzio\Handler\NotFoundHandler;
+use Mezzio\Helper\ServerUrlMiddleware;
+use Mezzio\Helper\UrlHelperMiddleware;
+use Mezzio\MiddlewareFactory;
+use Mezzio\Router\Middleware\DispatchMiddleware;
+use Mezzio\Router\Middleware\ImplicitHeadMiddleware;
+use Mezzio\Router\Middleware\ImplicitOptionsMiddleware;
+use Mezzio\Router\Middleware\MethodNotAllowedMiddleware;
+use Mezzio\Router\Middleware\RouteMiddleware;
+use Psr\Container\ContainerInterface;
+
+return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container): void {
+    // -------------------------------------------------------------------------
+    // 1. Error handling — outermost layer, catches everything.
+    //    Replaces Module::handleError() (MVC dispatch/render error events).
+    // -------------------------------------------------------------------------
+    $app->pipe(ErrorHandler::class);
+
+    // -------------------------------------------------------------------------
+    // 2. Trailing-slash redirect — must run before routing so FastRoute never
+    //    sees the slash. Replaces TrailingSlashRedirectListener.
+    // -------------------------------------------------------------------------
+    $app->pipe(TrailingSlashMiddleware::class);
+
+    // -------------------------------------------------------------------------
+    // 3. Request logging — pushes path, method, and trace-ID onto the Monolog
+    //    processor stack for all subsequent log calls in this request.
+    //    Replaces the logger->pushProcessor() block in Module::onBootstrap().
+    // -------------------------------------------------------------------------
+    $app->pipe(RequestLoggingMiddleware::class);
+
+    // -------------------------------------------------------------------------
+    // 4. Session bootstrap — configures the Redis save handler, starts the
+    //    laminas-session SessionManager, and regenerates the session ID on first
+    //    visit. Skipped for /ping/elb and /ping/json.
+    //    Replaces Module::bootstrapSession().
+    // -------------------------------------------------------------------------
+    $app->pipe(SessionBootstrapMiddleware::class);
+
+    // -------------------------------------------------------------------------
+    // 5. Identity token refresh — checks the authenticated user's API token on
+    //    every request and updates or clears the session identity accordingly.
+    //    Skipped for /ping/elb, /ping/json, and /session-state.
+    //    Replaces Module::bootstrapIdentity().
+    // -------------------------------------------------------------------------
+    $app->pipe(IdentityTokenRefreshMiddleware::class);
+
+    // -------------------------------------------------------------------------
+    // 6. Server URL helper — populates the ServerUrlHelper with the current
+    //    request's scheme and host so templates can build absolute URLs.
+    // -------------------------------------------------------------------------
+    $app->pipe(ServerUrlMiddleware::class);
+
+    // -------------------------------------------------------------------------
+    // 7. Routing — matches the request path to a registered route and stores
+    //    the RouteResult as a request attribute for downstream middleware.
+    // -------------------------------------------------------------------------
+    $app->pipe(RouteMiddleware::class);
+
+    // -------------------------------------------------------------------------
+    // 8. Implicit method handling and method-not-allowed responses.
+    //    Order matters: ImplicitHead and ImplicitOptions must precede
+    //    MethodNotAllowed.
+    // -------------------------------------------------------------------------
+    $app->pipe(ImplicitHeadMiddleware::class);
+    $app->pipe(ImplicitOptionsMiddleware::class);
+    $app->pipe(MethodNotAllowedMiddleware::class);
+
+    // -------------------------------------------------------------------------
+    // 9. URL helper — seeds UrlHelper with the matched route result so handlers
+    //    and middleware can call $urlHelper->generate('route-name').
+    // -------------------------------------------------------------------------
+    $app->pipe(UrlHelperMiddleware::class);
+
+    // -------------------------------------------------------------------------
+    // 10. Dispatch — invokes the matched handler (or per-route middleware
+    //     pipeline). Route-scoped middleware (Auth, UserDetails, T&C,
+    //     LpaLoader) is applied here via $factory->pipeline() in routes.php.
+    // -------------------------------------------------------------------------
+    $app->pipe(DispatchMiddleware::class);
+
+    // -------------------------------------------------------------------------
+    // 11. 404 fallback.
+    // -------------------------------------------------------------------------
+    $app->pipe(NotFoundHandler::class);
+};

--- a/service-front/mezzio/config/routes.php
+++ b/service-front/mezzio/config/routes.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * FastRoute route configuration
+ *
+ * @see https://github.com/nikic/FastRoute
+ *
+ * Setup routes with a single request method:
+ *
+ * $app->get('/', App\Handler\HomePageHandler::class, 'home');
+ * $app->post('/album', App\Handler\AlbumCreateHandler::class, 'album.create');
+ * $app->put('/album/{id:\d+}', App\Handler\AlbumUpdateHandler::class, 'album.put');
+ * $app->patch('/album/{id:\d+}', App\Handler\AlbumUpdateHandler::class, 'album.patch');
+ * $app->delete('/album/{id:\d+}', App\Handler\AlbumDeleteHandler::class, 'album.delete');
+ *
+ * Or with multiple request methods:
+ *
+ * $app->route('/contact', App\Handler\ContactHandler::class, ['GET', 'POST', ...], 'contact');
+ *
+ * Or handling all request methods:
+ *
+ * $app->route('/contact', App\Handler\ContactHandler::class)->setName('contact');
+ *
+ * or:
+ *
+ * $app->route(
+ *     '/contact',
+ *     App\Handler\ContactHandler::class,
+ *     Mezzio\Router\Route::HTTP_METHOD_ANY,
+ *     'contact'
+ * );
+ */
+
+declare(strict_types=1);
+
+use App\Handler\HomePageHandler;
+use App\Handler\PingHandler;
+use Mezzio\Application;
+use Mezzio\MiddlewareFactory;
+use Psr\Container\ContainerInterface;
+
+return static function (Application $app, MiddlewareFactory $factory, ContainerInterface $container): void {
+    $app->get('/', HomePageHandler::class, 'home');
+    $app->get('/api/ping', PingHandler::class, 'api.ping');
+};

--- a/service-front/mezzio/data/.gitignore
+++ b/service-front/mezzio/data/.gitignore
@@ -1,0 +1,4 @@
+*
+!cache
+!cache/.gitkeep
+!.gitignore

--- a/service-front/mezzio/phpcs.xml.dist
+++ b/service-front/mezzio/phpcs.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
+
+    <!-- Paths to check -->
+    <file>config</file>
+    <file>src</file>
+    <file>test</file>
+    <exclude-pattern>config/config.php</exclude-pattern>
+    <exclude-pattern>config/routes.php</exclude-pattern>
+
+    <!-- Include all rules from the Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
+
+    <rule ref="Squiz.Classes.ClassFileName.NoMatch">
+        <exclude-pattern>src/ConfigProvider.*.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR12.Files.FileHeader.IncorrectOrder">
+        <exclude-pattern>config/pipeline.php</exclude-pattern>
+        <exclude-pattern>src/MezzioInstaller/Resources/config/routes-*.php</exclude-pattern>
+    </rule>
+</ruleset>

--- a/service-front/mezzio/phpunit.xml.dist
+++ b/service-front/mezzio/phpunit.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    cacheDirectory=".phpunit.cache"
+    displayDetailsOnAllIssues="true"
+    failOnAllIssues="true"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>./test</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreIndirectDeprecations="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/service-front/mezzio/psalm-baseline.xml
+++ b/service-front/mezzio/psalm-baseline.xml
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
+  <file src="src/MezzioInstaller/OptionalPackages.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->stabilityFlags]]></code>
+    </ArgumentTypeCoercion>
+    <MixedArgument>
+      <code><![CDATA[$answer]]></code>
+      <code><![CDATA[$constraint]]></code>
+      <code><![CDATA[$filename]]></code>
+      <code><![CDATA[$filename]]></code>
+      <code><![CDATA[$package]]></code>
+      <code><![CDATA[$target]]></code>
+      <code><![CDATA[$this->composerDefinition['autoload']]]></code>
+      <code><![CDATA[$this->composerDefinition['autoload-dev']]]></code>
+      <code><![CDATA[$word]]></code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$package]]></code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess>
+      <code><![CDATA[$this->composerDefinition['autoload']['psr-4']]]></code>
+      <code><![CDATA[$this->composerDefinition['autoload']['psr-4']['MezzioInstaller\\']]]></code>
+      <code><![CDATA[$this->composerDefinition['autoload-dev']['psr-4']]]></code>
+      <code><![CDATA[$this->composerDefinition['autoload-dev']['psr-4']['MezzioInstallerTest\\']]]></code>
+      <code><![CDATA[$this->composerDefinition['scripts']['pre-install-cmd']]]></code>
+      <code><![CDATA[$this->composerDefinition['scripts']['pre-update-cmd']]]></code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->composerDefinition['autoload']['psr-4']]]></code>
+      <code><![CDATA[$this->composerDefinition['autoload']['psr-4']['App\\']]]></code>
+      <code><![CDATA[$this->composerDefinition['require'][$packageName]]]></code>
+      <code><![CDATA[$this->composerDefinition['require-dev'][$packageName]]]></code>
+      <code><![CDATA[$this->composerDefinition['scripts']['cs-check']]]></code>
+      <code><![CDATA[$this->composerDefinition['scripts']['cs-fix']]]></code>
+    </MixedArrayAssignment>
+    <MixedAssignment>
+      <code><![CDATA[$answer]]></code>
+      <code><![CDATA[$answer]]></code>
+      <code><![CDATA[$constraint]]></code>
+      <code><![CDATA[$fileInfo]]></code>
+      <code><![CDATA[$filename]]></code>
+      <code><![CDATA[$package]]></code>
+      <code><![CDATA[$target]]></code>
+      <code><![CDATA[$this->composerDefinition]]></code>
+    </MixedAssignment>
+    <MixedMethodCall>
+      <code><![CDATA[isDir]]></code>
+    </MixedMethodCall>
+    <MixedPropertyTypeCoercion>
+      <code><![CDATA[$this->composerDefinition]]></code>
+      <code><![CDATA[$this->composerDefinition]]></code>
+      <code><![CDATA[$this->composerDefinition]]></code>
+    </MixedPropertyTypeCoercion>
+    <NoValue>
+      <code><![CDATA[$this->installType]]></code>
+    </NoValue>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$contents]]></code>
+      <code><![CDATA[$phpunitConfig]]></code>
+      <code><![CDATA[$psalmConfig]]></code>
+      <code><![CDATA[$this->projectRoot]]></code>
+      <code><![CDATA[file_get_contents($ignoreFile)]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[realpath(__DIR__)]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyFalsePropertyAssignmentValue>
+      <code><![CDATA[$projectRoot ?? realpath(dirname($composerFile))]]></code>
+    </PossiblyFalsePropertyAssignmentValue>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$resource]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidIterator>
+      <code><![CDATA[$question['options'][$answer][$this->installType]]]></code>
+    </PossiblyInvalidIterator>
+    <PossiblyNullArgument>
+      <code><![CDATA[$content]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[install]]></code>
+    </PossiblyUnusedMethod>
+    <PropertyTypeCoercion>
+      <code><![CDATA[require __DIR__ . '/config.php']]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="test/AppTest/Handler/PingHandlerTest.php">
+    <MixedArgument>
+      <code><![CDATA[$json]]></code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code><![CDATA[$json]]></code>
+    </MixedAssignment>
+    <MixedPropertyFetch>
+      <code><![CDATA[$json->ack]]></code>
+    </MixedPropertyFetch>
+  </file>
+  <file src="test/MezzioInstallerTest/AddPackageTest.php">
+    <MixedArgument>
+      <code><![CDATA[$stabilityFlags]]></code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code><![CDATA[$stabilityFlags]]></code>
+    </MixedAssignment>
+  </file>
+  <file src="test/MezzioInstallerTest/ContainersTest.php">
+    <MixedArgument>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['router']]]></code>
+    </MixedArgument>
+    <MixedArrayAccess>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['router']]]></code>
+    </MixedArrayAccess>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$configFileContents]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$configFileContents]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="test/MezzioInstallerTest/ErrorHandlerTest.php">
+    <MixedArgument>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['error-handler']]]></code>
+    </MixedArgument>
+    <MixedArrayAccess>
+      <code><![CDATA[$config['dependencies']]]></code>
+      <code><![CDATA[$config['dependencies']['factories']]]></code>
+      <code><![CDATA[$config['dependencies']['factories'][ErrorResponseGenerator::class]]]></code>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['error-handler']]]></code>
+    </MixedArrayAccess>
+    <MixedAssignment>
+      <code><![CDATA[$config]]></code>
+    </MixedAssignment>
+  </file>
+  <file src="test/MezzioInstallerTest/HomePageResponseTest.php">
+    <MixedArgument>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['router']]]></code>
+      <code><![CDATA[$config['questions']['router']]]></code>
+      <code><![CDATA[$config['questions']['template-engine']]]></code>
+    </MixedArgument>
+    <MixedArrayAccess>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['router']]]></code>
+      <code><![CDATA[$config['questions']['router']]]></code>
+      <code><![CDATA[$config['questions']['template-engine']]]></code>
+    </MixedArrayAccess>
+    <MoreSpecificReturnType>
+      <code><![CDATA[Generator<string, array{
+     *     0: OptionalPackages::INSTALL_*,
+     *     1: int,
+     *     2: int,
+     *     3: class-string<TemplateRendererInterface>,
+     *     4: string,
+     *     5: string
+     * }>]]></code>
+      <code><![CDATA[Generator<string, array{
+     *     0: OptionalPackages::INSTALL_*,
+     *     1: int,
+     *     2: string,
+     *     3: string,
+     *     4: int,
+     *     5: class-string<RouterInterface>,
+     *     6: string,
+     *     7: string
+     * }>]]></code>
+    </MoreSpecificReturnType>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$contents]]></code>
+      <code><![CDATA[$contents]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidArrayOffset>
+      <code><![CDATA[self::$expectedContainerAttributes[$containerClass]]]></code>
+      <code><![CDATA[self::$expectedContainerAttributes[$containerClass]]]></code>
+      <code><![CDATA[self::$expectedRouterAttributes[$routerClass]]]></code>
+      <code><![CDATA[self::$rendererConfigProviders[$rendererClass]]]></code>
+      <code><![CDATA[self::$routerConfigProviders[$routerClass]]]></code>
+    </PossiblyInvalidArrayOffset>
+    <PossiblyNullArgument>
+      <code><![CDATA[$contents]]></code>
+      <code><![CDATA[$contents]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="test/MezzioInstallerTest/OptionalPackagesTestCase.php">
+    <MixedArgument>
+      <code><![CDATA[$properties['devDependencies']]]></code>
+      <code><![CDATA[$r->getValue($installer)]]></code>
+      <code><![CDATA[$r->getValue($installer)]]></code>
+      <code><![CDATA[$whitelist]]></code>
+    </MixedArgument>
+    <MixedArrayAccess>
+      <code><![CDATA[$composerJson['require']]]></code>
+      <code><![CDATA[$composerJson['require-dev']]]></code>
+      <code><![CDATA[$r->getValue($installer)['extra']]]></code>
+    </MixedArrayAccess>
+    <MixedAssignment>
+      <code><![CDATA[$composerJson]]></code>
+      <code><![CDATA[$whitelist]]></code>
+    </MixedAssignment>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->getInstallerProperty($installer, 'composerDefinition')]]></code>
+      <code><![CDATA[$this->getInstallerProperty($installer, 'config')]]></code>
+    </MixedReturnStatement>
+    <PossiblyFalseArgument>
+      <code><![CDATA[file_get_contents($this->packageRoot . '/composer.json')]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$this->packageRoot]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyFalsePropertyAssignmentValue>
+      <code><![CDATA[realpath(__DIR__ . '/../../')]]></code>
+    </PossiblyFalsePropertyAssignmentValue>
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$composerData]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="test/MezzioInstallerTest/ProcessAnswersTest.php">
+    <MixedArgument>
+      <code><![CDATA[$question]]></code>
+      <code><![CDATA[$question]]></code>
+      <code><![CDATA[$question]]></code>
+      <code><![CDATA[$question]]></code>
+      <code><![CDATA[$question]]></code>
+      <code><![CDATA[$question]]></code>
+    </MixedArgument>
+    <MixedArrayAccess>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['template-engine']]]></code>
+    </MixedArrayAccess>
+    <MixedAssignment>
+      <code><![CDATA[$question]]></code>
+      <code><![CDATA[$question]]></code>
+      <code><![CDATA[$question]]></code>
+      <code><![CDATA[$question]]></code>
+      <code><![CDATA[$question]]></code>
+      <code><![CDATA[$question]]></code>
+    </MixedAssignment>
+  </file>
+  <file src="test/MezzioInstallerTest/ProjectSandboxTrait.php">
+    <MixedArgument>
+      <code><![CDATA[$node]]></code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$this->autoloader]]></code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment>
+      <code><![CDATA[$node]]></code>
+      <code><![CDATA[$this->container]]></code>
+    </MixedAssignment>
+    <PossiblyFalseIterator>
+      <code><![CDATA[scandir($target)]]></code>
+    </PossiblyFalseIterator>
+    <UnresolvableInclude>
+      <code><![CDATA[require $path]]></code>
+    </UnresolvableInclude>
+  </file>
+  <file src="test/MezzioInstallerTest/RemoveDevDependenciesTest.php">
+    <MixedAssignment>
+      <code><![CDATA[$this->devDependencies]]></code>
+    </MixedAssignment>
+  </file>
+  <file src="test/MezzioInstallerTest/RoutersTest.php">
+    <MixedArgument>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['router']]]></code>
+    </MixedArgument>
+    <MixedArrayAccess>
+      <code><![CDATA[$config['dependencies']]]></code>
+      <code><![CDATA[$config['dependencies'][$dependencyKey]]]></code>
+      <code><![CDATA[$config['dependencies'][$dependencyKey][RouterInterface::class]]]></code>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['router']]]></code>
+    </MixedArrayAccess>
+    <MixedAssignment>
+      <code><![CDATA[$config]]></code>
+    </MixedAssignment>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$contents]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$contents]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="test/MezzioInstallerTest/SetupDataAndCacheDirTest.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[fileperms($this->projectRoot . '/data')]]></code>
+      <code><![CDATA[fileperms($this->projectRoot . '/data/cache')]]></code>
+    </PossiblyFalseArgument>
+    <UnusedProperty>
+      <code><![CDATA[$project]]></code>
+    </UnusedProperty>
+  </file>
+  <file src="test/MezzioInstallerTest/TemplateRenderersTest.php">
+    <MixedArgument>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['router']]]></code>
+      <code><![CDATA[$config['questions']['template-engine']]]></code>
+    </MixedArgument>
+    <MixedArrayAccess>
+      <code><![CDATA[$config['dependencies']]]></code>
+      <code><![CDATA[$config['dependencies']['factories']]]></code>
+      <code><![CDATA[$config['dependencies']['factories'][ErrorHandler::class]]]></code>
+      <code><![CDATA[$config['questions']['container']]]></code>
+      <code><![CDATA[$config['questions']['router']]]></code>
+      <code><![CDATA[$config['questions']['template-engine']]]></code>
+    </MixedArrayAccess>
+    <MixedAssignment>
+      <code><![CDATA[$config]]></code>
+    </MixedAssignment>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$contents]]></code>
+      <code><![CDATA[$contents]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$contents]]></code>
+      <code><![CDATA[$contents]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="test/MezzioInstallerTest/UpdateRootPackageTest.php">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$property]]></code>
+    </MixedArgumentTypeCoercion>
+  </file>
+</files>

--- a/service-front/mezzio/psalm.xml.dist
+++ b/service-front/mezzio/psalm.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<psalm
+    cacheDirectory="./.psalm-cache"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorLevel="1"
+    findUnusedPsalmSuppress="true"
+    findUnusedCode="true"
+    findUnusedBaselineEntry="true"
+    errorBaseline="psalm-baseline.xml"
+>
+    <issueHandlers>
+        <MissingOverrideAttribute>
+            <errorLevel type="suppress">
+                <directory name="src" />
+                <directory name="test" />
+            </errorLevel>
+        </MissingOverrideAttribute>
+    </issueHandlers>
+
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/service-front/mezzio/public/.htaccess
+++ b/service-front/mezzio/public/.htaccess
@@ -1,0 +1,19 @@
+RewriteEngine On
+# The following rule allows authentication to work with fast-cgi
+RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+# The following rule tells Apache that if the requested filename
+# exists, simply serve it.
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -l [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [NC,L]
+
+# The following rewrites all other queries to index.php. The
+# condition ensures that if you are using Apache aliases to do
+# mass virtual hosting, the base path will be prepended to
+# allow proper resolution of the index.php file; it will work
+# in non-aliased environments as well, providing a safe, one-size
+# fits all solution.
+RewriteCond $0::%{REQUEST_URI} ^([^:]*+(?::[^:]*+)*?)::(/.+?)\1$
+RewriteRule .+ - [E=BASE:%2]
+RewriteRule .* %{ENV:BASE}index.php [NC,L]

--- a/service-front/mezzio/public/index.php
+++ b/service-front/mezzio/public/index.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+// Delegate static file requests back to the PHP built-in webserver
+if (PHP_SAPI === 'cli-server' && $_SERVER['SCRIPT_FILENAME'] !== __FILE__) {
+    return false;
+}
+
+chdir(dirname(__DIR__));
+require 'vendor/autoload.php';
+
+// Replaces the register_shutdown_function in Module::onBootstrap().
+// The ErrorHandler middleware handles exceptions, but fatal PHP errors
+// (E_ERROR) bypass it entirely — this is the last line of defence.
+register_shutdown_function(static function (): void {
+    $error = error_get_last();
+    if (($error['type'] ?? null) === E_ERROR) {
+        // The fatal error will have been written to the error log already.
+        echo 'An unknown server error has occurred.';
+    }
+});
+
+/**
+ * Self-called anonymous function that creates its own scope and keeps the global namespace clean.
+ */
+(function () {
+    /** @var \Psr\Container\ContainerInterface $container */
+    $container = require 'config/container.php';
+
+    /** @var \Mezzio\Application $app */
+    $app = $container->get(\Mezzio\Application::class);
+    $factory = $container->get(\Mezzio\MiddlewareFactory::class);
+
+    // Execute programmatic/declarative middleware pipeline and routing
+    // configuration statements
+    (require 'config/pipeline.php')($app, $factory, $container);
+    (require 'config/routes.php')($app, $factory, $container);
+
+    $app->run();
+})();

--- a/service-front/mezzio/src/App/src/ConfigProvider.php
+++ b/service-front/mezzio/src/App/src/ConfigProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+/**
+ * The configuration provider for the App module
+ *
+ * @see https://docs.laminas.dev/laminas-component-installer/
+ */
+class ConfigProvider
+{
+    /**
+     * Returns the configuration array
+     *
+     * To add a bit of a structure, each section is defined in a separate
+     * method which returns an array with its configuration.
+     */
+    public function __invoke(): array
+    {
+        return [
+            'dependencies' => $this->getDependencies(),
+            'templates'    => $this->getTemplates(),
+        ];
+    }
+
+    /**
+     * Returns the container dependencies
+     */
+    public function getDependencies(): array
+    {
+        return [
+            'invokables' => [
+                Handler\PingHandler::class => Handler\PingHandler::class,
+            ],
+            'factories'  => [
+                Handler\HomePageHandler::class => Handler\HomePageHandlerFactory::class,
+            ],
+        ];
+    }
+
+    /**
+     * Returns the templates configuration
+     */
+    public function getTemplates(): array
+    {
+        return [
+            'paths' => [
+                'app'    => [__DIR__ . '/../templates/app'],
+                'error'  => [__DIR__ . '/../templates/error'],
+                'layout' => [__DIR__ . '/../templates/layout'],
+            ],
+        ];
+    }
+}

--- a/service-front/mezzio/src/App/src/Handler/HomePageHandler.php
+++ b/service-front/mezzio/src/App/src/Handler/HomePageHandler.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Handler;
+
+use Chubbyphp\Container\MinimalContainer;
+use DI\Container as PHPDIContainer;
+use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Diactoros\Response\JsonResponse;
+use Laminas\ServiceManager\ServiceManager;
+use Mezzio\LaminasView\LaminasViewRenderer;
+use Mezzio\Plates\PlatesRenderer;
+use Mezzio\Router\FastRouteRouter;
+use Mezzio\Router\LaminasRouter;
+use Mezzio\Router\RouterInterface;
+use Mezzio\Template\TemplateRendererInterface;
+use Mezzio\Twig\TwigRenderer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class HomePageHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly string $containerName,
+        private readonly RouterInterface $router,
+        private readonly ?TemplateRendererInterface $template = null
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $data = [];
+
+        switch ($this->containerName) {
+            case ServiceManager::class:
+                $data['containerName'] = 'Laminas Servicemanager';
+                $data['containerDocs'] = 'https://docs.laminas.dev/laminas-servicemanager/';
+                break;
+            case ContainerBuilder::class:
+                $data['containerName'] = 'Symfony DI Container';
+                $data['containerDocs'] = 'https://symfony.com/doc/current/service_container.html';
+                break;
+            case 'Elie\PHPDI\Config\ContainerWrapper':
+            case PHPDIContainer::class:
+                $data['containerName'] = 'PHP-DI';
+                $data['containerDocs'] = 'https://php-di.org';
+                break;
+            case MinimalContainer::class:
+                $data['containerName'] = 'Chubbyphp Container';
+                $data['containerDocs'] = 'https://github.com/chubbyphp/chubbyphp-container';
+                break;
+        }
+
+        if ($this->router instanceof FastRouteRouter) {
+            $data['routerName'] = 'FastRoute';
+            $data['routerDocs'] = 'https://github.com/nikic/FastRoute';
+        } elseif ($this->router instanceof LaminasRouter) {
+            $data['routerName'] = 'Laminas Router';
+            $data['routerDocs'] = 'https://docs.laminas.dev/laminas-router/';
+        }
+
+        if ($this->template === null) {
+            return new JsonResponse([
+                'welcome' => 'Congratulations! You have installed the mezzio skeleton application.',
+                'docsUrl' => 'https://docs.mezzio.dev/mezzio/',
+            ] + $data);
+        }
+
+        if ($this->template instanceof PlatesRenderer) {
+            $data['templateName'] = 'Plates';
+            $data['templateDocs'] = 'https://platesphp.com/';
+        } elseif ($this->template instanceof TwigRenderer) {
+            $data['templateName'] = 'Twig';
+            $data['templateDocs'] = 'https://twig.symfony.com';
+        } elseif ($this->template instanceof LaminasViewRenderer) {
+            $data['templateName'] = 'Laminas View';
+            $data['templateDocs'] = 'https://docs.laminas.dev/laminas-view/';
+        }
+
+        return new HtmlResponse($this->template->render('app::home-page', $data));
+    }
+}

--- a/service-front/mezzio/src/App/src/Handler/HomePageHandlerFactory.php
+++ b/service-front/mezzio/src/App/src/Handler/HomePageHandlerFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Handler;
+
+use Mezzio\Router\RouterInterface;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+use function assert;
+
+final class HomePageHandlerFactory
+{
+    public function __invoke(ContainerInterface $container): RequestHandlerInterface
+    {
+        $router = $container->get(RouterInterface::class);
+        assert($router instanceof RouterInterface);
+
+        $template = $container->has(TemplateRendererInterface::class)
+            ? $container->get(TemplateRendererInterface::class)
+            : null;
+        assert($template instanceof TemplateRendererInterface || null === $template);
+
+        return new HomePageHandler($container::class, $router, $template);
+    }
+}

--- a/service-front/mezzio/src/App/src/Handler/PingHandler.php
+++ b/service-front/mezzio/src/App/src/Handler/PingHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Handler;
+
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+use function time;
+
+final class PingHandler implements RequestHandlerInterface
+{
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return new JsonResponse(['ack' => time()]);
+    }
+}

--- a/service-front/mezzio/src/App/templates/app/home-page.html.twig
+++ b/service-front/mezzio/src/App/templates/app/home-page.html.twig
@@ -1,0 +1,120 @@
+{% extends '@layout/default.html.twig' %}
+
+{% block title %}Home{% endblock %}
+
+{% block content %}
+    <div class="jumbotron">
+        <h1>Welcome to <span class="mezzio-green">mezzio</span></h1>
+        <p>
+            Congratulations! You have successfully installed the
+            <a href="https://github.com/mezzio/mezzio-skeleton" target="_blank">mezzio skeleton application</a>.
+            This skeleton can serve as a simple starting point for you to begin building your application.
+        </p>
+        <p>
+            Mezzio builds on laminas-stratigility to provide a minimalist PSR-7 middleware framework for PHP.
+        </p>
+    </div>
+
+    <div class="row">
+        <div class="col-md-4">
+            <h2>
+                <a href="https://docs.mezzio.dev/mezzio/getting-started/features" target="_blank">
+                    <i class="fa fa-bolt"></i> Agile &amp; Lean
+                </a>
+            </h2>
+            <p>
+                Mezzio is fast, small and perfect for rapid application development, prototyping and api's.
+                You decide how you extend it and choose the best packages from major framework or standalone projects.
+            </p>
+        </div>
+
+        <div class="col-md-4">
+            <h2>
+                <a href="https://github.com/laminas/laminas-diactoros" target="_blank">
+                    <i class="fa fa-exchange-alt"></i> HTTP Messages
+                </a>
+            </h2>
+            <p>
+                HTTP messages are the foundation of web development. Web browsers and HTTP clients such as cURL create
+                HTTP request messages that are sent to a web server, which provides an HTTP response message.
+                Server-side code receives an HTTP request message, and returns an HTTP response message.
+            </p>
+        </div>
+
+        <div class="col-md-4">
+            <h2>
+                <a href="https://github.com/laminas/laminas-stratigility" target="_blank">
+                    <i class="fa fa-dot-circle"></i> Middleware
+                </a>
+            </h2>
+            <p>
+                Middleware is code that exists between the request and response, and which can take the incoming
+                request, perform actions based on it, and either complete the response or pass delegation on to the
+                next middleware in the queue. Your application is easily extended with custom middleware created by
+                yourself or <a href="https://packagist.org/search/?q=middleware" target="_blank">others</a>.
+            </p>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-4">
+            <h2>
+                <a href="https://docs.mezzio.dev/mezzio/features/container/intro" target="_blank">
+                    <i class="fa fa-cube"></i> Containers
+                </a>
+            </h2>
+            <p>
+                Mezzio promotes and advocates the usage of Dependency Injection/Inversion of Control containers
+                when writing your applications. Mezzio supports multiple containers which typehints against
+                <a href="https://github.com/php-fig/container" target="_blank">PSR Container</a>.
+            </p>
+            {% if containerName is defined %}
+                <p>
+                    <a href="{{ containerDocs }}" target="_blank">
+                        Get started with {{ containerName }}.
+                    </a>
+                </p>
+            {% endif %}
+        </div>
+
+        <div class="col-md-4">
+            <h2>
+                <a href="https://docs.mezzio.dev/mezzio/features/router/intro" target="_blank">
+                    <i class="fa fa-plane"></i> Routers
+                </a>
+            </h2>
+            <p>
+                One fundamental feature of mezzio is that it provides mechanisms for implementing dynamic
+                routing, a feature required in most modern web applications. Mezzio ships with multiple adapters.
+            </p>
+            {% if routerName is defined %}
+                <p>
+                    <a href="{{ routerDocs }}" target="_blank">
+                        Get started with {{ routerName }}.
+                    </a>
+                </p>
+            {% endif %}
+        </div>
+
+        <div class="col-md-4">
+            <h2>
+                <a href="https://docs.mezzio.dev/mezzio/features/template/twig" target="_blank">
+                    <i class="fa fa-edit"></i> Templating
+                </a>
+            </h2>
+            <p>
+                By default, no middleware in Mezzio is templated. We do not even provide a default templating
+                engine, as the choice of templating engine is often very specific to the project and/or organization.
+                However, Mezzio does provide abstraction for templating, which allows you to write middleware that
+                is engine-agnostic.
+            </p>
+            {% if templateName is defined %}
+                <p>
+                    <a href="{{ templateDocs }}" target="_blank">
+                        Get started with {{ templateName }}.
+                    </a>
+                </p>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}

--- a/service-front/mezzio/src/App/templates/error/404.html.twig
+++ b/service-front/mezzio/src/App/templates/error/404.html.twig
@@ -1,0 +1,13 @@
+{% extends '@layout/default.html.twig' %}
+
+{% block title %}404 Not Found{% endblock %}
+
+{% block content %}
+    <h1>Oops!</h1>
+    <h2>This is awkward.</h2>
+    <p>We encountered a 404 Not Found error.</p>
+    <p>
+        You are looking for something that doesn't exist or may have moved. Check out one of the links on this page
+        or head back to <a href="{{ path('home') }}">Home</a>.
+    </p>
+{% endblock %}

--- a/service-front/mezzio/src/App/templates/error/error.html.twig
+++ b/service-front/mezzio/src/App/templates/error/error.html.twig
@@ -1,0 +1,15 @@
+{% extends '@layout/default.html.twig' %}
+
+{% block title %}{{ status }} {{ reason }}{% endblock %}
+
+{% block content %}
+    <h1>Oops!</h1>
+    <h2>This is awkward.</h2>
+    <p>We encountered a {{ status }} {{ reason }} error.</p>
+    {% if status == 404 %}
+        <p>
+            You are looking for something that doesn't exist or may have moved. Check out one of the links on this page
+            or head back to <a href="{{ path('home') }}">Home</a>.
+        </p>
+    {% endif %}
+{% endblock %}

--- a/service-front/mezzio/src/App/templates/layout/default.html.twig
+++ b/service-front/mezzio/src/App/templates/layout/default.html.twig
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>{% block title %}{% endblock %} - mezzio</title>
+    <link rel="shortcut icon" href="https://getlaminas.org/images/favicon/favicon.ico" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" />
+    <link href="https://use.fontawesome.com/releases/v5.13.0/css/all.css" rel="stylesheet" />
+    <style>
+        body { padding-top: 70px; }
+        .app { min-height: 100vh; }
+        .app-footer { padding-bottom: 1em; }
+        .mezzio-green, h2 a, h2 a:hover { color: #009655; }
+        .navbar-brand { padding: 0; }
+        .navbar-brand img { margin: -.5rem 0; filter: brightness(0) invert(1); }
+    </style>
+    {% block stylesheets %}{% endblock %}
+</head>
+<body class="app">
+    <header class="app-header">
+        <nav class="navbar navbar-expand-sm navbar-dark bg-dark fixed-top" role="navigation">
+            <div class="container">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="#navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <!-- Brand -->
+                    <a class="navbar-brand" href="{{ path('home') }}">
+                        <img src="https://docs.laminas.dev/img/laminas-mezzio-rgb.svg" alt="Laminas Mezzio" height="56" />
+                    </a>
+                </div>
+                <!-- Links -->
+                <div class="collapse navbar-collapse" id="navbarCollapse">
+                    <ul class="navbar-nav mr-auto">
+                        <li class="nav-item">
+                            <a href="https://docs.mezzio.dev/mezzio" target="_blank" class="nav-link">
+                                <i class="fa fa-book"></i> Docs
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="https://github.com/mezzio/mezzio" target="_blank" class="nav-link">
+                                <i class="fa fa-wrench"></i> Contribute
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="{{ path('api.ping') }}" class="nav-link">
+                                Ping Test
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <div class="app-content">
+        <main class="container">
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+
+    <footer class="app-footer">
+        <div class="container">
+            <hr />
+            {% block footer %}
+                <p>
+                    &copy; {{ "now"|date("Y") }} <a href="https://getlaminas.org/">Laminas Project</a> a Series of LF Projects, LLC.
+                </p>
+            {% endblock %}
+        </div>
+    </footer>
+
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"></script>
+    {% block javascript %}{% endblock %}
+</body>
+</html>

--- a/service-front/mezzio/test/AppTest/Handler/HomePageHandlerFactoryTest.php
+++ b/service-front/mezzio/test/AppTest/Handler/HomePageHandlerFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Handler;
+
+use App\Handler\HomePageHandler;
+use App\Handler\HomePageHandlerFactory;
+use AppTest\InMemoryContainer;
+use Mezzio\Router\RouterInterface;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\TestCase;
+
+final class HomePageHandlerFactoryTest extends TestCase
+{
+    public function testFactoryWithoutTemplate(): void
+    {
+        $container = new InMemoryContainer();
+        $container->setService(RouterInterface::class, $this->createMock(RouterInterface::class));
+
+        $factory  = new HomePageHandlerFactory();
+        $homePage = $factory($container);
+
+        self::assertInstanceOf(HomePageHandler::class, $homePage);
+    }
+
+    public function testFactoryWithTemplate(): void
+    {
+        $container = new InMemoryContainer();
+        $container->setService(RouterInterface::class, $this->createMock(RouterInterface::class));
+        $container->setService(TemplateRendererInterface::class, $this->createMock(TemplateRendererInterface::class));
+
+        $factory  = new HomePageHandlerFactory();
+        $homePage = $factory($container);
+
+        self::assertInstanceOf(HomePageHandler::class, $homePage);
+    }
+}

--- a/service-front/mezzio/test/AppTest/Handler/HomePageHandlerTest.php
+++ b/service-front/mezzio/test/AppTest/Handler/HomePageHandlerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Handler;
+
+use App\Handler\HomePageHandler;
+use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Diactoros\Response\JsonResponse;
+use Mezzio\Router\RouterInterface;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class HomePageHandlerTest extends TestCase
+{
+    private ContainerInterface&MockObject $container;
+    private RouterInterface&MockObject $router;
+
+    protected function setUp(): void
+    {
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->router    = $this->createMock(RouterInterface::class);
+    }
+
+    public function testReturnsJsonResponseWhenNoTemplateRendererProvided(): void
+    {
+        $homePage = new HomePageHandler(
+            $this->container::class,
+            $this->router,
+            null
+        );
+        $response = $homePage->handle(
+            $this->createMock(ServerRequestInterface::class)
+        );
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+    }
+
+    public function testReturnsHtmlResponseWhenTemplateRendererProvided(): void
+    {
+        $renderer = $this->createMock(TemplateRendererInterface::class);
+        $renderer
+            ->expects($this->once())
+            ->method('render')
+            ->with('app::home-page', $this->isArray())
+            ->willReturn('');
+
+        $homePage = new HomePageHandler(
+            $this->container::class,
+            $this->router,
+            $renderer
+        );
+
+        $response = $homePage->handle(
+            $this->createMock(ServerRequestInterface::class)
+        );
+
+        self::assertInstanceOf(HtmlResponse::class, $response);
+    }
+}

--- a/service-front/mezzio/test/AppTest/Handler/PingHandlerTest.php
+++ b/service-front/mezzio/test/AppTest/Handler/PingHandlerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Handler;
+
+use App\Handler\PingHandler;
+use Laminas\Diactoros\Response\JsonResponse;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+use function json_decode;
+use function property_exists;
+
+use const JSON_THROW_ON_ERROR;
+
+final class PingHandlerTest extends TestCase
+{
+    public function testResponse(): void
+    {
+        $pingHandler = new PingHandler();
+        $response    = $pingHandler->handle(
+            $this->createMock(ServerRequestInterface::class)
+        );
+
+        $json = json_decode((string) $response->getBody(), null, 512, JSON_THROW_ON_ERROR);
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+        self::assertTrue(property_exists($json, 'ack') && $json->ack !== null);
+    }
+}

--- a/service-front/mezzio/test/AppTest/InMemoryContainer.php
+++ b/service-front/mezzio/test/AppTest/InMemoryContainer.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest;
+
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+use function array_key_exists;
+use function sprintf;
+
+/**
+ * A PSR Container stub. Useful for testing factories without excessive mocking
+ */
+final class InMemoryContainer implements ContainerInterface
+{
+    /** @var array<string, mixed> */
+    public array $services = [];
+
+    public function setService(string $name, mixed $service): void
+    {
+        $this->services[$name] = $service;
+    }
+
+    /**
+     * @param string $id
+     * @return mixed
+     */
+    public function get($id)
+    {
+        if (! $this->has($id)) {
+            throw new RuntimeException(sprintf('Service not found "%s"', $id));
+        }
+
+        return $this->services[$id];
+    }
+
+    /**
+     * @param string $id
+     * @return bool
+     */
+    public function has($id)
+    {
+        return array_key_exists($id, $this->services);
+    }
+}

--- a/service-front/module/Application/config/module.routes.php
+++ b/service-front/module/Application/config/module.routes.php
@@ -94,8 +94,7 @@ return [
                     'route'    => '/',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware' => Handler\HomeRedirectHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\HomeRedirectHandler::class),
                     ],
                 ],
             ], // index-redirect
@@ -106,8 +105,7 @@ return [
                     'route'    => '/home',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware' => Handler\HomeHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\HomeHandler::class),
                     ],
                 ],
             ], // home
@@ -118,8 +116,7 @@ return [
                     'route'    => '/terms',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\TermsHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\TermsHandler::class),
                     ],
                 ],
             ], // terms
@@ -130,11 +127,10 @@ return [
                     'route'    => '/accessibility',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\AccessibilityHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\AccessibilityHandler::class),
                     ],
                 ],
-            ], // terms
+            ], // accessibility
 
             'privacy' => [
                 'type' => Literal::class,
@@ -142,8 +138,7 @@ return [
                     'route'    => '/privacy-notice',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\PrivacyHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\PrivacyHandler::class),
                     ],
                 ],
             ], // privacy
@@ -154,8 +149,7 @@ return [
                     'route'    => '/contact',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\ContactHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\ContactHandler::class),
                     ],
                 ],
             ], // contact
@@ -166,11 +160,10 @@ return [
                     'route'    => '/cookies',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware' => Handler\CookiesHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\CookiesHandler::class),
                     ],
                 ],
-            ], // contact
+            ], // cookies
 
             'forgot-password' => [
                 'type' => Segment::class,
@@ -178,8 +171,7 @@ return [
                     'route'    => '/forgot-password',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware' => Handler\ForgotPasswordHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\ForgotPasswordHandler::class),
                     ],
                 ],
                 'may_terminate' => true,
@@ -193,8 +185,7 @@ return [
                             ],
                             'defaults' => [
                                 'controller' => PipeSpec::class,
-                                'middleware' => Handler\ResetPasswordHandler::class,
-                                'unauthenticated_route' => true
+                                'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\ResetPasswordHandler::class),
                             ],
                         ],
                     ],
@@ -207,8 +198,7 @@ return [
                     'route'    => '/send-feedback',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\FeedbackHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\FeedbackHandler::class),
                     ],
                 ],
             ], // send-feedback
@@ -219,8 +209,7 @@ return [
                     'route'    => '/feedback-thanks',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\FeedbackThanksHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\FeedbackThanksHandler::class),
                     ],
                 ],
             ], // feedback-thanks
@@ -231,9 +220,8 @@ return [
                     'route'    => '/guide[/:section]',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\GuidanceHandler::class,
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\GuidanceHandler::class),
                         'section'    => '',
-                        'unauthenticated_route' => true
                     ],
                 ],
             ], // guidance
@@ -244,8 +232,7 @@ return [
                     'route'    => '/enable-cookie',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\EnableCookieHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\EnableCookieHandler::class),
                     ],
                 ],
             ], // enable-cookie
@@ -256,8 +243,7 @@ return [
                     'route'    => '/login[/:state]',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\LoginHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\LoginHandler::class),
                     ],
                 ],
             ], // login
@@ -268,8 +254,7 @@ return [
                     'route'    => '/logout',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\LogoutHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\LogoutHandler::class),
                     ],
                 ],
             ], // logout
@@ -280,8 +265,7 @@ return [
                     'route' => '/session-state',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\SessionExpiryHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\SessionExpiryHandler::class),
                     ]
                 ],
             ], // session state
@@ -328,8 +312,7 @@ return [
                     'route'    => '/deleted',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\DeletedAccountHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\DeletedAccountHandler::class),
                     ],
                 ],
             ], // deleted
@@ -340,8 +323,7 @@ return [
                     'route'    => '/signup',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware' => Handler\RegisterHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\RegisterHandler::class),
                     ],
                 ],
                 'may_terminate' => true,
@@ -355,8 +337,7 @@ return [
                             ],
                             'defaults' => [
                                 'controller' => PipeSpec::class,
-                                'middleware' => Handler\ConfirmRegistrationHandler::class,
-                                'unauthenticated_route' => true
+                                'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\ConfirmRegistrationHandler::class),
                             ],
                         ],
                     ],
@@ -366,8 +347,7 @@ return [
                             'route'    => '/resend-email',
                             'defaults' => [
                                 'controller' => PipeSpec::class,
-                                'middleware' => Handler\ResendActivationEmailHandler::class,
-                                'unauthenticated_route' => true
+                                'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\ResendActivationEmailHandler::class),
                             ],
                         ],
                     ],
@@ -380,8 +360,7 @@ return [
                     'route'    => '/stats',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware' => Handler\StatsHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\StatsHandler::class),
                     ],
                 ],
             ], // stats
@@ -392,8 +371,7 @@ return [
                     'route'    => '/ping',
                     'defaults' => [
                         'controller' => PipeSpec::class,
-                        'middleware'     => Handler\PingHandler::class,
-                        'unauthenticated_route' => true
+                        'middleware' => Handler\PingHandler::class,
                     ],
                 ],
                 'may_terminate' => true,
@@ -404,8 +382,7 @@ return [
                             'route'    => '/json',
                             'defaults' => [
                                 'controller' => PipeSpec::class,
-                                'middleware'     => Handler\PingHandlerJson::class,
-                                'unauthenticated_route' => true
+                                'middleware' => Handler\PingHandlerJson::class,
                             ],
                         ],
                     ],
@@ -415,8 +392,7 @@ return [
                             'route'    => '/elb',
                             'defaults' => [
                                 'controller' => PipeSpec::class,
-                                'middleware'     => Handler\PingHandlerElb::class,
-                                'unauthenticated_route' => true
+                                'middleware' => Handler\PingHandlerElb::class,
                             ],
                         ],
                     ],
@@ -426,8 +402,7 @@ return [
                             'route'    => '/pingdom',
                             'defaults' => [
                                 'controller' => PipeSpec::class,
-                                'middleware'     => Handler\PingHandlerPingdom::class,
-                                'unauthenticated_route' => true
+                                'middleware' => Handler\PingHandlerPingdom::class,
                             ],
                         ],
                     ],
@@ -494,8 +469,7 @@ return [
                                     ],
                                     'defaults' => [
                                         'controller' => PipeSpec::class,
-                                        'middleware' => Handler\VerifyEmailAddressHandler::class,
-                                        'unauthenticated_route' => true,
+                                        'middleware' => RouteMiddlewareHelper::addPublicMiddleware(Handler\VerifyEmailAddressHandler::class),
                                     ],
                                 ],
                             ],

--- a/service-front/module/Application/src/ConfigProvider.php
+++ b/service-front/module/Application/src/ConfigProvider.php
@@ -1,0 +1,631 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application;
+
+use Application\Form\AbstractCsrfForm;
+use Application\Form\Element\CsrfBuilder;
+use Application\Form\Factory\CsrfBuilderFactory;
+use Application\Form\Error\FormLinkedErrors;
+use Application\Handler\AboutYouHandler;
+use Application\Handler\AccessibilityHandler;
+use Application\Handler\ChangeEmailAddressHandler;
+use Application\Handler\ChangePasswordHandler;
+use Application\Handler\ConfirmRegistrationHandler;
+use Application\Handler\ContactHandler;
+use Application\Handler\CookiesHandler;
+use Application\Handler\DashboardHandler;
+use Application\Handler\DeleteAccountConfirmHandler;
+use Application\Handler\DeleteAccountHandler;
+use Application\Handler\DeletedAccountHandler;
+use Application\Handler\EnableCookieHandler;
+use Application\Handler\Factory\AboutYouHandlerFactory;
+use Application\Handler\Factory\AccessibilityHandlerFactory;
+use Application\Handler\Factory\ChangeEmailAddressHandlerFactory;
+use Application\Handler\Factory\ChangePasswordHandlerFactory;
+use Application\Handler\Factory\ConfirmRegistrationHandlerFactory;
+use Application\Handler\Factory\ContactHandlerFactory;
+use Application\Handler\Factory\CookiesHandlerFactory;
+use Application\Handler\Factory\DashboardHandlerFactory;
+use Application\Handler\Factory\DeleteAccountConfirmHandlerFactory;
+use Application\Handler\Factory\DeleteAccountHandlerFactory;
+use Application\Handler\Factory\DeletedAccountHandlerFactory;
+use Application\Handler\Factory\EnableCookieHandlerFactory;
+use Application\Handler\Factory\FeedbackHandlerFactory;
+use Application\Handler\Factory\FeedbackThanksHandlerFactory;
+use Application\Handler\Factory\ForgotPasswordHandlerFactory;
+use Application\Handler\Factory\GuidanceHandlerFactory;
+use Application\Handler\Factory\HomeHandlerFactory;
+use Application\Handler\Factory\HomeRedirectHandlerFactory;
+use Application\Handler\Factory\LoginHandlerFactory;
+use Application\Handler\Factory\LogoutHandlerFactory;
+use Application\Handler\Factory\Lpa\ApplicantHandlerFactory;
+use Application\Handler\Factory\Lpa\CertificateProvider\CertificateProviderAddHandlerFactory;
+use Application\Handler\Factory\Lpa\CertificateProvider\CertificateProviderConfirmDeleteHandlerFactory;
+use Application\Handler\Factory\Lpa\CertificateProvider\CertificateProviderDeleteHandlerFactory;
+use Application\Handler\Factory\Lpa\CertificateProvider\CertificateProviderEditHandlerFactory;
+use Application\Handler\Factory\Lpa\CertificateProvider\CertificateProviderHandlerFactory;
+use Application\Handler\Factory\Lpa\CheckoutChequeHandlerFactory;
+use Application\Handler\Factory\Lpa\CheckoutConfirmHandlerFactory;
+use Application\Handler\Factory\Lpa\CheckoutIndexHandlerFactory;
+use Application\Handler\Factory\Lpa\CheckoutPayHandlerFactory;
+use Application\Handler\Factory\Lpa\CheckoutPayResponseHandlerFactory;
+use Application\Handler\Factory\Lpa\CompleteIndexHandlerFactory;
+use Application\Handler\Factory\Lpa\CompleteViewDocsHandlerFactory;
+use Application\Handler\Factory\Lpa\ConfirmDeleteLpaHandlerFactory;
+use Application\Handler\Factory\Lpa\CorrespondentEditHandlerFactory;
+use Application\Handler\Factory\Lpa\CorrespondentHandlerFactory;
+use Application\Handler\Factory\Lpa\CreateLpaHandlerFactory;
+use Application\Handler\Factory\Lpa\DateCheckHandlerFactory;
+use Application\Handler\Factory\Lpa\DateCheckValidHandlerFactory;
+use Application\Handler\Factory\Lpa\DeleteLpaHandlerFactory;
+use Application\Handler\Factory\Lpa\DonorAddHandlerFactory;
+use Application\Handler\Factory\Lpa\DonorEditHandlerFactory;
+use Application\Handler\Factory\Lpa\DonorIndexHandlerFactory;
+use Application\Handler\Factory\Lpa\Download\DownloadCheckHandlerFactory;
+use Application\Handler\Factory\Lpa\Download\DownloadFileHandlerFactory;
+use Application\Handler\Factory\Lpa\Download\DownloadHandlerFactory;
+use Application\Handler\Factory\Lpa\FeeReductionHandlerFactory;
+use Application\Handler\Factory\Lpa\HowPrimaryAttorneysMakeDecisionHandlerFactory;
+use Application\Handler\Factory\Lpa\HowReplacementAttorneysMakeDecisionHandlerFactory;
+use Application\Handler\Factory\Lpa\IndexHandlerFactory;
+use Application\Handler\Factory\Lpa\InstructionsHandlerFactory;
+use Application\Handler\Factory\Lpa\LifeSustainingHandlerFactory;
+use Application\Handler\Factory\Lpa\MoreInfoRequiredHandlerFactory;
+use Application\Handler\Factory\Lpa\PeopleToNotify\PeopleToNotifyAddHandlerFactory;
+use Application\Handler\Factory\Lpa\PeopleToNotify\PeopleToNotifyConfirmDeleteHandlerFactory;
+use Application\Handler\Factory\Lpa\PeopleToNotify\PeopleToNotifyDeleteHandlerFactory;
+use Application\Handler\Factory\Lpa\PeopleToNotify\PeopleToNotifyEditHandlerFactory;
+use Application\Handler\Factory\Lpa\PeopleToNotify\PeopleToNotifyHandlerFactory;
+use Application\Handler\Factory\Lpa\PrimaryAttorney\PrimaryAttorneyAddHandlerFactory;
+use Application\Handler\Factory\Lpa\PrimaryAttorney\PrimaryAttorneyAddTrustHandlerFactory;
+use Application\Handler\Factory\Lpa\PrimaryAttorney\PrimaryAttorneyConfirmDeleteHandlerFactory;
+use Application\Handler\Factory\Lpa\PrimaryAttorney\PrimaryAttorneyDeleteHandlerFactory;
+use Application\Handler\Factory\Lpa\PrimaryAttorney\PrimaryAttorneyEditHandlerFactory;
+use Application\Handler\Factory\Lpa\PrimaryAttorneyHandlerFactory;
+use Application\Handler\Factory\Lpa\RepeatApplicationHandlerFactory;
+use Application\Handler\Factory\Lpa\ReplacementAttorneyAddHandlerFactory;
+use Application\Handler\Factory\Lpa\ReplacementAttorneyAddTrustHandlerFactory;
+use Application\Handler\Factory\Lpa\ReplacementAttorneyConfirmDeleteHandlerFactory;
+use Application\Handler\Factory\Lpa\ReplacementAttorneyDeleteHandlerFactory;
+use Application\Handler\Factory\Lpa\ReplacementAttorneyEditHandlerFactory;
+use Application\Handler\Factory\Lpa\ReplacementAttorneyIndexHandlerFactory;
+use Application\Handler\Factory\Lpa\ReuseDetailsHandlerFactory;
+use Application\Handler\Factory\Lpa\StatusHandlerFactory;
+use Application\Handler\Factory\Lpa\SummaryHandlerFactory;
+use Application\Handler\Factory\Lpa\WhenLpaStartsHandlerFactory;
+use Application\Handler\Factory\Lpa\WhenReplacementAttorneyStepInHandlerFactory;
+use Application\Handler\Factory\Lpa\WhoAreYouHandlerFactory;
+use Application\Handler\Factory\LpaTypeHandlerFactory;
+use Application\Handler\Factory\PingHandlerFactory;
+use Application\Handler\Factory\PingHandlerJsonFactory;
+use Application\Handler\Factory\PingHandlerPingdomFactory;
+use Application\Handler\Factory\PostcodeHandlerFactory;
+use Application\Handler\Factory\PrivacyHandlerFactory;
+use Application\Handler\Factory\RegisterHandlerFactory;
+use Application\Handler\Factory\ResendActivationEmailHandlerFactory;
+use Application\Handler\Factory\ResetPasswordHandlerFactory;
+use Application\Handler\Factory\SessionExpiryHandlerFactory;
+use Application\Handler\ResetPasswordHandler;
+use Application\Handler\Factory\SessionKeepAliveHandlerFactory;
+use Application\Handler\Factory\SessionSetExpiryHandlerFactory;
+use Application\Handler\Factory\StatsHandlerFactory;
+use Application\Handler\Factory\StatusesHandlerFactory;
+use Application\Handler\Factory\TermsChangedHandlerFactory;
+use Application\Handler\Factory\TermsHandlerFactory;
+use Application\Handler\Factory\TypeHandlerFactory;
+use Application\Handler\FeedbackHandler;
+use Application\Handler\FeedbackThanksHandler;
+use Application\Handler\ForgotPasswordHandler;
+use Application\Handler\GuidanceHandler;
+use Application\Handler\HomeHandler;
+use Application\Handler\HomeRedirectHandler;
+use Application\Handler\LoginHandler;
+use Application\Handler\LogoutHandler;
+use Application\Handler\Lpa\ApplicantHandler;
+use Application\Handler\Lpa\CertificateProvider\CertificateProviderAddHandler;
+use Application\Handler\Lpa\CertificateProvider\CertificateProviderConfirmDeleteHandler;
+use Application\Handler\Lpa\CertificateProvider\CertificateProviderDeleteHandler;
+use Application\Handler\Lpa\CertificateProvider\CertificateProviderEditHandler;
+use Application\Handler\Lpa\CertificateProvider\CertificateProviderHandler;
+use Application\Handler\Lpa\CheckoutChequeHandler;
+use Application\Handler\Lpa\CheckoutConfirmHandler;
+use Application\Handler\Lpa\CheckoutIndexHandler;
+use Application\Handler\Lpa\CheckoutPayHandler;
+use Application\Handler\Lpa\CheckoutPayResponseHandler;
+use Application\Handler\Lpa\CompleteIndexHandler;
+use Application\Handler\Lpa\CompleteViewDocsHandler;
+use Application\Handler\Lpa\ConfirmDeleteLpaHandler;
+use Application\Handler\Lpa\CorrespondentEditHandler;
+use Application\Handler\Lpa\CorrespondentHandler;
+use Application\Handler\Lpa\CreateLpaHandler;
+use Application\Handler\Lpa\DateCheckHandler;
+use Application\Handler\Lpa\DateCheckValidHandler;
+use Application\Handler\Lpa\DeleteLpaHandler;
+use Application\Handler\Lpa\DonorAddHandler;
+use Application\Handler\Lpa\DonorEditHandler;
+use Application\Handler\Lpa\DonorIndexHandler;
+use Application\Handler\Lpa\Download\DownloadCheckHandler;
+use Application\Handler\Lpa\Download\DownloadFileHandler;
+use Application\Handler\Lpa\Download\DownloadHandler;
+use Application\Handler\Lpa\FeeReductionHandler;
+use Application\Handler\Lpa\HowPrimaryAttorneysMakeDecisionHandler;
+use Application\Handler\Lpa\HowReplacementAttorneysMakeDecisionHandler;
+use Application\Handler\Lpa\IndexHandler;
+use Application\Handler\Lpa\InstructionsHandler;
+use Application\Handler\Lpa\LifeSustainingHandler;
+use Application\Handler\Lpa\MoreInfoRequiredHandler;
+use Application\Handler\Lpa\PeopleToNotify\PeopleToNotifyAddHandler;
+use Application\Handler\Lpa\PeopleToNotify\PeopleToNotifyConfirmDeleteHandler;
+use Application\Handler\Lpa\PeopleToNotify\PeopleToNotifyDeleteHandler;
+use Application\Handler\Lpa\PeopleToNotify\PeopleToNotifyEditHandler;
+use Application\Handler\Lpa\PeopleToNotify\PeopleToNotifyHandler as PeopleToNotifyIndexHandler;
+use Application\Handler\Lpa\PrimaryAttorney\PrimaryAttorneyAddHandler;
+use Application\Handler\Lpa\PrimaryAttorney\PrimaryAttorneyAddTrustHandler;
+use Application\Handler\Lpa\PrimaryAttorney\PrimaryAttorneyConfirmDeleteHandler;
+use Application\Handler\Lpa\PrimaryAttorney\PrimaryAttorneyDeleteHandler;
+use Application\Handler\Lpa\PrimaryAttorney\PrimaryAttorneyEditHandler;
+use Application\Handler\Lpa\PrimaryAttorneyHandler;
+use Application\Handler\Lpa\RepeatApplicationHandler;
+use Application\Handler\Lpa\ReplacementAttorneyAddHandler;
+use Application\Handler\Lpa\ReplacementAttorneyAddTrustHandler;
+use Application\Handler\Lpa\ReplacementAttorneyConfirmDeleteHandler;
+use Application\Handler\Lpa\ReplacementAttorneyDeleteHandler;
+use Application\Handler\Lpa\ReplacementAttorneyEditHandler;
+use Application\Handler\Lpa\ReplacementAttorneyIndexHandler;
+use Application\Handler\Lpa\ReuseDetailsHandler;
+use Application\Handler\Lpa\StatusHandler;
+use Application\Handler\Lpa\SummaryHandler;
+use Application\Handler\Lpa\WhenLpaStartsHandler;
+use Application\Handler\Lpa\WhenReplacementAttorneyStepInHandler;
+use Application\Handler\Lpa\WhoAreYouHandler;
+use Application\Handler\LpaTypeHandler;
+use Application\Handler\PingHandler;
+use Application\Handler\PingHandlerJson;
+use Application\Handler\PingHandlerPingdom;
+use Application\Handler\PostcodeHandler;
+use Application\Handler\PrivacyHandler;
+use Application\Handler\RegisterHandler;
+use Application\Handler\ResendActivationEmailHandler;
+use Application\Handler\SessionExpiryHandler;
+use Application\Handler\SessionKeepAliveHandler;
+use Application\Handler\SessionSetExpiryHandler;
+use Application\Handler\StatsHandler;
+use Application\Handler\StatusesHandler;
+use Application\Handler\TermsChangedHandler;
+use Application\Handler\TermsHandler;
+use Application\Handler\TypeHandler;
+use Application\Handler\VerifyEmailAddressHandler;
+use Application\Middleware\AuthenticationMiddleware;
+use Application\Middleware\Factory\AuthenticationMiddlewareFactory;
+use Application\Middleware\Factory\IdentityTokenRefreshMiddlewareFactory;
+use Application\Middleware\Factory\LpaLoaderMiddlewareFactory;
+use Application\Middleware\Factory\RequestLoggingMiddlewareFactory;
+use Application\Middleware\Factory\SessionBootstrapMiddlewareFactory;
+use Application\Middleware\Factory\TermsAndConditionsMiddlewareFactory;
+use Application\Middleware\Factory\UserDetailsMiddlewareFactory;
+use Application\Middleware\IdentityTokenRefreshMiddleware;
+use Application\Middleware\LpaLoaderMiddleware;
+use Application\Middleware\RequestLoggingMiddleware;
+use Application\Middleware\RouteMatchMiddleware;
+use Application\Middleware\SessionBootstrapMiddleware;
+use Application\Middleware\TermsAndConditionsMiddleware;
+use Application\Middleware\TrailingSlashMiddleware;
+use Application\Middleware\UserDetailsMiddleware;
+use Application\Model\Service\AddressLookup\OrdnanceSurvey;
+use Application\Model\Service\AddressLookup\OrdnanceSurveyFactory;
+use Application\Model\Service\ApiClient\ClientFactory;
+use Application\Model\Service\Authentication\AuthenticationService;
+use Application\Model\Service\Authentication\AuthenticationServiceFactory;
+use Application\Model\Service\Date\DateService;
+use Application\Model\Service\Date\IDateService;
+use Application\Model\Service\Lpa\ContinuationSheets;
+use Application\Model\Service\Mail\Transport\MailTransportFactory;
+use Application\Model\Service\Redis\RedisClient;
+use Application\Model\Service\Session\NativeSessionConfig;
+use Application\Model\Service\Session\SessionFactory;
+use Application\Model\Service\Session\SessionManagerSupport;
+use Application\Model\Service\Session\SessionUtility;
+use Application\Model\Service\Session\WritePolicy;
+use Application\Service\AccordionService;
+use Application\Service\CompleteViewParamsHelper;
+use Application\Service\DateCheckViewModelHelper;
+use Application\Service\Factory\AccordionServiceFactory;
+use Application\Service\Factory\ActorReuseDetailsServiceFactory;
+use Application\Model\Service\Lpa\ActorReuseDetailsService;
+use Application\Service\Factory\AppFiltersExtensionFactory;
+use Application\Service\Factory\AppFunctionsExtensionFactory;
+use Application\Service\Factory\CompleteViewParamsHelperFactory;
+use Application\Service\Factory\DynamoDbSystemMessageCacheFactory;
+use Application\Service\Factory\DynamoDbSystemMessageClientFactory;
+use Application\Service\Factory\FormLinkedErrorsFactory;
+use Application\Service\Factory\GovPayClientFactory;
+use Application\Service\Factory\HttpClientFactory;
+use Application\Service\Factory\LpaAuthAdapterFactory;
+use Application\Service\Factory\NavigationViewModelHelperFactory;
+use Application\Service\Factory\NativeSessionConfigFactory;
+use Application\Service\Factory\RedisClientFactory;
+use Application\Service\Factory\SaveHandlerFactory;
+use Application\Service\Factory\SessionManagerSupportFactory;
+use Application\Service\Factory\SessionMiddlewareFactory;
+use Application\Service\Factory\SystemMessageFactory;
+use Application\Service\Factory\TelemetryTracerFactory;
+use Application\Service\Factory\TwigViewRendererFactory;
+use Application\Service\Factory\WritePolicyFactory;
+use Application\Service\NavigationViewModelHelper;
+use Application\Service\SystemMessage;
+use Application\View\Twig\AppFiltersExtension;
+use Application\View\Twig\AppFunctionsExtension;
+use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
+use Laminas\ServiceManager\Factory\InvokableFactory;
+use Laminas\Session\SessionManager;
+use MakeShared\DataModel\Lpa\Payment\Calculator;
+use MakeShared\Logging\LoggerFactory;
+use MakeShared\Telemetry\Exporter\ExporterFactory;
+use MakeShared\Telemetry\Tracer;
+use Mezzio\Session\SessionMiddleware;
+use Mezzio\Template\TemplateRendererInterface;
+use Mezzio\Twig\TwigRenderer;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Mezzio ConfigProvider for the Application module.
+ *
+ * Consolidates all service, middleware, and handler registrations that were
+ * previously split across Module::getServiceConfig(), Module::getFormElementConfig(),
+ * and the service_manager section of module.config.php.
+ *
+ * Register this provider in mezzio/config/config.php via the ConfigAggregator.
+ */
+class ConfigProvider
+{
+    public function __invoke(): array
+    {
+        return [
+            'dependencies'  => $this->getDependencies(),
+            'form_elements' => $this->getFormElementConfig(),
+            'templates'     => $this->getTemplates(),
+        ];
+    }
+
+    /**
+     * Container dependency configuration.
+     *
+     * Sourced from Module::getServiceConfig() (primary) and the
+     * service_manager key in module.config.php (secondary).
+     */
+    public function getDependencies(): array
+    {
+        return [
+            // HttpClient must not be shared so each consumer gets a fresh instance.
+            'shared' => [
+                'HttpClient' => false,
+            ],
+
+            'aliases' => [
+                OrdnanceSurvey::class        => 'OrdnanceSurvey',
+                AuthenticationService::class => 'AuthenticationService',
+                IDateService::class          => DateService::class,
+                // Bind Mezzio's TemplateRendererInterface to the Twig implementation.
+                TemplateRendererInterface::class => TwigRenderer::class,
+                // Ensure requests for the FQCN key resolve to our custom SessionFactory
+                // rather than Laminas\Session\Module's built-in SessionManagerFactory,
+                // which requires a 'session_config' key we don't provide.
+                SessionManager::class        => 'SessionManager',
+                // String aliases from module.config.php service_manager — allow code
+                // that still uses short string keys to resolve the correct FQCN service.
+                'AdminService'               => 'Application\Model\Service\Admin\Admin',
+                'ApplicantService'           => 'Application\Model\Service\Lpa\Applicant',
+                'Communication'              => 'Application\Model\Service\Lpa\Communication',
+                'Feedback'                   => 'Application\Model\Service\Feedback\Feedback',
+                'Guidance'                   => 'Application\Model\Service\Guidance\Guidance',
+                'LpaApplicationService'      => 'Application\Model\Service\Lpa\Application',
+                'Metadata'                   => 'Application\Model\Service\Lpa\Metadata',
+                'ReplacementAttorneyCleanup' => 'Application\Model\Service\Lpa\ReplacementAttorneyCleanup',
+                'SiteStatus'                 => 'Application\Model\Service\System\Status',
+                'StatsService'               => 'Application\Model\Service\Stats\Stats',
+                'UserService'                => 'Application\Model\Service\User\Details',
+            ],
+
+            'abstract_factories' => [
+                // Resolves Application\Model\Service\* services generically.
+                \Application\Model\Service\ServiceAbstractFactory::class,
+                // Provides Laminas\Cache storage adapters.
+                \Laminas\Cache\Service\StorageCacheAbstractServiceFactory::class,
+                // Auto-wires any service whose constructor dependencies are all
+                // resolvable from the container (fallback for unregistered services).
+                ReflectionBasedAbstractFactory::class,
+            ],
+
+            'factories' => [
+                // ----------------------------------------------------------------
+                // Infrastructure / third-party clients
+                // ----------------------------------------------------------------
+                'HttpClient'                  => HttpClientFactory::class,
+                'GovPayClient'                => GovPayClientFactory::class,
+                'DynamoDbSystemMessageClient' => DynamoDbSystemMessageClientFactory::class,
+                'DynamoDbSystemMessageCache'  => DynamoDbSystemMessageCacheFactory::class,
+                RedisClient::class            => RedisClientFactory::class,
+
+                // ----------------------------------------------------------------
+                // Telemetry
+                // ----------------------------------------------------------------
+                ExporterFactory::class => ReflectionBasedAbstractFactory::class,
+                'TelemetryTracer'      => TelemetryTracerFactory::class,
+                Tracer::class          => TelemetryTracerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Logging
+                // ----------------------------------------------------------------
+                'Logger'               => LoggerFactory::class,
+                LoggerInterface::class => LoggerFactory::class,
+
+                // ----------------------------------------------------------------
+                // API / authentication
+                // ----------------------------------------------------------------
+                'ApiClient'             => ClientFactory::class,
+                'AuthenticationService' => AuthenticationServiceFactory::class,
+                'LpaAuthAdapter'        => LpaAuthAdapterFactory::class,
+                'MailTransport'         => MailTransportFactory::class,
+                'OrdnanceSurvey'        => OrdnanceSurveyFactory::class,
+
+                // ----------------------------------------------------------------
+                // Session
+                // ----------------------------------------------------------------
+                'SessionManager'           => SessionFactory::class,
+                SessionUtility::class      => InvokableFactory::class,
+                SessionManagerSupport::class => SessionManagerSupportFactory::class,
+                SessionMiddleware::class   => SessionMiddlewareFactory::class,
+                WritePolicy::class         => WritePolicyFactory::class,
+                'SaveHandler'              => SaveHandlerFactory::class,
+                NativeSessionConfig::class => NativeSessionConfigFactory::class,
+
+                // ----------------------------------------------------------------
+                // Application services
+                // ----------------------------------------------------------------
+                CsrfBuilder::class               => CsrfBuilderFactory::class,
+                DateService::class               => InvokableFactory::class,
+                ContinuationSheets::class        => InvokableFactory::class,
+                'Calculator'                     => InvokableFactory::class,
+                Calculator::class                => InvokableFactory::class,
+                AccordionService::class          => AccordionServiceFactory::class,
+                CompleteViewParamsHelper::class  => CompleteViewParamsHelperFactory::class,
+                // No dedicated factory; constructor dependencies are all auto-wireable.
+                DateCheckViewModelHelper::class  => ReflectionBasedAbstractFactory::class,
+                NavigationViewModelHelper::class => NavigationViewModelHelperFactory::class,
+                SystemMessage::class             => SystemMessageFactory::class,
+                ActorReuseDetailsService::class  => ActorReuseDetailsServiceFactory::class,
+                FormLinkedErrors::class          => FormLinkedErrorsFactory::class,
+
+                // ----------------------------------------------------------------
+                // Twig extensions
+                // ----------------------------------------------------------------
+                'TwigViewRenderer'           => TwigViewRendererFactory::class,
+                AppFiltersExtension::class   => AppFiltersExtensionFactory::class,
+                AppFunctionsExtension::class => AppFunctionsExtensionFactory::class,
+
+                // ----------------------------------------------------------------
+                // Middleware
+                // ----------------------------------------------------------------
+                TrailingSlashMiddleware::class              => InvokableFactory::class,
+                RequestLoggingMiddleware::class             => RequestLoggingMiddlewareFactory::class,
+                SessionBootstrapMiddleware::class           => SessionBootstrapMiddlewareFactory::class,
+                IdentityTokenRefreshMiddleware::class       => IdentityTokenRefreshMiddlewareFactory::class,
+                AuthenticationMiddleware::class             => AuthenticationMiddlewareFactory::class,
+                UserDetailsMiddleware::class                => UserDetailsMiddlewareFactory::class,
+                TermsAndConditionsMiddleware::class         => TermsAndConditionsMiddlewareFactory::class,
+                // TODO(mezzio): LpaLoaderMiddlewareFactory currently injects MvcUrlHelper
+                // which wraps Laminas MVC's RouteStackInterface. Before enabling this in
+                // production Mezzio, update LpaLoaderMiddleware to accept
+                // Mezzio\Helper\UrlHelper and update LpaLoaderMiddlewareFactory accordingly.
+                LpaLoaderMiddleware::class          => LpaLoaderMiddlewareFactory::class,
+                RouteMatchMiddleware::class         => InvokableFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — general / public
+                // ----------------------------------------------------------------
+                PingHandler::class         => PingHandlerFactory::class,
+                PingHandlerJson::class     => PingHandlerJsonFactory::class,
+                PingHandlerPingdom::class  => PingHandlerPingdomFactory::class,
+                PostcodeHandler::class     => PostcodeHandlerFactory::class,
+                HomeHandler::class         => HomeHandlerFactory::class,
+                HomeRedirectHandler::class => HomeRedirectHandlerFactory::class,
+                AccessibilityHandler::class => AccessibilityHandlerFactory::class,
+                CookiesHandler::class      => CookiesHandlerFactory::class,
+                EnableCookieHandler::class => EnableCookieHandlerFactory::class,
+                ContactHandler::class      => ContactHandlerFactory::class,
+                FeedbackHandler::class     => FeedbackHandlerFactory::class,
+                FeedbackThanksHandler::class => FeedbackThanksHandlerFactory::class,
+                GuidanceHandler::class     => GuidanceHandlerFactory::class,
+                PrivacyHandler::class      => PrivacyHandlerFactory::class,
+                TermsHandler::class        => TermsHandlerFactory::class,
+                StatsHandler::class        => StatsHandlerFactory::class,
+                StatusesHandler::class     => StatusesHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — authentication
+                // ----------------------------------------------------------------
+                LoginHandler::class                  => LoginHandlerFactory::class,
+                LogoutHandler::class                 => LogoutHandlerFactory::class,
+                RegisterHandler::class               => RegisterHandlerFactory::class,
+                ForgotPasswordHandler::class         => ForgotPasswordHandlerFactory::class,
+                ResendActivationEmailHandler::class  => ResendActivationEmailHandlerFactory::class,
+                ConfirmRegistrationHandler::class    => ConfirmRegistrationHandlerFactory::class,
+                ResetPasswordHandler::class          => ResetPasswordHandlerFactory::class,
+                // No dedicated factory exists; ReflectionBasedAbstractFactory auto-wires this.
+                VerifyEmailAddressHandler::class     => ReflectionBasedAbstractFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — account management
+                // ----------------------------------------------------------------
+                AboutYouHandler::class             => AboutYouHandlerFactory::class,
+                ChangeEmailAddressHandler::class   => ChangeEmailAddressHandlerFactory::class,
+                ChangePasswordHandler::class       => ChangePasswordHandlerFactory::class,
+                DeleteAccountHandler::class        => DeleteAccountHandlerFactory::class,
+                DeleteAccountConfirmHandler::class => DeleteAccountConfirmHandlerFactory::class,
+                DeletedAccountHandler::class       => DeletedAccountHandlerFactory::class,
+                TermsChangedHandler::class         => TermsChangedHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — session
+                // ----------------------------------------------------------------
+                SessionExpiryHandler::class    => SessionExpiryHandlerFactory::class,
+                SessionKeepAliveHandler::class => SessionKeepAliveHandlerFactory::class,
+                SessionSetExpiryHandler::class => SessionSetExpiryHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — LPA top-level
+                // ----------------------------------------------------------------
+                LpaTypeHandler::class          => LpaTypeHandlerFactory::class,
+                TypeHandler::class             => TypeHandlerFactory::class,
+                DashboardHandler::class        => DashboardHandlerFactory::class,
+                IndexHandler::class            => IndexHandlerFactory::class,
+                CreateLpaHandler::class        => CreateLpaHandlerFactory::class,
+                DeleteLpaHandler::class        => DeleteLpaHandlerFactory::class,
+                ConfirmDeleteLpaHandler::class => ConfirmDeleteLpaHandlerFactory::class,
+                ApplicantHandler::class        => ApplicantHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — LPA donor
+                // ----------------------------------------------------------------
+                DonorIndexHandler::class => DonorIndexHandlerFactory::class,
+                DonorAddHandler::class   => DonorAddHandlerFactory::class,
+                DonorEditHandler::class  => DonorEditHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — LPA primary attorneys
+                // ----------------------------------------------------------------
+                PrimaryAttorneyHandler::class              => PrimaryAttorneyHandlerFactory::class,
+                PrimaryAttorneyAddHandler::class           => PrimaryAttorneyAddHandlerFactory::class,
+                PrimaryAttorneyAddTrustHandler::class      => PrimaryAttorneyAddTrustHandlerFactory::class,
+                PrimaryAttorneyEditHandler::class          => PrimaryAttorneyEditHandlerFactory::class,
+                PrimaryAttorneyConfirmDeleteHandler::class => PrimaryAttorneyConfirmDeleteHandlerFactory::class,
+                PrimaryAttorneyDeleteHandler::class        => PrimaryAttorneyDeleteHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — LPA replacement attorneys
+                // ----------------------------------------------------------------
+                ReplacementAttorneyIndexHandler::class        => ReplacementAttorneyIndexHandlerFactory::class,
+                ReplacementAttorneyAddHandler::class          => ReplacementAttorneyAddHandlerFactory::class,
+                ReplacementAttorneyAddTrustHandler::class     => ReplacementAttorneyAddTrustHandlerFactory::class,
+                ReplacementAttorneyEditHandler::class         => ReplacementAttorneyEditHandlerFactory::class,
+                ReplacementAttorneyConfirmDeleteHandler::class => ReplacementAttorneyConfirmDeleteHandlerFactory::class,
+                ReplacementAttorneyDeleteHandler::class       => ReplacementAttorneyDeleteHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — LPA certificate provider
+                // ----------------------------------------------------------------
+                CertificateProviderHandler::class              => CertificateProviderHandlerFactory::class,
+                CertificateProviderAddHandler::class           => CertificateProviderAddHandlerFactory::class,
+                CertificateProviderEditHandler::class          => CertificateProviderEditHandlerFactory::class,
+                CertificateProviderConfirmDeleteHandler::class => CertificateProviderConfirmDeleteHandlerFactory::class,
+                CertificateProviderDeleteHandler::class        => CertificateProviderDeleteHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — LPA people to notify
+                // ----------------------------------------------------------------
+                PeopleToNotifyIndexHandler::class        => PeopleToNotifyHandlerFactory::class,
+                PeopleToNotifyAddHandler::class          => PeopleToNotifyAddHandlerFactory::class,
+                PeopleToNotifyEditHandler::class         => PeopleToNotifyEditHandlerFactory::class,
+                PeopleToNotifyConfirmDeleteHandler::class => PeopleToNotifyConfirmDeleteHandlerFactory::class,
+                PeopleToNotifyDeleteHandler::class       => PeopleToNotifyDeleteHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — LPA decisions / preferences
+                // ----------------------------------------------------------------
+                LifeSustainingHandler::class                      => LifeSustainingHandlerFactory::class,
+                HowPrimaryAttorneysMakeDecisionHandler::class     => HowPrimaryAttorneysMakeDecisionHandlerFactory::class,
+                HowReplacementAttorneysMakeDecisionHandler::class => HowReplacementAttorneysMakeDecisionHandlerFactory::class,
+                WhenReplacementAttorneyStepInHandler::class       => WhenReplacementAttorneyStepInHandlerFactory::class,
+                WhenLpaStartsHandler::class                       => WhenLpaStartsHandlerFactory::class,
+                MoreInfoRequiredHandler::class                    => MoreInfoRequiredHandlerFactory::class,
+                InstructionsHandler::class                        => InstructionsHandlerFactory::class,
+                FeeReductionHandler::class                        => FeeReductionHandlerFactory::class,
+                RepeatApplicationHandler::class                   => RepeatApplicationHandlerFactory::class,
+                ReuseDetailsHandler::class                        => ReuseDetailsHandlerFactory::class,
+                WhoAreYouHandler::class                           => WhoAreYouHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — LPA date check / summary / completion
+                // ----------------------------------------------------------------
+                DateCheckHandler::class      => DateCheckHandlerFactory::class,
+                DateCheckValidHandler::class => DateCheckValidHandlerFactory::class,
+                SummaryHandler::class        => SummaryHandlerFactory::class,
+                StatusHandler::class         => StatusHandlerFactory::class,
+                CompleteIndexHandler::class  => CompleteIndexHandlerFactory::class,
+                CompleteViewDocsHandler::class => CompleteViewDocsHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — LPA correspondent
+                // ----------------------------------------------------------------
+                CorrespondentHandler::class     => CorrespondentHandlerFactory::class,
+                CorrespondentEditHandler::class => CorrespondentEditHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — LPA checkout
+                // ----------------------------------------------------------------
+                CheckoutIndexHandler::class       => CheckoutIndexHandlerFactory::class,
+                CheckoutChequeHandler::class      => CheckoutChequeHandlerFactory::class,
+                CheckoutConfirmHandler::class     => CheckoutConfirmHandlerFactory::class,
+                CheckoutPayHandler::class         => CheckoutPayHandlerFactory::class,
+                CheckoutPayResponseHandler::class => CheckoutPayResponseHandlerFactory::class,
+
+                // ----------------------------------------------------------------
+                // Handlers — LPA download
+                // ----------------------------------------------------------------
+                DownloadHandler::class      => DownloadHandlerFactory::class,
+                DownloadCheckHandler::class => DownloadCheckHandlerFactory::class,
+                DownloadFileHandler::class  => DownloadFileHandlerFactory::class,
+            ],
+
+            // Injects a logger into any service implementing LoggerAwareInterface.
+            // Consider removing this in favour of explicit constructor injection
+            // as handlers are migrated fully to Mezzio.
+            'initializers' => [
+                function (ContainerInterface $container, object $instance): void {
+                    if ($instance instanceof LoggerAwareInterface) {
+                        $instance->setLogger($container->get(LoggerInterface::class));
+                    }
+                },
+            ],
+        ];
+    }
+
+    /**
+     * FormElementManager configuration.
+     *
+     * Injects CsrfBuilder into any AbstractCsrfForm at construction time.
+     * Sourced from Module::getFormElementConfig().
+     */
+    public function getFormElementConfig(): array
+    {
+        return [
+            'initializers' => [
+                'InitCsrfForm' => static function (\Laminas\ServiceManager\ServiceManager $serviceManager, object $form): void {
+                    if ($form instanceof AbstractCsrfForm) {
+                        $form->setCsrf($serviceManager->get(CsrfBuilder::class));
+                    }
+                },
+            ],
+        ];
+    }
+
+    /**
+     * Twig template path configuration.
+     *
+     * Sourced from the templates key in module.config.php.
+     * The Mezzio ConfigAggregator merges this with paths registered by
+     * other providers (e.g. App\ConfigProvider).
+     */
+    public function getTemplates(): array
+    {
+        return [
+            'paths' => [
+                'application' => [__DIR__ . '/../view/application'],
+            ],
+        ];
+    }
+}

--- a/service-front/module/Application/src/Form/Factory/CsrfBuilderFactory.php
+++ b/service-front/module/Application/src/Form/Factory/CsrfBuilderFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Form\Factory;
+
+use Application\Form\Element\CsrfBuilder;
+use Laminas\ServiceManager\ServiceManager;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Creates CsrfBuilder, injecting the ServiceManager directly.
+ *
+ * CsrfBuilder acts as a service-locator factory for CSRF form elements — it
+ * needs the full ServiceManager so it can lazily resolve config, Logger, and
+ * SessionUtility when building each Csrf element instance. In a laminas-servicemanager
+ * Mezzio container the ContainerInterface IS the ServiceManager, so we cast it.
+ */
+class CsrfBuilderFactory
+{
+    public function __invoke(ContainerInterface $container): CsrfBuilder
+    {
+        /** @var ServiceManager $container */
+        return new CsrfBuilder($container);
+    }
+}

--- a/service-front/module/Application/src/Handler/Factory/AccessibilityHandlerFactory.php
+++ b/service-front/module/Application/src/Handler/Factory/AccessibilityHandlerFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Handler\Factory;
+
+use Application\Handler\AccessibilityHandler;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Container\ContainerInterface;
+
+class AccessibilityHandlerFactory
+{
+    public function __invoke(ContainerInterface $container): AccessibilityHandler
+    {
+        return new AccessibilityHandler(
+            $container->get(TemplateRendererInterface::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Handler/Factory/ContactHandlerFactory.php
+++ b/service-front/module/Application/src/Handler/Factory/ContactHandlerFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Handler\Factory;
+
+use Application\Handler\ContactHandler;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Container\ContainerInterface;
+
+class ContactHandlerFactory
+{
+    public function __invoke(ContainerInterface $container): ContactHandler
+    {
+        return new ContactHandler(
+            $container->get(TemplateRendererInterface::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Handler/Factory/EnableCookieHandlerFactory.php
+++ b/service-front/module/Application/src/Handler/Factory/EnableCookieHandlerFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Handler\Factory;
+
+use Application\Handler\EnableCookieHandler;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Container\ContainerInterface;
+
+class EnableCookieHandlerFactory
+{
+    public function __invoke(ContainerInterface $container): EnableCookieHandler
+    {
+        return new EnableCookieHandler(
+            $container->get(TemplateRendererInterface::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Handler/Factory/PrivacyHandlerFactory.php
+++ b/service-front/module/Application/src/Handler/Factory/PrivacyHandlerFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Handler\Factory;
+
+use Application\Handler\PrivacyHandler;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Container\ContainerInterface;
+
+class PrivacyHandlerFactory
+{
+    public function __invoke(ContainerInterface $container): PrivacyHandler
+    {
+        return new PrivacyHandler(
+            $container->get(TemplateRendererInterface::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Handler/Factory/TermsHandlerFactory.php
+++ b/service-front/module/Application/src/Handler/Factory/TermsHandlerFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Handler\Factory;
+
+use Application\Handler\TermsHandler;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Container\ContainerInterface;
+
+class TermsHandlerFactory
+{
+    public function __invoke(ContainerInterface $container): TermsHandler
+    {
+        return new TermsHandler(
+            $container->get(TemplateRendererInterface::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Helper/RouteMiddlewareHelper.php
+++ b/service-front/module/Application/src/Helper/RouteMiddlewareHelper.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Application\Helper;
 
 use Application\Middleware\AuthenticationMiddleware;
+use Application\Middleware\IdentityTokenRefreshMiddleware;
 use Application\Middleware\LpaLoaderMiddleware;
+use Application\Middleware\RequestLoggingMiddleware;
 use Application\Middleware\RouteMatchMiddleware;
+use Application\Middleware\SessionBootstrapMiddleware;
 use Application\Middleware\TermsAndConditionsMiddleware;
 use Application\Middleware\UserDetailsMiddleware;
 use Laminas\Mvc\Middleware\PipeSpec;
@@ -14,14 +17,43 @@ use Laminas\Mvc\Middleware\PipeSpec;
 class RouteMiddlewareHelper
 {
     /**
-     * Builds a PipeSpec with the standard authenticated middleware stack, minus any classes in $ignore.
+     * Middleware that runs on every non-ping request: attaches request context
+     * to logs, bootstraps the session, and refreshes the identity token.
+     * Must always come first in any PipeSpec.
+     */
+    private const array GLOBAL_MIDDLEWARE = [
+        RequestLoggingMiddleware::class,
+        SessionBootstrapMiddleware::class,
+        IdentityTokenRefreshMiddleware::class,
+    ];
+
+    /**
+     * Builds a PipeSpec for public (unauthenticated) routes.
+     *
+     * Includes the global middleware stack and RouteMatchMiddleware so that
+     * downstream handlers can read the Mezzio RouteResult attribute, but
+     * intentionally omits auth, user-details, T&C, and LPA loader checks.
+     */
+    public static function addPublicMiddleware(string $handlerClass): PipeSpec
+    {
+        return new PipeSpec(...[
+            ...self::GLOBAL_MIDDLEWARE,
+            RouteMatchMiddleware::class,
+            $handlerClass,
+        ]);
+    }
+
+    /**
+     * Builds a PipeSpec with the standard authenticated middleware stack,
+     * minus any classes in $ignore.
      *
      * @param string $handlerClass The handler to append at the end of the pipeline.
      * @param string[] $ignore Middleware classes to omit from the stack.
      */
-    public static function addMiddleware(string $handlerClass, array $ignore): PipeSpec
+    public static function addMiddleware(string $handlerClass, array $ignore = []): PipeSpec
     {
         $middlewares = array_diff([
+            ...self::GLOBAL_MIDDLEWARE,
             RouteMatchMiddleware::class,
             AuthenticationMiddleware::class,
             UserDetailsMiddleware::class,

--- a/service-front/module/Application/src/Middleware/AuthenticationMiddleware.php
+++ b/service-front/module/Application/src/Middleware/AuthenticationMiddleware.php
@@ -79,11 +79,11 @@ class AuthenticationMiddleware implements MiddlewareInterface
 
         // TODO(mezzio): update routeName when we setup Mezzio routes
         if ($this->urlHelper === null) {
-            return new RedirectResponse('/login?state=' . $reason);
+            return new RedirectResponse('/login/' . $reason);
         }
 
         return new RedirectResponse(
-            $this->urlHelper->generate('login', [], ['state' => $reason])
+            $this->urlHelper->generate('login', ['state' => $reason])
         );
     }
 

--- a/service-front/module/Application/src/Middleware/Factory/AuthenticationMiddlewareFactory.php
+++ b/service-front/module/Application/src/Middleware/Factory/AuthenticationMiddlewareFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware\Factory;
+
+use Application\Middleware\AuthenticationMiddleware;
+use Application\Model\Service\Authentication\AuthenticationService;
+use Application\Model\Service\Session\SessionUtility;
+use Mezzio\Helper\UrlHelper;
+use Psr\Container\ContainerInterface;
+
+class AuthenticationMiddlewareFactory
+{
+    public function __invoke(ContainerInterface $container): AuthenticationMiddleware
+    {
+        return new AuthenticationMiddleware(
+            $container->get(SessionUtility::class),
+            $container->get(AuthenticationService::class),
+            $container->get(UrlHelper::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Middleware/Factory/IdentityTokenRefreshMiddlewareFactory.php
+++ b/service-front/module/Application/src/Middleware/Factory/IdentityTokenRefreshMiddlewareFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware\Factory;
+
+use Application\Middleware\IdentityTokenRefreshMiddleware;
+use Application\Model\Service\Authentication\AuthenticationService;
+use Application\Model\Service\Session\SessionUtility;
+use Application\Model\Service\User\Details as UserService;
+use Psr\Container\ContainerInterface;
+
+class IdentityTokenRefreshMiddlewareFactory
+{
+    public function __invoke(ContainerInterface $container): IdentityTokenRefreshMiddleware
+    {
+        return new IdentityTokenRefreshMiddleware(
+            $container->get(AuthenticationService::class),
+            $container->get(UserService::class),
+            $container->get(SessionUtility::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Middleware/Factory/LpaLoaderMiddlewareFactory.php
+++ b/service-front/module/Application/src/Middleware/Factory/LpaLoaderMiddlewareFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware\Factory;
+
+use Application\Helper\MvcUrlHelper;
+use Application\Middleware\LpaLoaderMiddleware;
+use Application\Model\Service\Lpa\Application as LpaApplicationService;
+use Psr\Container\ContainerInterface;
+
+/**
+ * TODO(mezzio): LpaLoaderMiddleware is currently typed to MvcUrlHelper which wraps
+ * Laminas MVC's RouteStackInterface. Before this factory can be used in a pure Mezzio
+ * context, LpaLoaderMiddleware must be updated to accept Mezzio\Helper\UrlHelper instead.
+ * At that point, replace the MvcUrlHelper injection below with:
+ *     $container->get(\Mezzio\Helper\UrlHelper::class)
+ */
+class LpaLoaderMiddlewareFactory
+{
+    public function __invoke(ContainerInterface $container): LpaLoaderMiddleware
+    {
+        return new LpaLoaderMiddleware(
+            $container->get(LpaApplicationService::class),
+            $container->get(MvcUrlHelper::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Middleware/Factory/RequestLoggingMiddlewareFactory.php
+++ b/service-front/module/Application/src/Middleware/Factory/RequestLoggingMiddlewareFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware\Factory;
+
+use Application\Middleware\RequestLoggingMiddleware;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+class RequestLoggingMiddlewareFactory
+{
+    public function __invoke(ContainerInterface $container): RequestLoggingMiddleware
+    {
+        return new RequestLoggingMiddleware($container->get(LoggerInterface::class));
+    }
+}

--- a/service-front/module/Application/src/Middleware/Factory/SessionBootstrapMiddlewareFactory.php
+++ b/service-front/module/Application/src/Middleware/Factory/SessionBootstrapMiddlewareFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Middleware\Factory;
 
 use Application\Middleware\SessionBootstrapMiddleware;
+use Application\Model\Service\Session\NativeSessionConfig;
 use Application\Model\Service\Session\SessionManagerSupport;
 use Psr\Container\ContainerInterface;
 
@@ -13,6 +14,7 @@ class SessionBootstrapMiddlewareFactory
     public function __invoke(ContainerInterface $container): SessionBootstrapMiddleware
     {
         return new SessionBootstrapMiddleware(
+            $container->get(NativeSessionConfig::class),
             $container->get('SessionManager'),
             $container->get(SessionManagerSupport::class),
         );

--- a/service-front/module/Application/src/Middleware/Factory/SessionBootstrapMiddlewareFactory.php
+++ b/service-front/module/Application/src/Middleware/Factory/SessionBootstrapMiddlewareFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware\Factory;
+
+use Application\Middleware\SessionBootstrapMiddleware;
+use Application\Model\Service\Session\NativeSessionConfig;
+use Application\Model\Service\Session\SessionManagerSupport;
+use Psr\Container\ContainerInterface;
+
+class SessionBootstrapMiddlewareFactory
+{
+    public function __invoke(ContainerInterface $container): SessionBootstrapMiddleware
+    {
+        return new SessionBootstrapMiddleware(
+            $container->get(NativeSessionConfig::class),
+            $container->get('SessionManager'),
+            $container->get(SessionManagerSupport::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Middleware/Factory/SessionBootstrapMiddlewareFactory.php
+++ b/service-front/module/Application/src/Middleware/Factory/SessionBootstrapMiddlewareFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Application\Middleware\Factory;
 
 use Application\Middleware\SessionBootstrapMiddleware;
-use Application\Model\Service\Session\NativeSessionConfig;
 use Application\Model\Service\Session\SessionManagerSupport;
 use Psr\Container\ContainerInterface;
 
@@ -14,7 +13,6 @@ class SessionBootstrapMiddlewareFactory
     public function __invoke(ContainerInterface $container): SessionBootstrapMiddleware
     {
         return new SessionBootstrapMiddleware(
-            $container->get(NativeSessionConfig::class),
             $container->get('SessionManager'),
             $container->get(SessionManagerSupport::class),
         );

--- a/service-front/module/Application/src/Middleware/Factory/TermsAndConditionsMiddlewareFactory.php
+++ b/service-front/module/Application/src/Middleware/Factory/TermsAndConditionsMiddlewareFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware\Factory;
+
+use Application\Middleware\TermsAndConditionsMiddleware;
+use Application\Model\Service\Authentication\AuthenticationService;
+use Application\Model\Service\Session\SessionUtility;
+use Mezzio\Helper\UrlHelper;
+use Psr\Container\ContainerInterface;
+
+class TermsAndConditionsMiddlewareFactory
+{
+    public function __invoke(ContainerInterface $container): TermsAndConditionsMiddleware
+    {
+        return new TermsAndConditionsMiddleware(
+            $container->get('config'),
+            $container->get(SessionUtility::class),
+            $container->get(AuthenticationService::class),
+            $container->get(UrlHelper::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Middleware/Factory/UserDetailsMiddlewareFactory.php
+++ b/service-front/module/Application/src/Middleware/Factory/UserDetailsMiddlewareFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware\Factory;
+
+use Application\Middleware\UserDetailsMiddleware;
+use Application\Model\Service\Authentication\AuthenticationService;
+use Application\Model\Service\Session\SessionUtility;
+use Application\Model\Service\User\Details;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+class UserDetailsMiddlewareFactory
+{
+    public function __invoke(ContainerInterface $container): UserDetailsMiddleware
+    {
+        return new UserDetailsMiddleware(
+            $container->get(SessionUtility::class),
+            $container->get(Details::class),
+            $container->get(AuthenticationService::class),
+            $container->get('SessionManager'),
+            $container->get(LoggerInterface::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Middleware/IdentityTokenRefreshMiddleware.php
+++ b/service-front/module/Application/src/Middleware/IdentityTokenRefreshMiddleware.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware;
+
+use Application\Model\Service\ApiClient\Exception\ApiException;
+use Application\Model\Service\Authentication\AuthenticationService;
+use Application\Model\Service\Authentication\Identity\User as Identity;
+use Application\Model\Service\Session\ContainerNamespace;
+use Application\Model\Service\Session\SessionUtility;
+use Application\Model\Service\User\Details as UserService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Refreshes the authenticated user's API token on every request.
+ *
+ * Replicates the bootstrapIdentity() logic from Module::onBootstrap(), converted
+ * to PSR-15 middleware. Skipped for health-check endpoints and the session-state
+ * endpoint (which calls this path without a full session context).
+ *
+ * We don't redirect unauthenticated users here — AuthenticationMiddleware handles
+ * that on protected routes. We only clear a stale or failed identity so that
+ * downstream middleware sees an accurate authentication state.
+ *
+ * Must run after SessionBootstrapMiddleware.
+ */
+class IdentityTokenRefreshMiddleware implements MiddlewareInterface
+{
+    private const array EXCLUDED_PATHS = [
+        '/ping/elb',
+        '/ping/json',
+    ];
+
+    public function __construct(
+        private readonly AuthenticationService $authenticationService,
+        private readonly UserService $userService,
+        private readonly SessionUtility $sessionUtility,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $path = $request->getUri()->getPath();
+
+        // Skip health-check endpoints entirely.
+        if (!in_array($path, self::EXCLUDED_PATHS, true)) {
+            // The session-state endpoint is called without needing token refresh.
+            $updateToken = ($path !== '/session-state');
+
+            $this->refreshIdentity($updateToken);
+        }
+
+        return $handler->handle($request);
+    }
+
+    /**
+     * Checks the current identity's token against the API and updates or clears
+     * it as appropriate — mirroring Module::bootstrapIdentity().
+     */
+    private function refreshIdentity(bool $updateToken): void
+    {
+        /** @var Identity|null $identity */
+        $identity = $this->authenticationService->getIdentity();
+
+        if ($identity === null || !$updateToken) {
+            return;
+        }
+
+        try {
+            $info = $this->userService->getTokenInfo($identity->token());
+
+            if ($info['success'] && $info['expiresIn'] !== null) {
+                // Update the cached expiry time in the session identity.
+                $identity->tokenExpiresIn($info['expiresIn']);
+            } else {
+                $this->authenticationService->clearIdentity();
+
+                // Record the failure reason so AuthenticationMiddleware can surface it.
+                if (($info['failureCode'] ?? 0) >= 500) {
+                    $this->sessionUtility->setInMvc(
+                        ContainerNamespace::AUTH_FAILURE_REASON,
+                        'reason',
+                        'Internal system error',
+                    );
+                    $this->sessionUtility->setInMvc(
+                        ContainerNamespace::AUTH_FAILURE_REASON,
+                        'code',
+                        $info['failureCode'],
+                    );
+                }
+            }
+        } catch (ApiException) {
+            $this->authenticationService->clearIdentity();
+        }
+    }
+}

--- a/service-front/module/Application/src/Middleware/RequestLoggingMiddleware.php
+++ b/service-front/module/Application/src/Middleware/RequestLoggingMiddleware.php
@@ -6,6 +6,7 @@ namespace Application\Middleware;
 
 use MakeShared\Constants;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -31,16 +32,12 @@ class RequestLoggingMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if ($this->logger instanceof Logger) {
-            $this->logger->pushProcessor(function (array $record) use ($request): array {
-                $record['extra']['request_path']   = $request->getUri()->getPath();
-                $record['extra']['request_method'] = $request->getMethod();
-
-                $traceId = $request->getHeaderLine('X-Request-ID');
-                if ($traceId !== '') {
-                    $record['extra'][Constants::TRACE_ID_FIELD_NAME] = $traceId;
-                }
-
-                return $record;
+            $this->logger->pushProcessor(function (LogRecord $record) use ($request): LogRecord {
+                return $record->with(extra: array_merge($record->extra, [
+                    'request_path'                       => $request->getUri()->getPath(),
+                    'request_method'                     => $request->getMethod(),
+                    Constants::TRACE_ID_FIELD_NAME       => $request->getHeaderLine('X-Request-ID') ?: '',
+                ]));
             });
         }
 

--- a/service-front/module/Application/src/Middleware/RequestLoggingMiddleware.php
+++ b/service-front/module/Application/src/Middleware/RequestLoggingMiddleware.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware;
+
+use MakeShared\Constants;
+use Monolog\Logger;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Pushes a Monolog processor that adds request context (path, method,
+ * trace ID) to every log record produced during the request lifecycle.
+ *
+ * Replicates the logger->pushProcessor() call in Module::onBootstrap(),
+ * converted to PSR-15 middleware.
+ *
+ * Should run early in the pipeline — after ErrorHandler but before any
+ * middleware that may log.
+ */
+class RequestLoggingMiddleware implements MiddlewareInterface
+{
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($this->logger instanceof Logger) {
+            $this->logger->pushProcessor(function (array $record) use ($request): array {
+                $record['extra']['request_path']   = $request->getUri()->getPath();
+                $record['extra']['request_method'] = $request->getMethod();
+
+                $traceId = $request->getHeaderLine('X-Request-ID');
+                if ($traceId !== '') {
+                    $record['extra'][Constants::TRACE_ID_FIELD_NAME] = $traceId;
+                }
+
+                return $record;
+            });
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/service-front/module/Application/src/Middleware/SessionBootstrapMiddleware.php
+++ b/service-front/module/Application/src/Middleware/SessionBootstrapMiddleware.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Middleware;
 
-use Application\Model\Service\Session\NativeSessionConfig;
 use Application\Model\Service\Session\SessionManagerSupport;
-use Laminas\Session\Container;
 use Laminas\Session\SessionManager;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -16,12 +14,12 @@ use Psr\Http\Server\RequestHandlerInterface;
 /**
  * Bootstraps the laminas-session stack on every request that requires a session.
  *
- * Replicates the bootstrapSession() logic from Module::onBootstrap(), converted
- * to PSR-15 middleware. Skipped for health-check endpoints that must not create
- * sessions.
- *
- * Must run before any middleware that reads or writes the session (e.g.
- * IdentityTokenRefreshMiddleware, AuthenticationMiddleware).
+ * NativeSessionConfig::configure() and Container::setDefaultManager() are called
+ * earlier, in Module::onBootstrap(), so that the Redis save handler is registered
+ * before any Laminas Container subclass (e.g. authentication storage) is constructed
+ * during service wiring.  This middleware is responsible only for starting the
+ * session (if it has not already been started by a Container constructor) and
+ * running the session-ID regeneration logic.
  */
 class SessionBootstrapMiddleware implements MiddlewareInterface
 {
@@ -34,7 +32,6 @@ class SessionBootstrapMiddleware implements MiddlewareInterface
     ];
 
     public function __construct(
-        private readonly NativeSessionConfig $nativeSessionConfig,
         private readonly SessionManager $sessionManager,
         private readonly SessionManagerSupport $sessionManagerSupport,
     ) {
@@ -45,14 +42,15 @@ class SessionBootstrapMiddleware implements MiddlewareInterface
         $path = $request->getUri()->getPath();
 
         if (!in_array($path, self::SESSION_EXCLUDED_PATHS, true)) {
-            // Configure the save handler (Redis), cookie settings, etc.
-            $this->nativeSessionConfig->configure();
+            // configure() and Container::setDefaultManager() are called early in
+            // Module::onBootstrap() so that the correct save handler is registered
+            // before any Laminas\Session\Container subclass (e.g. authentication
+            // storage) is instantiated during service wiring.
+            // Here we only need to ensure the session is open and initialised.
+            if (PHP_SESSION_NONE === session_status()) {
+                $this->sessionManager->start();
+            }
 
-            // Start the session and make this manager the default for all Containers.
-            $this->sessionManager->start();
-            Container::setDefaultManager($this->sessionManager);
-
-            // Regenerate session ID on first visit to prevent fixation.
             $this->sessionManagerSupport->initialise();
         }
 

--- a/service-front/module/Application/src/Middleware/SessionBootstrapMiddleware.php
+++ b/service-front/module/Application/src/Middleware/SessionBootstrapMiddleware.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware;
+
+use Application\Model\Service\Session\NativeSessionConfig;
+use Application\Model\Service\Session\SessionManagerSupport;
+use Laminas\Session\Container;
+use Laminas\Session\SessionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Bootstraps the laminas-session stack on every request that requires a session.
+ *
+ * Replicates the bootstrapSession() logic from Module::onBootstrap(), converted
+ * to PSR-15 middleware. Skipped for health-check endpoints that must not create
+ * sessions.
+ *
+ * Must run before any middleware that reads or writes the session (e.g.
+ * IdentityTokenRefreshMiddleware, AuthenticationMiddleware).
+ */
+class SessionBootstrapMiddleware implements MiddlewareInterface
+{
+    /**
+     * Paths that must not start a session (health checks, elb ping etc.).
+     */
+    private const array SESSION_EXCLUDED_PATHS = [
+        '/ping/elb',
+        '/ping/json',
+    ];
+
+    public function __construct(
+        private readonly NativeSessionConfig $nativeSessionConfig,
+        private readonly SessionManager $sessionManager,
+        private readonly SessionManagerSupport $sessionManagerSupport,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $path = $request->getUri()->getPath();
+
+        if (!in_array($path, self::SESSION_EXCLUDED_PATHS, true)) {
+            // Configure the save handler (Redis), cookie settings, etc.
+            $this->nativeSessionConfig->configure();
+
+            // Start the session and make this manager the default for all Containers.
+            $this->sessionManager->start();
+            Container::setDefaultManager($this->sessionManager);
+
+            // Regenerate session ID on first visit to prevent fixation.
+            $this->sessionManagerSupport->initialise();
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/service-front/module/Application/src/Middleware/SessionBootstrapMiddleware.php
+++ b/service-front/module/Application/src/Middleware/SessionBootstrapMiddleware.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Application\Middleware;
 
+use Application\Model\Service\Session\NativeSessionConfig;
 use Application\Model\Service\Session\SessionManagerSupport;
+use Laminas\Session\Container;
 use Laminas\Session\SessionManager;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -14,12 +16,17 @@ use Psr\Http\Server\RequestHandlerInterface;
 /**
  * Bootstraps the laminas-session stack on every request that requires a session.
  *
- * NativeSessionConfig::configure() and Container::setDefaultManager() are called
- * earlier, in Module::onBootstrap(), so that the Redis save handler is registered
- * before any Laminas Container subclass (e.g. authentication storage) is constructed
- * during service wiring.  This middleware is responsible only for starting the
- * session (if it has not already been started by a Container constructor) and
- * running the session-ID regeneration logic.
+ * In a pure Mezzio pipeline this middleware is responsible for the full
+ * session setup: configure (save handler, cookie settings) → start → initialise.
+ *
+ * In the Laminas MVC app Module::onBootstrap() calls
+ * NativeSessionConfig::configure() and Container::setDefaultManager() early
+ * so that the correct save handler is in place before any Container subclass
+ * (e.g. Laminas\Authentication\Storage\Session) is constructed during service
+ * wiring.  When that early setup has already run, configure() is a no-op here
+ * because session_status() will be PHP_SESSION_ACTIVE.
+ *
+ * Skipped entirely for health-check endpoints that must not create sessions.
  */
 class SessionBootstrapMiddleware implements MiddlewareInterface
 {
@@ -32,6 +39,7 @@ class SessionBootstrapMiddleware implements MiddlewareInterface
     ];
 
     public function __construct(
+        private readonly NativeSessionConfig $nativeSessionConfig,
         private readonly SessionManager $sessionManager,
         private readonly SessionManagerSupport $sessionManagerSupport,
     ) {
@@ -42,13 +50,14 @@ class SessionBootstrapMiddleware implements MiddlewareInterface
         $path = $request->getUri()->getPath();
 
         if (!in_array($path, self::SESSION_EXCLUDED_PATHS, true)) {
-            // configure() and Container::setDefaultManager() are called early in
-            // Module::onBootstrap() so that the correct save handler is registered
-            // before any Laminas\Session\Container subclass (e.g. authentication
-            // storage) is instantiated during service wiring.
-            // Here we only need to ensure the session is open and initialised.
+            // configure() sets the save handler and ini settings.
+            // In the MVC app this has already been called in Module::onBootstrap(),
+            // so session_status() will be PHP_SESSION_ACTIVE and the call is a no-op.
+            // In a pure Mezzio pipeline it runs here for the first time.
             if (PHP_SESSION_NONE === session_status()) {
+                $this->nativeSessionConfig->configure();
                 $this->sessionManager->start();
+                Container::setDefaultManager($this->sessionManager);
             }
 
             $this->sessionManagerSupport->initialise();

--- a/service-front/module/Application/src/Middleware/TrailingSlashMiddleware.php
+++ b/service-front/module/Application/src/Middleware/TrailingSlashMiddleware.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Middleware;
+
+use Laminas\Diactoros\Response\RedirectResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Redirects any request whose path ends with a trailing slash (other than "/")
+ * to the same URL with the slash removed.
+ *
+ * Replaces the MVC TrailingSlashRedirectListener. In Mezzio we don't need to
+ * verify the stripped path matches a route first — FastRoute will return a 404
+ * for genuinely unknown routes after the redirect anyway.
+ *
+ * Must run before RouteMiddleware so the redirect happens before routing.
+ */
+class TrailingSlashMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $uri  = $request->getUri();
+        $path = $uri->getPath();
+
+        if ($path !== '/' && str_ends_with($path, '/')) {
+            $strippedUri = $uri->withPath(rtrim($path, '/'));
+            return new RedirectResponse((string) $strippedUri, 301);
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/service-front/module/Application/src/Module.php
+++ b/service-front/module/Application/src/Module.php
@@ -154,23 +154,26 @@ use Application\Listener\TrailingSlashRedirectListener;
 use Application\Listener\UserDetailsListener;
 use Application\Listener\ViewVariablesListener;
 use Application\Middleware\AuthenticationMiddleware;
+use Application\Middleware\Factory\IdentityTokenRefreshMiddlewareFactory;
+use Application\Middleware\Factory\RequestLoggingMiddlewareFactory;
+use Application\Middleware\Factory\SessionBootstrapMiddlewareFactory;
+use Application\Middleware\IdentityTokenRefreshMiddleware;
 use Application\Middleware\LpaLoaderMiddleware;
+use Application\Middleware\RequestLoggingMiddleware;
 use Application\Middleware\RouteMatchMiddleware;
+use Application\Middleware\SessionBootstrapMiddleware;
 use Application\Middleware\TermsAndConditionsMiddleware;
 use Application\Middleware\UserDetailsMiddleware;
 use Application\Model\Service\AddressLookup\OrdnanceSurvey;
 use Application\Model\Service\AddressLookup\OrdnanceSurveyFactory;
-use Application\Model\Service\ApiClient\Exception\ApiException;
 use Application\Model\Service\Authentication\Adapter\LpaAuthAdapter;
 use Application\Model\Service\Authentication\AuthenticationService;
-use Application\Model\Service\Authentication\Identity\User as Identity;
 use Application\Model\Service\Date\DateService;
 use Application\Model\Service\Date\IDateService;
 use Application\Model\Service\Lpa\ActorReuseDetailsService;
 use Application\Model\Service\Lpa\Application as LpaApplicationService;
 use Application\Model\Service\Lpa\ContinuationSheets;
 use Application\Model\Service\Redis\RedisClient;
-use Application\Model\Service\Session\ContainerNamespace;
 use Application\Model\Service\Session\FilteringSaveHandler;
 use Application\Model\Service\Session\NativeSessionConfig;
 use Application\Model\Service\Session\PersistentSessionDetails;
@@ -178,6 +181,7 @@ use Application\Model\Service\Session\SessionManagerSupport;
 use Application\Model\Service\Session\SessionUtility;
 use Application\Model\Service\Session\WritePolicy;
 use Application\Model\Service\User\Details;
+use Laminas\Http\PhpEnvironment\Request as HttpRequest;
 use Application\Service\AccordionService;
 use Application\Service\CompleteViewParamsHelper;
 use Application\Service\Factory\AccordionServiceFactory;
@@ -189,7 +193,6 @@ use Application\Service\SystemMessage;
 use Application\View\Twig\AppFiltersExtension;
 use Application\View\Twig\AppFunctionsExtension;
 use Aws\DynamoDb\DynamoDbClient;
-use Laminas\Http\PhpEnvironment\Request as HttpRequest;
 use Laminas\ModuleManager\Feature\FormElementProviderInterface;
 use Laminas\Mvc\ModuleRouteListener;
 use Laminas\Mvc\MvcEvent;
@@ -202,7 +205,6 @@ use Laminas\Session\Container;
 use Laminas\Session\SessionManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\View\Model\ViewModel;
-use MakeShared\Constants;
 use MakeShared\DataModel\Lpa\Payment\Calculator;
 use MakeShared\Logging\LoggerFactory;
 use MakeShared\Telemetry\Exporter\ExporterFactory;
@@ -245,117 +247,25 @@ class Module implements FormElementProviderInterface
 
         $serviceManager = $application->getServiceManager();
         $request = $application->getRequest();
-        $logger = $serviceManager->get(LoggerInterface::class);
+        $dateService = $serviceManager->get(DateService::class);
 
-        // Add request context to logs as a processor
+        // Configure the session and register our SessionManager as the default for all
+        // Laminas\Session\Container instances.  This must happen in onBootstrap — before
+        // any Container subclass (e.g. Laminas\Authentication\Storage\Session) is
+        // instantiated during the service-wiring phase — otherwise AbstractContainer
+        // creates a bare SessionManager with no save handler and calls session_start()
+        // before our middleware has a chance to configure Redis.
         if ($request instanceof HttpRequest) {
-            $logger->pushProcessor(function ($record) use ($request) {
-                $record['extra']['request_path'] = $request->getUri()->getPath();
-                $record['extra']['request_method'] = $request->getMethod();
-
-                if ($request->getHeader('X-Request-ID')) {
-                    $record['extra'][Constants::TRACE_ID_FIELD_NAME] =  $request->getHeader('X-Request-ID')->getFieldValue() ?? '';
-                }
-
-                return $record;
-            });
-
-            $path = $request->getUri()->getPath();
-
-            // Only bootstrap the session if it's *not* PHPUnit AND is not an excluded url.
-            if (
-                !strstr($request->getServer('SCRIPT_NAME'), 'phpunit') &&
-                !in_array($path, [
-                    // URLs excluded from creating a session
-                    '/ping/elb',
-                    '/ping/json',
-                ])
-            ) {
-                $sessionManager = $this->bootstrapSession($e);
-                $this->bootstrapIdentity($e, $path != '/session-state');
-
-                $authenticationService = $serviceManager->get(AuthenticationService::class);
-                $sessionUtility = $serviceManager->get(SessionUtility::class);
-                $userService = $serviceManager->get(Details::class);
-                $dateService = $serviceManager->get(DateService::class);
-
-                // Listeners that run on every request, just before controllers execute (higher priority numbers run first)
-                new CurrentRouteListener()->attach($eventManager, 1004);
-                new AuthenticationListener($sessionUtility, $authenticationService)->attach($eventManager, 1003);
-                new UserDetailsListener($sessionUtility, $userService, $authenticationService, $sessionManager, $logger)->attach($eventManager, 1002);
-
-                // Listeners that run on every request, just before view is rendered (higher priority numbers run first)
-                new ViewVariablesListener($dateService)->attach($eventManager, 1001);
-                new LpaViewInjectListener()->attach($eventManager, 1000);
-            }
+            $serviceManager->get(NativeSessionConfig::class)->configure();
+            Container::setDefaultManager($serviceManager->get('SessionManager'));
         }
-    }
 
-    /**
-     * Sets up and starts global sessions.
-     *
-     * @param MvcEvent $e
-     */
-    private function bootstrapSession(MvcEvent $e): SessionManager
-    {
-        $sm = $e->getApplication()->getServiceManager();
+        // Listeners that run on every request, just before controllers execute (higher priority numbers run first)
+        new CurrentRouteListener()->attach($eventManager, 1004);
 
-        $nativeSession = $sm->get(NativeSessionConfig::class);
-        $nativeSession->configure();
-
-        /** @var SessionManager $session */
-        $sessionManager = $sm->get('SessionManager');
-
-        // Always starts the session.
-        $sessionManager->start();
-
-        // Ensures this SessionManager is used for all Session Containers.
-        Container::setDefaultManager($sessionManager);
-
-        $sm->get(SessionManagerSupport::class)->initialise();
-
-        return $sessionManager;
-    }
-
-    /**
-     *
-     * This now checks the token on every request otherwise we have no method of knowing if the user has
-     * logged in on another browser.
-     *
-     * We don't deal with forcing the user to re-authenticate here as they
-     * may be accessing a page that does not require authentication.
-     *
-     * @param MvcEvent $e
-     */
-    private function bootstrapIdentity(MvcEvent $e, bool $updateToken = true)
-    {
-        $sm = $e->getApplication()->getServiceManager();
-        $authenticationService = $sm->get(AuthenticationService::class);
-        /** @var Identity $identity */
-        $identity = $authenticationService->getIdentity();
-
-        //  If there is an identity (logged in user) then get the token details and check to see if it has expired
-        if (!is_null($identity) && $updateToken) {
-            try {
-                $info = $sm->get('UserService')->getTokenInfo($identity->token());
-
-                if ($info['success'] && !is_null($info['expiresIn'])) {
-                    // update the time the token expires in the session
-                    $identity->tokenExpiresIn($info['expiresIn']);
-                } else {
-                    $authenticationService->clearIdentity();
-
-                    // Record that identity was cleared because of a 500 error (normally db-related)
-                    if ($info['failureCode'] >= 500) {
-                        $sessionUtility = $sm->get(SessionUtility::class);
-                        $sessionUtility->setInMvc(ContainerNamespace::AUTH_FAILURE_REASON, 'reason', 'Internal system error');
-                        $sessionUtility->setInMvc(ContainerNamespace::AUTH_FAILURE_REASON, 'code', $info['failureCode']);
-                    }
-                }
-            } catch (ApiException $ex) {
-                $authenticationService->clearIdentity();
-            }
-        }
+        // Listeners that run on every request, just before view is rendered (higher priority numbers run first)
+        new ViewVariablesListener($dateService)->attach($eventManager, 1001);
+        new LpaViewInjectListener()->attach($eventManager, 1000);
     }
 
     public function getServiceConfig()
@@ -369,6 +279,7 @@ class Module implements FormElementProviderInterface
                 AuthenticationService::class => 'AuthenticationService',
                 ServiceLocatorInterface::class => ServiceManager::class,
                 IDateService::class => DateService::class,
+                SessionManager::class => 'SessionManager',
             ],
             'factories' => [
                 'ApiClient'             => 'Application\Model\Service\ApiClient\ClientFactory',
@@ -586,6 +497,9 @@ class Module implements FormElementProviderInterface
                 },
 
                 RouteMatchMiddleware::class => InvokableFactory::class,
+                RequestLoggingMiddleware::class => RequestLoggingMiddlewareFactory::class,
+                SessionBootstrapMiddleware::class => SessionBootstrapMiddlewareFactory::class,
+                IdentityTokenRefreshMiddleware::class => IdentityTokenRefreshMiddlewareFactory::class,
 
                 RegisterHandler::class => RegisterHandlerFactory::class,
                 ResendActivationEmailHandler::class => ResendActivationEmailHandlerFactory::class,

--- a/service-front/module/Application/src/Service/Factory/ActorReuseDetailsServiceFactory.php
+++ b/service-front/module/Application/src/Service/Factory/ActorReuseDetailsServiceFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Application\Model\Service\Lpa\ActorReuseDetailsService;
+use Application\Model\Service\Lpa\Application as LpaApplicationService;
+use Application\Model\Service\Session\SessionUtility;
+use Psr\Container\ContainerInterface;
+
+class ActorReuseDetailsServiceFactory
+{
+    public function __invoke(ContainerInterface $container): ActorReuseDetailsService
+    {
+        return new ActorReuseDetailsService(
+            $container->get(LpaApplicationService::class),
+            $container->get(SessionUtility::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/AppFiltersExtensionFactory.php
+++ b/service-front/module/Application/src/Service/Factory/AppFiltersExtensionFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Application\View\Twig\AppFiltersExtension;
+use Psr\Container\ContainerInterface;
+
+class AppFiltersExtensionFactory
+{
+    public function __invoke(ContainerInterface $container): AppFiltersExtension
+    {
+        return new AppFiltersExtension($container->get('config'));
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/AppFunctionsExtensionFactory.php
+++ b/service-front/module/Application/src/Service/Factory/AppFunctionsExtensionFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Application\Form\Error\FormLinkedErrors;
+use Application\Service\AccordionService;
+use Application\Service\NavigationViewModelHelper;
+use Application\Service\SystemMessage;
+use Application\View\Twig\AppFunctionsExtension;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Container\ContainerInterface;
+
+class AppFunctionsExtensionFactory
+{
+    public function __invoke(ContainerInterface $container): AppFunctionsExtension
+    {
+        return new AppFunctionsExtension(
+            $container->get('config'),
+            $container->get(FormLinkedErrors::class),
+            $container->get(TemplateRendererInterface::class),
+            $container->get(SystemMessage::class),
+            $container->get(AccordionService::class),
+            $container->get(NavigationViewModelHelper::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/DynamoDbSystemMessageCacheFactory.php
+++ b/service-front/module/Application/src/Service/Factory/DynamoDbSystemMessageCacheFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Application\Adapter\DynamoDbKeyValueStore;
+use Psr\Container\ContainerInterface;
+
+class DynamoDbSystemMessageCacheFactory
+{
+    public function __invoke(ContainerInterface $container): DynamoDbKeyValueStore
+    {
+        $config = $container->get('config')['admin']['dynamodb'];
+        $config['keyPrefix'] = $container->get('config')['stack']['name'];
+
+        $dynamoDbAdapter = new DynamoDbKeyValueStore($config);
+        $dynamoDbAdapter->setDynamoDbClient($container->get('DynamoDbSystemMessageClient'));
+
+        return $dynamoDbAdapter;
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/DynamoDbSystemMessageClientFactory.php
+++ b/service-front/module/Application/src/Service/Factory/DynamoDbSystemMessageClientFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Aws\DynamoDb\DynamoDbClient;
+use Psr\Container\ContainerInterface;
+
+class DynamoDbSystemMessageClientFactory
+{
+    public function __invoke(ContainerInterface $container): DynamoDbClient
+    {
+        return new DynamoDbClient(
+            $container->get('config')['admin']['dynamodb']['client'],
+        );
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/FormLinkedErrorsFactory.php
+++ b/service-front/module/Application/src/Service/Factory/FormLinkedErrorsFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Application\Form\Error\FormLinkedErrors;
+use Psr\Container\ContainerInterface;
+
+class FormLinkedErrorsFactory
+{
+    public function __invoke(ContainerInterface $container): FormLinkedErrors
+    {
+        return new FormLinkedErrors();
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/GovPayClientFactory.php
+++ b/service-front/module/Application/src/Service/Factory/GovPayClientFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Alphagov\Pay\Client as GovPayClient;
+use Psr\Container\ContainerInterface;
+
+class GovPayClientFactory
+{
+    public function __invoke(ContainerInterface $container): GovPayClient
+    {
+        $config = $container->get('config')['alphagov']['pay'];
+
+        return new GovPayClient([
+            'apiKey'     => $config['key'],
+            'httpClient' => $container->get('HttpClient'),
+            'baseUrl'    => $config['url'],
+        ]);
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/HttpClientFactory.php
+++ b/service-front/module/Application/src/Service/Factory/HttpClientFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Http\Adapter\Guzzle7\Client;
+use Psr\Container\ContainerInterface;
+
+class HttpClientFactory
+{
+    public function __invoke(ContainerInterface $container): Client
+    {
+        return new Client();
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/LpaAuthAdapterFactory.php
+++ b/service-front/module/Application/src/Service/Factory/LpaAuthAdapterFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Application\Model\Service\Authentication\Adapter\LpaAuthAdapter;
+use Psr\Container\ContainerInterface;
+
+class LpaAuthAdapterFactory
+{
+    public function __invoke(ContainerInterface $container): LpaAuthAdapter
+    {
+        return new LpaAuthAdapter($container->get('ApiClient'));
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/NativeSessionConfigFactory.php
+++ b/service-front/module/Application/src/Service/Factory/NativeSessionConfigFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Application\Model\Service\Session\NativeSessionConfig;
+use Psr\Container\ContainerInterface;
+
+class NativeSessionConfigFactory
+{
+    public function __invoke(ContainerInterface $container): NativeSessionConfig
+    {
+        $settings = $container->get('config')['session']['native_settings'] ?? [];
+
+        return new NativeSessionConfig(
+            $settings,
+            $container->get('SaveHandler'),
+        );
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/RedisClientFactory.php
+++ b/service-front/module/Application/src/Service/Factory/RedisClientFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Application\Model\Service\Redis\RedisClient;
+use Psr\Container\ContainerInterface;
+use Redis;
+
+class RedisClientFactory
+{
+    public function __invoke(ContainerInterface $container): RedisClient
+    {
+        $config = $container->get('config');
+
+        return new RedisClient(
+            $config['redis']['url'],
+            $config['redis']['ttlMs'],
+            new Redis(),
+        );
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/SaveHandlerFactory.php
+++ b/service-front/module/Application/src/Service/Factory/SaveHandlerFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Application\Model\Service\Session\FilteringSaveHandler;
+use Application\Model\Service\Session\WritePolicy;
+use Application\Model\Service\Redis\RedisClient;
+use Psr\Container\ContainerInterface;
+
+class SaveHandlerFactory
+{
+    public function __invoke(ContainerInterface $container): FilteringSaveHandler
+    {
+        $redisClient = $container->get(RedisClient::class);
+        $policy = $container->has(WritePolicy::class) ? $container->get(WritePolicy::class) : null;
+
+        $filter = static function () use ($policy) {
+            return $policy === null ? empty($_SERVER['HTTP_X_SESSIONREADONLY']) : $policy->allowsWrite();
+        };
+
+        return new FilteringSaveHandler($redisClient, [$filter]);
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/SessionManagerSupportFactory.php
+++ b/service-front/module/Application/src/Service/Factory/SessionManagerSupportFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Application\Model\Service\Session\SessionManagerSupport;
+use Application\Model\Service\Session\SessionUtility;
+use Psr\Container\ContainerInterface;
+
+class SessionManagerSupportFactory
+{
+    public function __invoke(ContainerInterface $container): SessionManagerSupport
+    {
+        return new SessionManagerSupport(
+            $container->get('SessionManager'),
+            $container->get(SessionUtility::class),
+        );
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/SessionMiddlewareFactory.php
+++ b/service-front/module/Application/src/Service/Factory/SessionMiddlewareFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Mezzio\Session\Ext\PhpSessionPersistence;
+use Mezzio\Session\SessionMiddleware;
+use Psr\Container\ContainerInterface;
+
+class SessionMiddlewareFactory
+{
+    public function __invoke(ContainerInterface $container): SessionMiddleware
+    {
+        return new SessionMiddleware(new PhpSessionPersistence());
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/TelemetryTracerFactory.php
+++ b/service-front/module/Application/src/Service/Factory/TelemetryTracerFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use MakeShared\Telemetry\Exporter\ExporterFactory;
+use MakeShared\Telemetry\Tracer;
+use Psr\Container\ContainerInterface;
+
+class TelemetryTracerFactory
+{
+    public function __invoke(ContainerInterface $container): Tracer
+    {
+        $telemetryConfig = $container->get('config')['telemetry'];
+
+        return Tracer::create(
+            $container->get(ExporterFactory::class),
+            $telemetryConfig,
+        );
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/TwigViewRendererFactory.php
+++ b/service-front/module/Application/src/Service/Factory/TwigViewRendererFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Psr\Container\ContainerInterface;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+class TwigViewRendererFactory
+{
+    public function __invoke(ContainerInterface $container): Environment
+    {
+        $loader = new FilesystemLoader('module/Application/view/application');
+
+        return new Environment(
+            $loader,
+            ['cache' => $container->get('config')['twig']['cache_dir']],
+        );
+    }
+}

--- a/service-front/module/Application/src/Service/Factory/WritePolicyFactory.php
+++ b/service-front/module/Application/src/Service/Factory/WritePolicyFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Application\Model\Service\Session\WritePolicy;
+use Psr\Container\ContainerInterface;
+
+/**
+ * In Mezzio context there is no Laminas\Http\PhpEnvironment\Request, so WritePolicy
+ * is constructed without one. It falls back to checking $_SERVER['HTTP_X_SESSIONREADONLY']
+ * directly, which is sufficient for PSR-7 usage.
+ */
+class WritePolicyFactory
+{
+    public function __invoke(ContainerInterface $container): WritePolicy
+    {
+        return new WritePolicy();
+    }
+}

--- a/service-front/module/Application/tests/Form/Factory/CsrfBuilderFactoryTest.php
+++ b/service-front/module/Application/tests/Form/Factory/CsrfBuilderFactoryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Form\Factory;
+
+use Application\Form\Element\CsrfBuilder;
+use Application\Form\Factory\CsrfBuilderFactory;
+use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
+
+class CsrfBuilderFactoryTest extends TestCase
+{
+    public function testFactoryReturnsCsrfBuilder(): void
+    {
+        // CsrfBuilder requires a ServiceManager (not just ContainerInterface)
+        // because it acts as a service-locator factory internally.
+        $serviceManager = $this->createMock(ServiceManager::class);
+
+        $builder = (new CsrfBuilderFactory())($serviceManager);
+
+        $this->assertInstanceOf(CsrfBuilder::class, $builder);
+    }
+}

--- a/service-front/module/Application/tests/Handler/Factory/AccessibilityHandlerFactoryTest.php
+++ b/service-front/module/Application/tests/Handler/Factory/AccessibilityHandlerFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Handler\Factory;
+
+use Application\Handler\AccessibilityHandler;
+use Application\Handler\Factory\AccessibilityHandlerFactory;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class AccessibilityHandlerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsAccessibilityHandler(): void
+    {
+        $renderer = $this->createMock(TemplateRendererInterface::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with(TemplateRendererInterface::class)
+            ->willReturn($renderer);
+
+        $handler = (new AccessibilityHandlerFactory())($container);
+
+        $this->assertInstanceOf(AccessibilityHandler::class, $handler);
+    }
+}

--- a/service-front/module/Application/tests/Handler/Factory/ContactHandlerFactoryTest.php
+++ b/service-front/module/Application/tests/Handler/Factory/ContactHandlerFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Handler\Factory;
+
+use Application\Handler\ContactHandler;
+use Application\Handler\Factory\ContactHandlerFactory;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class ContactHandlerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsContactHandler(): void
+    {
+        $renderer = $this->createMock(TemplateRendererInterface::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with(TemplateRendererInterface::class)
+            ->willReturn($renderer);
+
+        $handler = (new ContactHandlerFactory())($container);
+
+        $this->assertInstanceOf(ContactHandler::class, $handler);
+    }
+}

--- a/service-front/module/Application/tests/Handler/Factory/EnableCookieHandlerFactoryTest.php
+++ b/service-front/module/Application/tests/Handler/Factory/EnableCookieHandlerFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Handler\Factory;
+
+use Application\Handler\EnableCookieHandler;
+use Application\Handler\Factory\EnableCookieHandlerFactory;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class EnableCookieHandlerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsEnableCookieHandler(): void
+    {
+        $renderer = $this->createMock(TemplateRendererInterface::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with(TemplateRendererInterface::class)
+            ->willReturn($renderer);
+
+        $handler = (new EnableCookieHandlerFactory())($container);
+
+        $this->assertInstanceOf(EnableCookieHandler::class, $handler);
+    }
+}

--- a/service-front/module/Application/tests/Handler/Factory/PrivacyHandlerFactoryTest.php
+++ b/service-front/module/Application/tests/Handler/Factory/PrivacyHandlerFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Handler\Factory;
+
+use Application\Handler\Factory\PrivacyHandlerFactory;
+use Application\Handler\PrivacyHandler;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class PrivacyHandlerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsPrivacyHandler(): void
+    {
+        $renderer = $this->createMock(TemplateRendererInterface::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with(TemplateRendererInterface::class)
+            ->willReturn($renderer);
+
+        $handler = (new PrivacyHandlerFactory())($container);
+
+        $this->assertInstanceOf(PrivacyHandler::class, $handler);
+    }
+}

--- a/service-front/module/Application/tests/Handler/Factory/TermsHandlerFactoryTest.php
+++ b/service-front/module/Application/tests/Handler/Factory/TermsHandlerFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Handler\Factory;
+
+use Application\Handler\Factory\TermsHandlerFactory;
+use Application\Handler\TermsHandler;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class TermsHandlerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsTermsHandler(): void
+    {
+        $renderer = $this->createMock(TemplateRendererInterface::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with(TemplateRendererInterface::class)
+            ->willReturn($renderer);
+
+        $handler = (new TermsHandlerFactory())($container);
+
+        $this->assertInstanceOf(TermsHandler::class, $handler);
+    }
+}

--- a/service-front/module/Application/tests/Helper/RouteMiddlewareHelperTest.php
+++ b/service-front/module/Application/tests/Helper/RouteMiddlewareHelperTest.php
@@ -6,8 +6,11 @@ namespace ApplicationTest\Helper;
 
 use Application\Helper\RouteMiddlewareHelper;
 use Application\Middleware\AuthenticationMiddleware;
+use Application\Middleware\IdentityTokenRefreshMiddleware;
 use Application\Middleware\LpaLoaderMiddleware;
+use Application\Middleware\RequestLoggingMiddleware;
 use Application\Middleware\RouteMatchMiddleware;
+use Application\Middleware\SessionBootstrapMiddleware;
 use Application\Middleware\TermsAndConditionsMiddleware;
 use Application\Middleware\UserDetailsMiddleware;
 use Laminas\Mvc\Middleware\PipeSpec;
@@ -16,6 +19,9 @@ use PHPUnit\Framework\TestCase;
 class RouteMiddlewareHelperTest extends TestCase
 {
     private const FULL_STACK = [
+        RequestLoggingMiddleware::class,
+        SessionBootstrapMiddleware::class,
+        IdentityTokenRefreshMiddleware::class,
         RouteMatchMiddleware::class,
         AuthenticationMiddleware::class,
         UserDetailsMiddleware::class,
@@ -77,9 +83,22 @@ class RouteMiddlewareHelperTest extends TestCase
 
     public function testAllMiddlewareCanBeIgnored(): void
     {
-        $result = RouteMiddlewareHelper::addMiddleware('SomeHandler', self::FULL_STACK);
+        $ignorable = [
+            RouteMatchMiddleware::class,
+            AuthenticationMiddleware::class,
+            UserDetailsMiddleware::class,
+            TermsAndConditionsMiddleware::class,
+            LpaLoaderMiddleware::class,
+        ];
 
-        $this->assertSame(['SomeHandler'], $result->getSpec());
+        $result = RouteMiddlewareHelper::addMiddleware('SomeHandler', $ignorable);
+
+        $this->assertSame([
+            RequestLoggingMiddleware::class,
+            SessionBootstrapMiddleware::class,
+            IdentityTokenRefreshMiddleware::class,
+            'SomeHandler',
+        ], $result->getSpec());
     }
 
     public function testIgnoringNonExistentMiddlewareHasNoEffect(): void

--- a/service-front/module/Application/tests/Middleware/AuthenticationMiddlewareTest.php
+++ b/service-front/module/Application/tests/Middleware/AuthenticationMiddlewareTest.php
@@ -220,12 +220,12 @@ class AuthenticationMiddlewareTest extends TestCase
             ->method('unsetInMvc')
             ->with(ContainerNamespace::USER_DETAILS, 'user');
 
-        $expectedUrl = '/login?state=' . $expectedState;
+        $expectedUrl = '/login/' . $expectedState;
         $urlHelper = $this->createMock(UrlHelper::class);
         $urlHelper
             ->expects($this->once())
             ->method('generate')
-            ->with('login', [], ['state' => $expectedState])
+            ->with('login', ['state' => $expectedState])
             ->willReturn($expectedUrl);
 
         $request = (new ServerRequest(uri: $requestPath))->withAttribute(RouteResult::class, $routeResult);

--- a/service-front/module/Application/tests/Middleware/Factory/AuthenticationMiddlewareFactoryTest.php
+++ b/service-front/module/Application/tests/Middleware/Factory/AuthenticationMiddlewareFactoryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Middleware\Factory;
+
+use Application\Middleware\AuthenticationMiddleware;
+use Application\Middleware\Factory\AuthenticationMiddlewareFactory;
+use Application\Model\Service\Authentication\AuthenticationService;
+use Application\Model\Service\Session\SessionUtility;
+use Mezzio\Helper\UrlHelper;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class AuthenticationMiddlewareFactoryTest extends TestCase
+{
+    public function testFactoryReturnsAuthenticationMiddleware(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            SessionUtility::class        => $this->createMock(SessionUtility::class),
+            AuthenticationService::class => $this->createMock(AuthenticationService::class),
+            UrlHelper::class             => $this->createMock(UrlHelper::class),
+        });
+
+        $middleware = (new AuthenticationMiddlewareFactory())($container);
+
+        $this->assertInstanceOf(AuthenticationMiddleware::class, $middleware);
+    }
+}

--- a/service-front/module/Application/tests/Middleware/Factory/IdentityTokenRefreshMiddlewareFactoryTest.php
+++ b/service-front/module/Application/tests/Middleware/Factory/IdentityTokenRefreshMiddlewareFactoryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Middleware\Factory;
+
+use Application\Middleware\Factory\IdentityTokenRefreshMiddlewareFactory;
+use Application\Middleware\IdentityTokenRefreshMiddleware;
+use Application\Model\Service\Authentication\AuthenticationService;
+use Application\Model\Service\Session\SessionUtility;
+use Application\Model\Service\User\Details as UserService;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class IdentityTokenRefreshMiddlewareFactoryTest extends TestCase
+{
+    public function testFactoryReturnsIdentityTokenRefreshMiddleware(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            AuthenticationService::class => $this->createMock(AuthenticationService::class),
+            UserService::class           => $this->createMock(UserService::class),
+            SessionUtility::class        => $this->createMock(SessionUtility::class),
+        });
+
+        $middleware = (new IdentityTokenRefreshMiddlewareFactory())($container);
+
+        $this->assertInstanceOf(IdentityTokenRefreshMiddleware::class, $middleware);
+    }
+}

--- a/service-front/module/Application/tests/Middleware/Factory/LpaLoaderMiddlewareFactoryTest.php
+++ b/service-front/module/Application/tests/Middleware/Factory/LpaLoaderMiddlewareFactoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Middleware\Factory;
+
+use Application\Helper\MvcUrlHelper;
+use Application\Middleware\Factory\LpaLoaderMiddlewareFactory;
+use Application\Middleware\LpaLoaderMiddleware;
+use Application\Model\Service\Lpa\Application as LpaApplicationService;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class LpaLoaderMiddlewareFactoryTest extends TestCase
+{
+    public function testFactoryReturnsLpaLoaderMiddleware(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            LpaApplicationService::class => $this->createMock(LpaApplicationService::class),
+            MvcUrlHelper::class          => $this->createMock(MvcUrlHelper::class),
+        });
+
+        $middleware = (new LpaLoaderMiddlewareFactory())($container);
+
+        $this->assertInstanceOf(LpaLoaderMiddleware::class, $middleware);
+    }
+}

--- a/service-front/module/Application/tests/Middleware/Factory/RequestLoggingMiddlewareFactoryTest.php
+++ b/service-front/module/Application/tests/Middleware/Factory/RequestLoggingMiddlewareFactoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Middleware\Factory;
+
+use Application\Middleware\Factory\RequestLoggingMiddlewareFactory;
+use Application\Middleware\RequestLoggingMiddleware;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+class RequestLoggingMiddlewareFactoryTest extends TestCase
+{
+    public function testFactoryReturnsRequestLoggingMiddleware(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with(LoggerInterface::class)
+            ->willReturn($this->createMock(LoggerInterface::class));
+
+        $middleware = (new RequestLoggingMiddlewareFactory())($container);
+
+        $this->assertInstanceOf(RequestLoggingMiddleware::class, $middleware);
+    }
+}

--- a/service-front/module/Application/tests/Middleware/Factory/SessionBootstrapMiddlewareFactoryTest.php
+++ b/service-front/module/Application/tests/Middleware/Factory/SessionBootstrapMiddlewareFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Middleware\Factory;
+
+use Application\Middleware\Factory\SessionBootstrapMiddlewareFactory;
+use Application\Middleware\SessionBootstrapMiddleware;
+use Application\Model\Service\Session\NativeSessionConfig;
+use Application\Model\Service\Session\SessionManagerSupport;
+use Laminas\Session\SaveHandler\SaveHandlerInterface;
+use Laminas\Session\SessionManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class SessionBootstrapMiddlewareFactoryTest extends TestCase
+{
+    public function testFactoryReturnsSessionBootstrapMiddleware(): void
+    {
+        // NativeSessionConfig is final — construct a real instance.
+        $nativeSessionConfig = new NativeSessionConfig([], $this->createMock(SaveHandlerInterface::class));
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            NativeSessionConfig::class   => $nativeSessionConfig,
+            'SessionManager'             => $this->createMock(SessionManager::class),
+            SessionManagerSupport::class => $this->createMock(SessionManagerSupport::class),
+        });
+
+        $middleware = (new SessionBootstrapMiddlewareFactory())($container);
+
+        $this->assertInstanceOf(SessionBootstrapMiddleware::class, $middleware);
+    }
+}

--- a/service-front/module/Application/tests/Middleware/Factory/TermsAndConditionsMiddlewareFactoryTest.php
+++ b/service-front/module/Application/tests/Middleware/Factory/TermsAndConditionsMiddlewareFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Middleware\Factory;
+
+use Application\Middleware\Factory\TermsAndConditionsMiddlewareFactory;
+use Application\Middleware\TermsAndConditionsMiddleware;
+use Application\Model\Service\Authentication\AuthenticationService;
+use Application\Model\Service\Session\SessionUtility;
+use Mezzio\Helper\UrlHelper;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class TermsAndConditionsMiddlewareFactoryTest extends TestCase
+{
+    public function testFactoryReturnsTermsAndConditionsMiddleware(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            'config'                     => ['terms' => ['lastUpdated' => '2020-01-01']],
+            SessionUtility::class        => $this->createMock(SessionUtility::class),
+            AuthenticationService::class => $this->createMock(AuthenticationService::class),
+            UrlHelper::class             => $this->createMock(UrlHelper::class),
+        });
+
+        $middleware = (new TermsAndConditionsMiddlewareFactory())($container);
+
+        $this->assertInstanceOf(TermsAndConditionsMiddleware::class, $middleware);
+    }
+}

--- a/service-front/module/Application/tests/Middleware/Factory/UserDetailsMiddlewareFactoryTest.php
+++ b/service-front/module/Application/tests/Middleware/Factory/UserDetailsMiddlewareFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Middleware\Factory;
+
+use Application\Middleware\Factory\UserDetailsMiddlewareFactory;
+use Application\Middleware\UserDetailsMiddleware;
+use Application\Model\Service\Authentication\AuthenticationService;
+use Application\Model\Service\Session\SessionUtility;
+use Application\Model\Service\User\Details;
+use Laminas\Session\SessionManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+class UserDetailsMiddlewareFactoryTest extends TestCase
+{
+    public function testFactoryReturnsUserDetailsMiddleware(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            SessionUtility::class        => $this->createMock(SessionUtility::class),
+            Details::class               => $this->createMock(Details::class),
+            AuthenticationService::class => $this->createMock(AuthenticationService::class),
+            'SessionManager'             => $this->createMock(SessionManager::class),
+            LoggerInterface::class       => $this->createMock(LoggerInterface::class),
+        });
+
+        $middleware = (new UserDetailsMiddlewareFactory())($container);
+
+        $this->assertInstanceOf(UserDetailsMiddleware::class, $middleware);
+    }
+}

--- a/service-front/module/Application/tests/Middleware/IdentityTokenRefreshMiddlewareTest.php
+++ b/service-front/module/Application/tests/Middleware/IdentityTokenRefreshMiddlewareTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Middleware;
+
+use Application\Middleware\IdentityTokenRefreshMiddleware;
+use Application\Model\Service\ApiClient\Exception\ApiException;
+use Application\Model\Service\Authentication\AuthenticationService;
+use Application\Model\Service\Authentication\Identity\User as Identity;
+use Application\Model\Service\Session\ContainerNamespace;
+use Application\Model\Service\Session\SessionUtility;
+use Application\Model\Service\User\Details as UserService;
+use DateTime;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\ServerRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class IdentityTokenRefreshMiddlewareTest extends TestCase
+{
+    private AuthenticationService&MockObject $authService;
+    private UserService&MockObject $userService;
+    private SessionUtility&MockObject $sessionUtility;
+    private IdentityTokenRefreshMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->authService    = $this->createMock(AuthenticationService::class);
+        $this->userService    = $this->createMock(UserService::class);
+        $this->sessionUtility = $this->createMock(SessionUtility::class);
+
+        $this->middleware = new IdentityTokenRefreshMiddleware(
+            $this->authService,
+            $this->userService,
+            $this->sessionUtility,
+        );
+    }
+
+    private function makeHandler(): RequestHandlerInterface
+    {
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn(new Response());
+        return $handler;
+    }
+
+    private function makeIdentity(string $token = 'test-token'): Identity
+    {
+        return new Identity('user-123', $token, 3600, new DateTime());
+    }
+
+    // -------------------------------------------------------------------------
+    // Excluded paths
+    // -------------------------------------------------------------------------
+
+    public function testSkipsRefreshForPingElb(): void
+    {
+        $this->authService->expects($this->never())->method('getIdentity');
+
+        $request = new ServerRequest(uri: 'https://example.com/ping/elb');
+        $this->middleware->process($request, $this->makeHandler());
+    }
+
+    public function testSkipsRefreshForPingJson(): void
+    {
+        $this->authService->expects($this->never())->method('getIdentity');
+
+        $request = new ServerRequest(uri: 'https://example.com/ping/json');
+        $this->middleware->process($request, $this->makeHandler());
+    }
+
+    // -------------------------------------------------------------------------
+    // No identity
+    // -------------------------------------------------------------------------
+
+    public function testDoesNothingWhenNoIdentity(): void
+    {
+        $this->authService->expects($this->once())->method('getIdentity')->willReturn(null);
+        $this->userService->expects($this->never())->method('getTokenInfo');
+
+        $request = new ServerRequest(uri: 'https://example.com/dashboard');
+        $this->middleware->process($request, $this->makeHandler());
+    }
+
+    // -------------------------------------------------------------------------
+    // /session-state path — identity checked but token NOT refreshed
+    // -------------------------------------------------------------------------
+
+    public function testSkipsTokenUpdateForSessionStatePath(): void
+    {
+        $this->authService->expects($this->once())->method('getIdentity')->willReturn(null);
+        $this->userService->expects($this->never())->method('getTokenInfo');
+
+        $request = new ServerRequest(uri: 'https://example.com/session-state');
+        $this->middleware->process($request, $this->makeHandler());
+    }
+
+    // -------------------------------------------------------------------------
+    // Token refresh success
+    // -------------------------------------------------------------------------
+
+    public function testUpdatesTokenExpiryOnSuccess(): void
+    {
+        $identity = $this->makeIdentity();
+
+        $this->authService->expects($this->once())->method('getIdentity')->willReturn($identity);
+        $this->userService->expects($this->once())
+            ->method('getTokenInfo')
+            ->with('test-token')
+            ->willReturn(['success' => true, 'expiresIn' => 1800, 'failureCode' => null]);
+
+        $this->authService->expects($this->never())->method('clearIdentity');
+
+        $request = new ServerRequest(uri: 'https://example.com/dashboard');
+        $this->middleware->process($request, $this->makeHandler());
+
+        // tokenExpiresIn stores via tokenExpiresIn() mutator — assert it was called
+        // by verifying the identity still has an expiry (non-null tokenExpiresAt)
+        $this->assertNotNull($identity->tokenExpiresAt());
+    }
+
+    // -------------------------------------------------------------------------
+    // Token refresh failure — non-500
+    // -------------------------------------------------------------------------
+
+    public function testClearsIdentityOnNonSuccessResponse(): void
+    {
+        $identity = $this->makeIdentity();
+
+        $this->authService->expects($this->once())->method('getIdentity')->willReturn($identity);
+        $this->userService->expects($this->once())
+            ->method('getTokenInfo')
+            ->willReturn(['success' => false, 'expiresIn' => null, 'failureCode' => 401]);
+
+        $this->authService->expects($this->once())->method('clearIdentity');
+        $this->sessionUtility->expects($this->never())->method('setInMvc');
+
+        $request = new ServerRequest(uri: 'https://example.com/dashboard');
+        $this->middleware->process($request, $this->makeHandler());
+    }
+
+    // -------------------------------------------------------------------------
+    // Token refresh failure — 500-class error
+    // -------------------------------------------------------------------------
+
+    public function testRecordsInternalSystemErrorInSessionOn500(): void
+    {
+        $identity = $this->makeIdentity();
+
+        $this->authService->expects($this->once())->method('getIdentity')->willReturn($identity);
+        $this->userService->expects($this->once())
+            ->method('getTokenInfo')
+            ->willReturn(['success' => false, 'expiresIn' => null, 'failureCode' => 503]);
+
+        $this->authService->expects($this->once())->method('clearIdentity');
+
+        $this->sessionUtility->expects($this->exactly(2))
+            ->method('setInMvc')
+            ->willReturnCallback(function (string $namespace, string $key, mixed $value): void {
+                static $calls = [];
+                $calls[] = [$namespace, $key, $value];
+            });
+
+        $request = new ServerRequest(uri: 'https://example.com/dashboard');
+        $this->middleware->process($request, $this->makeHandler());
+    }
+
+    public function testRecordsFailureReasonNamespaceAndCode(): void
+    {
+        $identity = $this->makeIdentity();
+
+        $this->authService->method('getIdentity')->willReturn($identity);
+        $this->userService->method('getTokenInfo')
+            ->willReturn(['success' => false, 'expiresIn' => null, 'failureCode' => 500]);
+
+        $this->sessionUtility->expects($this->exactly(2))
+            ->method('setInMvc')
+            ->willReturnCallback(function (string $namespace, string $key, mixed $value) use (&$recorded): void {
+                $recorded[] = [$namespace, $key, $value];
+            });
+
+        $request = new ServerRequest(uri: 'https://example.com/dashboard');
+        $this->middleware->process($request, $this->makeHandler());
+
+        $this->assertSame([ContainerNamespace::AUTH_FAILURE_REASON, 'reason', 'Internal system error'], $recorded[0]);
+        $this->assertSame([ContainerNamespace::AUTH_FAILURE_REASON, 'code', 500], $recorded[1]);
+    }
+
+    // -------------------------------------------------------------------------
+    // ApiException
+    // -------------------------------------------------------------------------
+
+    public function testClearsIdentityOnApiException(): void
+    {
+        $identity = $this->makeIdentity();
+
+        $this->authService->expects($this->once())->method('getIdentity')->willReturn($identity);
+        $this->userService->expects($this->once())
+            ->method('getTokenInfo')
+            ->willThrowException(new ApiException(new EmptyResponse(500)));
+
+        $this->authService->expects($this->once())->method('clearIdentity');
+
+        $request = new ServerRequest(uri: 'https://example.com/dashboard');
+        $this->middleware->process($request, $this->makeHandler());
+    }
+
+    // -------------------------------------------------------------------------
+    // Response passthrough
+    // -------------------------------------------------------------------------
+
+    public function testPassesThroughResponseFromHandler(): void
+    {
+        $this->authService->method('getIdentity')->willReturn(null);
+
+        $expectedResponse = new Response();
+        $request = new ServerRequest(uri: 'https://example.com/dashboard');
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->with($request)->willReturn($expectedResponse);
+
+        $response = $this->middleware->process($request, $handler);
+
+        $this->assertSame($expectedResponse, $response);
+    }
+}

--- a/service-front/module/Application/tests/Middleware/RequestLoggingMiddlewareTest.php
+++ b/service-front/module/Application/tests/Middleware/RequestLoggingMiddlewareTest.php
@@ -8,7 +8,9 @@ use Application\Middleware\RequestLoggingMiddleware;
 use MakeShared\Constants;
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ServerRequest;
+use Monolog\Level;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
@@ -21,6 +23,18 @@ class RequestLoggingMiddlewareTest extends TestCase
         $handler = $this->createMock(RequestHandlerInterface::class);
         $handler->method('handle')->willReturn(new Response());
         return $handler;
+    }
+
+    private function makeRecord(array $extra = []): LogRecord
+    {
+        return new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'test',
+            level: Level::Info,
+            message: 'test',
+            context: [],
+            extra: $extra,
+        );
     }
 
     public function testPushesProcessorWhenLoggerIsMonolog(): void
@@ -37,12 +51,10 @@ class RequestLoggingMiddlewareTest extends TestCase
 
     public function testDoesNotPushProcessorForNonMonologLogger(): void
     {
-        // NullLogger implements LoggerInterface but is not a Monolog\Logger instance
         $logger = new NullLogger();
 
         $middleware = new RequestLoggingMiddleware($logger);
 
-        // No exception and handler is still called
         $request = new ServerRequest(uri: 'https://example.com/dashboard');
         $handler = $this->createMock(RequestHandlerInterface::class);
         $handler->expects($this->once())->method('handle');
@@ -71,10 +83,11 @@ class RequestLoggingMiddlewareTest extends TestCase
 
         $this->assertNotNull($capturedProcessor);
 
-        $record = $capturedProcessor(['extra' => []]);
+        $result = $capturedProcessor($this->makeRecord());
 
-        $this->assertSame('/login', $record['extra']['request_path']);
-        $this->assertSame('POST', $record['extra']['request_method']);
+        $this->assertInstanceOf(LogRecord::class, $result);
+        $this->assertSame('/login', $result->extra['request_path']);
+        $this->assertSame('POST', $result->extra['request_method']);
     }
 
     public function testProcessorAddsTraceIdWhenHeaderPresent(): void
@@ -94,13 +107,14 @@ class RequestLoggingMiddlewareTest extends TestCase
         $middleware = new RequestLoggingMiddleware($logger);
         $middleware->process($request, $this->makeHandler());
 
-        $record = $capturedProcessor(['extra' => []]);
+        $result = $capturedProcessor($this->makeRecord());
 
-        $this->assertArrayHasKey(Constants::TRACE_ID_FIELD_NAME, $record['extra']);
-        $this->assertSame('trace-abc-123', $record['extra'][Constants::TRACE_ID_FIELD_NAME]);
+        $this->assertInstanceOf(LogRecord::class, $result);
+        $this->assertArrayHasKey(Constants::TRACE_ID_FIELD_NAME, $result->extra);
+        $this->assertSame('trace-abc-123', $result->extra[Constants::TRACE_ID_FIELD_NAME]);
     }
 
-    public function testProcessorDoesNotAddTraceIdWhenHeaderAbsent(): void
+    public function testProcessorSetsEmptyTraceIdWhenHeaderAbsent(): void
     {
         $capturedProcessor = null;
 
@@ -116,9 +130,11 @@ class RequestLoggingMiddlewareTest extends TestCase
         $middleware = new RequestLoggingMiddleware($logger);
         $middleware->process($request, $this->makeHandler());
 
-        $record = $capturedProcessor(['extra' => []]);
+        $result = $capturedProcessor($this->makeRecord());
 
-        $this->assertArrayNotHasKey(Constants::TRACE_ID_FIELD_NAME, $record['extra']);
+        $this->assertInstanceOf(LogRecord::class, $result);
+        $this->assertArrayHasKey(Constants::TRACE_ID_FIELD_NAME, $result->extra);
+        $this->assertSame('', $result->extra[Constants::TRACE_ID_FIELD_NAME]);
     }
 
     public function testPassesThroughResponseFromHandler(): void

--- a/service-front/module/Application/tests/Middleware/RequestLoggingMiddlewareTest.php
+++ b/service-front/module/Application/tests/Middleware/RequestLoggingMiddlewareTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Middleware;
+
+use Application\Middleware\RequestLoggingMiddleware;
+use MakeShared\Constants;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequest;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+class RequestLoggingMiddlewareTest extends TestCase
+{
+    private function makeHandler(): RequestHandlerInterface
+    {
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn(new Response());
+        return $handler;
+    }
+
+    public function testPushesProcessorWhenLoggerIsMonolog(): void
+    {
+        $logger = $this->createMock(Logger::class);
+        $logger->expects($this->once())
+            ->method('pushProcessor')
+            ->with($this->isType('callable'))
+            ->willReturnSelf();
+
+        $middleware = new RequestLoggingMiddleware($logger);
+        $middleware->process(new ServerRequest(), $this->makeHandler());
+    }
+
+    public function testDoesNotPushProcessorForNonMonologLogger(): void
+    {
+        // NullLogger implements LoggerInterface but is not a Monolog\Logger instance
+        $logger = new NullLogger();
+
+        $middleware = new RequestLoggingMiddleware($logger);
+
+        // No exception and handler is still called
+        $request = new ServerRequest(uri: 'https://example.com/dashboard');
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle');
+
+        $middleware->process($request, $handler);
+    }
+
+    public function testProcessorAddsRequestPathAndMethod(): void
+    {
+        $capturedProcessor = null;
+
+        $logger = $this->createMock(Logger::class);
+        $logger->method('pushProcessor')
+            ->willReturnCallback(function (callable $processor) use (&$capturedProcessor, $logger): Logger {
+                $capturedProcessor = $processor;
+                return $logger;
+            });
+
+        $request = new ServerRequest(
+            method: 'POST',
+            uri: 'https://example.com/login',
+        );
+
+        $middleware = new RequestLoggingMiddleware($logger);
+        $middleware->process($request, $this->makeHandler());
+
+        $this->assertNotNull($capturedProcessor);
+
+        $record = $capturedProcessor(['extra' => []]);
+
+        $this->assertSame('/login', $record['extra']['request_path']);
+        $this->assertSame('POST', $record['extra']['request_method']);
+    }
+
+    public function testProcessorAddsTraceIdWhenHeaderPresent(): void
+    {
+        $capturedProcessor = null;
+
+        $logger = $this->createMock(Logger::class);
+        $logger->method('pushProcessor')
+            ->willReturnCallback(function (callable $processor) use (&$capturedProcessor, $logger): Logger {
+                $capturedProcessor = $processor;
+                return $logger;
+            });
+
+        $request = (new ServerRequest(uri: 'https://example.com/dashboard'))
+            ->withHeader('X-Request-ID', 'trace-abc-123');
+
+        $middleware = new RequestLoggingMiddleware($logger);
+        $middleware->process($request, $this->makeHandler());
+
+        $record = $capturedProcessor(['extra' => []]);
+
+        $this->assertArrayHasKey(Constants::TRACE_ID_FIELD_NAME, $record['extra']);
+        $this->assertSame('trace-abc-123', $record['extra'][Constants::TRACE_ID_FIELD_NAME]);
+    }
+
+    public function testProcessorDoesNotAddTraceIdWhenHeaderAbsent(): void
+    {
+        $capturedProcessor = null;
+
+        $logger = $this->createMock(Logger::class);
+        $logger->method('pushProcessor')
+            ->willReturnCallback(function (callable $processor) use (&$capturedProcessor, $logger): Logger {
+                $capturedProcessor = $processor;
+                return $logger;
+            });
+
+        $request = new ServerRequest(uri: 'https://example.com/dashboard');
+
+        $middleware = new RequestLoggingMiddleware($logger);
+        $middleware->process($request, $this->makeHandler());
+
+        $record = $capturedProcessor(['extra' => []]);
+
+        $this->assertArrayNotHasKey(Constants::TRACE_ID_FIELD_NAME, $record['extra']);
+    }
+
+    public function testPassesThroughResponseFromHandler(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $expectedResponse = new Response();
+
+        $request = new ServerRequest();
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->with($request)->willReturn($expectedResponse);
+
+        $middleware = new RequestLoggingMiddleware($logger);
+        $response = $middleware->process($request, $handler);
+
+        $this->assertSame($expectedResponse, $response);
+    }
+}

--- a/service-front/module/Application/tests/Middleware/SessionBootstrapMiddlewareTest.php
+++ b/service-front/module/Application/tests/Middleware/SessionBootstrapMiddlewareTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Middleware;
+
+use Application\Middleware\SessionBootstrapMiddleware;
+use Application\Model\Service\Session\NativeSessionConfig;
+use Application\Model\Service\Session\SessionManagerSupport;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Session\SaveHandler\SaveHandlerInterface;
+use Laminas\Session\SessionManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class SessionBootstrapMiddlewareTest extends TestCase
+{
+    private NativeSessionConfig $nativeSessionConfig;
+    private SessionManager&MockObject $sessionManager;
+    private SessionManagerSupport&MockObject $sessionManagerSupport;
+    private SessionBootstrapMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        // NativeSessionConfig is final — construct a real instance with a mock save handler.
+        $saveHandler = $this->createMock(SaveHandlerInterface::class);
+        $this->nativeSessionConfig   = new NativeSessionConfig([], $saveHandler);
+        $this->sessionManager        = $this->createMock(SessionManager::class);
+        $this->sessionManagerSupport = $this->createMock(SessionManagerSupport::class);
+
+        $this->middleware = new SessionBootstrapMiddleware(
+            $this->nativeSessionConfig,
+            $this->sessionManager,
+            $this->sessionManagerSupport,
+        );
+    }
+
+    private function makeHandler(): RequestHandlerInterface
+    {
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn(new Response());
+        return $handler;
+    }
+
+    public function testBootstrapsSessionForNormalRequest(): void
+    {
+        $this->sessionManager->expects($this->once())->method('start');
+        $this->sessionManagerSupport->expects($this->once())->method('initialise');
+
+        $request = new ServerRequest(uri: 'https://example.com/dashboard');
+        $this->middleware->process($request, $this->makeHandler());
+    }
+
+    public function testSkipsSessionForPingElb(): void
+    {
+        $this->sessionManager->expects($this->never())->method('start');
+        $this->sessionManagerSupport->expects($this->never())->method('initialise');
+
+        $request = new ServerRequest(uri: 'https://example.com/ping/elb');
+        $this->middleware->process($request, $this->makeHandler());
+    }
+
+    public function testSkipsSessionForPingJson(): void
+    {
+        $this->sessionManager->expects($this->never())->method('start');
+        $this->sessionManagerSupport->expects($this->never())->method('initialise');
+
+        $request = new ServerRequest(uri: 'https://example.com/ping/json');
+        $this->middleware->process($request, $this->makeHandler());
+    }
+
+    public function testPassesThroughToHandler(): void
+    {
+        $expectedResponse = new Response();
+        $request = new ServerRequest(uri: 'https://example.com/login');
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->with($request)->willReturn($expectedResponse);
+
+        $response = $this->middleware->process($request, $handler);
+
+        $this->assertSame($expectedResponse, $response);
+    }
+
+    public function testHandlerReceivesUnmodifiedRequestForExcludedPath(): void
+    {
+        $request = new ServerRequest(uri: 'https://example.com/ping/elb');
+        $expectedResponse = new Response();
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->with($request)->willReturn($expectedResponse);
+
+        $response = $this->middleware->process($request, $handler);
+
+        $this->assertSame($expectedResponse, $response);
+    }
+}

--- a/service-front/module/Application/tests/Middleware/SessionBootstrapMiddlewareTest.php
+++ b/service-front/module/Application/tests/Middleware/SessionBootstrapMiddlewareTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace ApplicationTest\Middleware;
 
 use Application\Middleware\SessionBootstrapMiddleware;
+use Application\Model\Service\Session\NativeSessionConfig;
 use Application\Model\Service\Session\SessionManagerSupport;
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ServerRequest;
+use Laminas\Session\SaveHandler\SaveHandlerInterface;
 use Laminas\Session\SessionManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -15,16 +17,21 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class SessionBootstrapMiddlewareTest extends TestCase
 {
+    private NativeSessionConfig $nativeSessionConfig;
     private SessionManager&MockObject $sessionManager;
     private SessionManagerSupport&MockObject $sessionManagerSupport;
     private SessionBootstrapMiddleware $middleware;
 
     protected function setUp(): void
     {
+        // NativeSessionConfig is final — construct a real instance with a mock save handler.
+        $saveHandler = $this->createMock(SaveHandlerInterface::class);
+        $this->nativeSessionConfig   = new NativeSessionConfig([], $saveHandler);
         $this->sessionManager        = $this->createMock(SessionManager::class);
         $this->sessionManagerSupport = $this->createMock(SessionManagerSupport::class);
 
         $this->middleware = new SessionBootstrapMiddleware(
+            $this->nativeSessionConfig,
             $this->sessionManager,
             $this->sessionManagerSupport,
         );
@@ -39,6 +46,8 @@ class SessionBootstrapMiddlewareTest extends TestCase
 
     public function testBootstrapsSessionForNormalRequest(): void
     {
+        // session_status() returns PHP_SESSION_NONE in a unit-test context, so
+        // start() is expected to be called once.
         $this->sessionManager->expects($this->once())->method('start');
         $this->sessionManagerSupport->expects($this->once())->method('initialise');
 

--- a/service-front/module/Application/tests/Middleware/SessionBootstrapMiddlewareTest.php
+++ b/service-front/module/Application/tests/Middleware/SessionBootstrapMiddlewareTest.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace ApplicationTest\Middleware;
 
 use Application\Middleware\SessionBootstrapMiddleware;
-use Application\Model\Service\Session\NativeSessionConfig;
 use Application\Model\Service\Session\SessionManagerSupport;
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ServerRequest;
-use Laminas\Session\SaveHandler\SaveHandlerInterface;
 use Laminas\Session\SessionManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -17,21 +15,16 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class SessionBootstrapMiddlewareTest extends TestCase
 {
-    private NativeSessionConfig $nativeSessionConfig;
     private SessionManager&MockObject $sessionManager;
     private SessionManagerSupport&MockObject $sessionManagerSupport;
     private SessionBootstrapMiddleware $middleware;
 
     protected function setUp(): void
     {
-        // NativeSessionConfig is final — construct a real instance with a mock save handler.
-        $saveHandler = $this->createMock(SaveHandlerInterface::class);
-        $this->nativeSessionConfig   = new NativeSessionConfig([], $saveHandler);
         $this->sessionManager        = $this->createMock(SessionManager::class);
         $this->sessionManagerSupport = $this->createMock(SessionManagerSupport::class);
 
         $this->middleware = new SessionBootstrapMiddleware(
-            $this->nativeSessionConfig,
             $this->sessionManager,
             $this->sessionManagerSupport,
         );

--- a/service-front/module/Application/tests/Middleware/TrailingSlashMiddlewareTest.php
+++ b/service-front/module/Application/tests/Middleware/TrailingSlashMiddlewareTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Middleware;
+
+use Application\Middleware\TrailingSlashMiddleware;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class TrailingSlashMiddlewareTest extends TestCase
+{
+    private TrailingSlashMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->middleware = new TrailingSlashMiddleware();
+    }
+
+    private function makeHandler(): RequestHandlerInterface
+    {
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn(new Response());
+        return $handler;
+    }
+
+    public function testRedirectsTrailingSlashPath(): void
+    {
+        $request = new ServerRequest(uri: 'https://example.com/login/');
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->never())->method('handle');
+
+        $response = $this->middleware->process($request, $handler);
+
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('https://example.com/login', $response->getHeaderLine('Location'));
+    }
+
+    public function testRedirectsDeepTrailingSlashPath(): void
+    {
+        $request = new ServerRequest(uri: 'https://example.com/lpa/123/donor/');
+
+        $response = $this->middleware->process($request, $this->makeHandler());
+
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('https://example.com/lpa/123/donor', $response->getHeaderLine('Location'));
+    }
+
+    public function testPreservesQueryStringOnRedirect(): void
+    {
+        $request = new ServerRequest(uri: 'https://example.com/login/?state=timeout');
+
+        $response = $this->middleware->process($request, $this->makeHandler());
+
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('https://example.com/login?state=timeout', $response->getHeaderLine('Location'));
+    }
+
+    public function testDoesNotRedirectRootPath(): void
+    {
+        $request = new ServerRequest(uri: 'https://example.com/');
+        $expectedResponse = new Response();
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->willReturn($expectedResponse);
+
+        $response = $this->middleware->process($request, $handler);
+
+        $this->assertSame($expectedResponse, $response);
+    }
+
+    public function testDoesNotRedirectPathWithoutTrailingSlash(): void
+    {
+        $request = new ServerRequest(uri: 'https://example.com/login');
+        $expectedResponse = new Response();
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->willReturn($expectedResponse);
+
+        $response = $this->middleware->process($request, $handler);
+
+        $this->assertSame($expectedResponse, $response);
+    }
+
+    public function testPassesThroughResponseFromHandler(): void
+    {
+        $request = new ServerRequest(uri: 'https://example.com/dashboard');
+        $expectedResponse = new Response('php://memory', 200);
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($expectedResponse);
+
+        $response = $this->middleware->process($request, $handler);
+
+        $this->assertSame($expectedResponse, $response);
+    }
+}

--- a/service-front/module/Application/tests/Model/Service/Session/SessionUtilityTest.php
+++ b/service-front/module/Application/tests/Model/Service/Session/SessionUtilityTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace ApplicationTest\Model\Service\Session;
 
 use Application\Model\Service\Session\SessionUtility;
+use Laminas\Session\Config\StandardConfig;
 use Laminas\Session\Container as LaminasContainer;
+use Laminas\Session\SessionManager;
+use Laminas\Session\Storage\ArrayStorage;
 use Mezzio\Session\SessionInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -17,6 +20,9 @@ class SessionUtilityTest extends TestCase
 
     protected function setUp(): void
     {
+        $manager = new SessionManager(new StandardConfig(), new ArrayStorage());
+        LaminasContainer::setDefaultManager($manager);
+
         $container = new LaminasContainer(self::CONTAINER_NAME);
         foreach ($container as $key => $value) {
             unset($container->$key);

--- a/service-front/module/Application/tests/Service/Factory/ActorReuseDetailsServiceFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/ActorReuseDetailsServiceFactoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Model\Service\Lpa\ActorReuseDetailsService;
+use Application\Model\Service\Lpa\Application as LpaApplicationService;
+use Application\Model\Service\Session\SessionUtility;
+use Application\Service\Factory\ActorReuseDetailsServiceFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class ActorReuseDetailsServiceFactoryTest extends TestCase
+{
+    public function testFactoryReturnsActorReuseDetailsService(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            LpaApplicationService::class => $this->createMock(LpaApplicationService::class),
+            SessionUtility::class        => $this->createMock(SessionUtility::class),
+        });
+
+        $service = (new ActorReuseDetailsServiceFactory())($container);
+
+        $this->assertInstanceOf(ActorReuseDetailsService::class, $service);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/AppFiltersExtensionFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/AppFiltersExtensionFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Service\Factory\AppFiltersExtensionFactory;
+use Application\View\Twig\AppFiltersExtension;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class AppFiltersExtensionFactoryTest extends TestCase
+{
+    public function testFactoryReturnsAppFiltersExtension(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with('config')
+            ->willReturn(['version' => ['tag' => 'v1']]);
+
+        $extension = (new AppFiltersExtensionFactory())($container);
+
+        $this->assertInstanceOf(AppFiltersExtension::class, $extension);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/AppFunctionsExtensionFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/AppFunctionsExtensionFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Form\Error\FormLinkedErrors;
+use Application\Service\AccordionService;
+use Application\Service\Factory\AppFunctionsExtensionFactory;
+use Application\Service\NavigationViewModelHelper;
+use Application\Service\SystemMessage;
+use Application\View\Twig\AppFunctionsExtension;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class AppFunctionsExtensionFactoryTest extends TestCase
+{
+    public function testFactoryReturnsAppFunctionsExtension(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            'config'                         => [],
+            FormLinkedErrors::class          => $this->createMock(FormLinkedErrors::class),
+            TemplateRendererInterface::class => $this->createMock(TemplateRendererInterface::class),
+            SystemMessage::class             => $this->createMock(SystemMessage::class),
+            AccordionService::class          => $this->createMock(AccordionService::class),
+            NavigationViewModelHelper::class => $this->createMock(NavigationViewModelHelper::class),
+        });
+
+        $extension = (new AppFunctionsExtensionFactory())($container);
+
+        $this->assertInstanceOf(AppFunctionsExtension::class, $extension);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/DynamoDbSystemMessageCacheFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/DynamoDbSystemMessageCacheFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Adapter\DynamoDbKeyValueStore;
+use Application\Service\Factory\DynamoDbSystemMessageCacheFactory;
+use Aws\DynamoDb\DynamoDbClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class DynamoDbSystemMessageCacheFactoryTest extends TestCase
+{
+    public function testFactoryReturnsDynamoDbKeyValueStore(): void
+    {
+        $config = [
+            'admin' => [
+                'dynamodb' => [
+                    'keyPrefix' => '',
+                    'settings'  => ['table_name' => 'system-messages'],
+                    'region'    => 'eu-west-1',
+                ],
+            ],
+            'stack' => ['name' => 'test-stack'],
+        ];
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            'config'                    => $config,
+            'DynamoDbSystemMessageClient' => $this->createMock(DynamoDbClient::class),
+        });
+
+        $store = (new DynamoDbSystemMessageCacheFactory())($container);
+
+        $this->assertInstanceOf(DynamoDbKeyValueStore::class, $store);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/DynamoDbSystemMessageClientFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/DynamoDbSystemMessageClientFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Service\Factory\DynamoDbSystemMessageClientFactory;
+use Aws\DynamoDb\DynamoDbClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class DynamoDbSystemMessageClientFactoryTest extends TestCase
+{
+    public function testFactoryReturnsDynamoDbClient(): void
+    {
+        $config = [
+            'admin' => [
+                'dynamodb' => [
+                    'client' => [
+                        'region'  => 'eu-west-1',
+                        'version' => 'latest',
+                    ],
+                ],
+            ],
+        ];
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with('config')
+            ->willReturn($config);
+
+        $client = (new DynamoDbSystemMessageClientFactory())($container);
+
+        $this->assertInstanceOf(DynamoDbClient::class, $client);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/FormLinkedErrorsFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/FormLinkedErrorsFactoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Form\Error\FormLinkedErrors;
+use Application\Service\Factory\FormLinkedErrorsFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class FormLinkedErrorsFactoryTest extends TestCase
+{
+    public function testFactoryReturnsFormLinkedErrors(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        $service = (new FormLinkedErrorsFactory())($container);
+
+        $this->assertInstanceOf(FormLinkedErrors::class, $service);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/GovPayClientFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/GovPayClientFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Alphagov\Pay\Client as GovPayClient;
+use Application\Service\Factory\GovPayClientFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class GovPayClientFactoryTest extends TestCase
+{
+    public function testFactoryReturnsGovPayClient(): void
+    {
+        $config = [
+            'alphagov' => [
+                'pay' => [
+                    'key' => 'test-api-key',
+                    'url' => 'https://publicapi.payments.service.gov.uk',
+                ],
+            ],
+        ];
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            'config'     => $config,
+            // Http\Adapter\Guzzle7\Client is final — create a real instance.
+            'HttpClient' => new \Http\Adapter\Guzzle7\Client(),
+        });
+
+        $client = (new GovPayClientFactory())($container);
+
+        $this->assertInstanceOf(GovPayClient::class, $client);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/HttpClientFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/HttpClientFactoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Service\Factory\HttpClientFactory;
+use Http\Adapter\Guzzle7\Client;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class HttpClientFactoryTest extends TestCase
+{
+    public function testFactoryReturnsGuzzleClient(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        $client = (new HttpClientFactory())($container);
+
+        $this->assertInstanceOf(Client::class, $client);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/LpaAuthAdapterFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/LpaAuthAdapterFactoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Model\Service\ApiClient\Client as ApiClient;
+use Application\Model\Service\Authentication\Adapter\LpaAuthAdapter;
+use Application\Service\Factory\LpaAuthAdapterFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class LpaAuthAdapterFactoryTest extends TestCase
+{
+    public function testFactoryReturnsLpaAuthAdapter(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with('ApiClient')
+            ->willReturn($this->createMock(ApiClient::class));
+
+        $adapter = (new LpaAuthAdapterFactory())($container);
+
+        $this->assertInstanceOf(LpaAuthAdapter::class, $adapter);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/NativeSessionConfigFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/NativeSessionConfigFactoryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Model\Service\Session\NativeSessionConfig;
+use Application\Service\Factory\NativeSessionConfigFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class NativeSessionConfigFactoryTest extends TestCase
+{
+    public function testFactoryReturnsNativeSessionConfig(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            'config'       => ['session' => ['native_settings' => ['name' => 'lpa']]],
+            'SaveHandler'  => $this->createMock(\Laminas\Session\SaveHandler\SaveHandlerInterface::class),
+        });
+
+        $config = (new NativeSessionConfigFactory())($container);
+
+        $this->assertInstanceOf(NativeSessionConfig::class, $config);
+    }
+
+    public function testFactoryUsesEmptySettingsWhenMissing(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            'config'       => [],
+            'SaveHandler'  => $this->createMock(\Laminas\Session\SaveHandler\SaveHandlerInterface::class),
+        });
+
+        $config = (new NativeSessionConfigFactory())($container);
+
+        $this->assertInstanceOf(NativeSessionConfig::class, $config);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/RedisClientFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/RedisClientFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Model\Service\Redis\RedisClient;
+use Application\Service\Factory\RedisClientFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class RedisClientFactoryTest extends TestCase
+{
+    public function testFactoryReturnsRedisClient(): void
+    {
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped('ext-redis is not available in this environment.');
+        }
+
+        $config = [
+            'redis' => [
+                'url'   => 'redis://localhost:6379',
+                'ttlMs' => 3600000,
+            ],
+        ];
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with('config')
+            ->willReturn($config);
+
+        $client = (new RedisClientFactory())($container);
+
+        $this->assertInstanceOf(RedisClient::class, $client);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/SaveHandlerFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/SaveHandlerFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Model\Service\Session\FilteringSaveHandler;
+use Application\Model\Service\Session\WritePolicy;
+use Application\Model\Service\Redis\RedisClient;
+use Application\Service\Factory\SaveHandlerFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class SaveHandlerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsSaveHandlerWithWritePolicy(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->with(WritePolicy::class)->willReturn(true);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            RedisClient::class  => $this->createMock(RedisClient::class),
+            // WritePolicy is final — use a real instance (no constructor args needed in Mezzio).
+            WritePolicy::class  => new WritePolicy(),
+        });
+
+        $handler = (new SaveHandlerFactory())($container);
+
+        $this->assertInstanceOf(FilteringSaveHandler::class, $handler);
+    }
+
+    public function testFactoryReturnsSaveHandlerWithoutWritePolicy(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->with(WritePolicy::class)->willReturn(false);
+        $container->method('get')
+            ->with(RedisClient::class)
+            ->willReturn($this->createMock(RedisClient::class));
+
+        $handler = (new SaveHandlerFactory())($container);
+
+        $this->assertInstanceOf(FilteringSaveHandler::class, $handler);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/SessionManagerSupportFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/SessionManagerSupportFactoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Model\Service\Session\SessionManagerSupport;
+use Application\Model\Service\Session\SessionUtility;
+use Application\Service\Factory\SessionManagerSupportFactory;
+use Laminas\Session\SessionManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class SessionManagerSupportFactoryTest extends TestCase
+{
+    public function testFactoryReturnsSessionManagerSupport(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            'SessionManager'      => $this->createMock(SessionManager::class),
+            SessionUtility::class => $this->createMock(SessionUtility::class),
+        });
+
+        $support = (new SessionManagerSupportFactory())($container);
+
+        $this->assertInstanceOf(SessionManagerSupport::class, $support);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/SessionMiddlewareFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/SessionMiddlewareFactoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Service\Factory\SessionMiddlewareFactory;
+use Mezzio\Session\SessionMiddleware;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class SessionMiddlewareFactoryTest extends TestCase
+{
+    public function testFactoryReturnsSessionMiddleware(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        $middleware = (new SessionMiddlewareFactory())($container);
+
+        $this->assertInstanceOf(SessionMiddleware::class, $middleware);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/TelemetryTracerFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/TelemetryTracerFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Service\Factory\TelemetryTracerFactory;
+use MakeShared\Telemetry\Exporter\ExporterFactory;
+use MakeShared\Telemetry\Tracer;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class TelemetryTracerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsTracer(): void
+    {
+        $exporterFactory = $this->createMock(ExporterFactory::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(fn($s) => match ($s) {
+            'config'               => [
+                'telemetry' => [
+                    'exporter' => [
+                        'serviceName' => 'opg-lpa-front',
+                    ],
+                ],
+            ],
+            ExporterFactory::class => $exporterFactory,
+        });
+
+        $tracer = (new TelemetryTracerFactory())($container);
+
+        $this->assertInstanceOf(Tracer::class, $tracer);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/TwigViewRendererFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/TwigViewRendererFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Service\Factory\TwigViewRendererFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Twig\Environment;
+
+class TwigViewRendererFactoryTest extends TestCase
+{
+    public function testFactoryReturnsTwigEnvironment(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with('config')
+            ->willReturn(['twig' => ['cache_dir' => false]]);
+
+        $renderer = (new TwigViewRendererFactory())($container);
+
+        $this->assertInstanceOf(Environment::class, $renderer);
+    }
+}

--- a/service-front/module/Application/tests/Service/Factory/WritePolicyFactoryTest.php
+++ b/service-front/module/Application/tests/Service/Factory/WritePolicyFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Service\Factory;
+
+use Application\Service\Factory\WritePolicyFactory;
+use Application\Model\Service\Session\WritePolicy;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class WritePolicyFactoryTest extends TestCase
+{
+    public function testFactoryReturnsWritePolicy(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        $policy = (new WritePolicyFactory())($container);
+
+        $this->assertInstanceOf(WritePolicy::class, $policy);
+    }
+
+    public function testWritePolicyAllowsWriteByDefault(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+
+        $policy = (new WritePolicyFactory())($container);
+
+        // Without the MVC Request (Mezzio context), falls back to $_SERVER check.
+        // In a test environment HTTP_X_SESSIONREADONLY is absent, so writes are allowed.
+        $this->assertTrue($policy->allowsWrite());
+    }
+}

--- a/service-pdf/docker/app/.snyk
+++ b/service-pdf/docker/app/.snyk
@@ -6,5 +6,5 @@ ignore:
   snyk:lic:composer:tecnickcom:tcpdf:((GPL-3.0_OR_LGPL-3.0)_OR_GPL-2.0_OR_GPL-3.0):
     - "*":
         reason: This will not be resolved
-        expires: 2026-04-23T14:57:38.314Z
-        created: 2026-03-26T11:29:38.316Z
+        expires: 2026-04-30T00:00:00.000Z
+        created: 2026-04-23T00:00:00.000Z


### PR DESCRIPTION
## Purpose

**Note I branched from #3327 as it wasn't merged by the end of the day and requires changes introduced there.**

This is a fresh (untested) mezzio app with:
* Container DI wired up by referencing a `ConfigProvider` in the existing laminas-mvc app
* Middleware that runs on every request piped in

Next steps for this will be to hook up one existing handler (`HomeHandler` is a good candidate) and wire up to docker using patterns established for `mezzio-test-app`. I considered re-using the `mezzio-test-app` but it wasn't clear how much we had deviated from a "standard"  setup and I ran into a couple of autoload issues when trying to share Handlers outside the directory. If we can overcome the autoload issues then it may be cleaner to have the app outside `service-front`.

