### PR TITLE
LPAL-1974 fix missing apple icons

### DIFF
--- a/service-front/module/Application/view/layout/layout.twig
+++ b/service-front/module/Application/view/layout/layout.twig
@@ -10,17 +10,15 @@
 
     <link href="{{ '/assets/v2/css/govuk-template-print.css' | asset_path({ 'minify':true }) }}" media="print" rel="stylesheet" type="text/css" />
 
-    <link rel="shortcut icon" href="/assets/v2/images/favicon.ico" type="image/x-icon" />
-    <!-- For third-generation iPad with high-resolution Retina display: -->
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/assets/v2/images/apple-touch-icon-144x144.png">
-    <!-- For iPhone with high-resolution Retina display: -->
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/assets/v2/images/apple-touch-icon-114x114.png">
-    <!-- For first- and second-generation iPad: -->
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/assets/v2/images/apple-touch-icon-72x72.png">
-    <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-    <link rel="apple-touch-icon-precomposed" href="/assets/v2/images/apple-touch-icon-57x57.png">
 
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" sizes="48x48" href="/assets/v2/images/favicon.ico">
+    <link rel="icon" sizes="any" href="/assets/v2/images/favicon.svg" type="image/svg+xml">
+    <link rel="mask-icon" href="/assets/v2/images/govuk-icon-mask.svg" color="#1d70b8">
+    <link rel="apple-touch-icon" href="/assets/v2/images/govuk-icon-180.png">
+    <link rel="manifest" href="/assets/v2/rebrand/manifest.json">
+
+    <meta name="theme-color" content="#1d70b8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="og:image" content="/assets/v2/images/opengraph-image.png">
     <meta name="description" content="Make a lasting power of attorney">
     <meta content="Family" name="x-section-name">


### PR DESCRIPTION
LPAL-1974

Replaces the legacy apple-touch-icon-precomposed declarations (inherited from govuk_template_mustache) with the current GOV.UK Design System icon set

Removed four apple-touch-icon-precomposed links (144×144, 114×114, 72×72, 57×57) — these used obsolete sizes/rel values and didn't cover all iOS device resolutions, causing devices to guess URLs that don't exist

Added a single <link rel="apple-touch-icon" href="govuk-icon-180.png"> (no sizes attribute) — iOS will downscale this for any device

Added <link rel="manifest"> pointing to the existing rebrand manifest.json
Added <meta name="theme-color" content="#1d70b8"> and viewport-fit=cover per current Design System template