### PR TITLE
LPAL-2076 - add iac scanning with snyk shared action to all workflows

### DIFF
--- a/.github/workflows/snyk_iac_scan.yml
+++ b/.github/workflows/snyk_iac_scan.yml
@@ -37,11 +37,11 @@ jobs:
       matrix:
         include:
           - image_name: region
-            terraform_configuration_path: "./terraform/region/"
+            terraform_configuration_path: ./terraform/region/
           - image_name: account
-            terraform_configuration_path: "./terraform/account/"
+            terraform_configuration_path: ./terraform/account/
           - image_name: environment
-            terraform_configuration_path: "./terraform/environment/"
+            terraform_configuration_path: ./terraform/environment/
 
     steps:
       - name: Checkout
@@ -65,9 +65,10 @@ jobs:
         uses: ministryofjustice/opg-github-actions/actions/snyk-iac@9e8b7c2fb29c11e77b12913f74459fa48b11829f # v4.8.2
         with:
           # iac_test_directory: "./terraform/environment/"
-          iac_test_directory: ${{ matrix.terraform_configuration_path }}
+          iac_test_directory: "${{ matrix.terraform_configuration_path }}"
           SNYK_TOKEN: ${{ secrets.snyk_token }}
           snyk_test_args: "--severity-threshold=high"
+          snyk_policy_path: "${{ matrix.terraform_configuration_path }}.snyk"
       # - name: Upload Snyk IaC results to GitHub Security tab
       #   uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
       #   if: always()

--- a/.github/workflows/snyk_iac_scan.yml
+++ b/.github/workflows/snyk_iac_scan.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           iac_test_directory: "${{ matrix.terraform_configuration_path }}"
           SNYK_TOKEN: ${{ secrets.snyk_token }}
-          snyk_test_args: "--severity-threshold=medium"
+          snyk_test_args: "--severity-threshold=high"
           snyk_policy_path: "${{ matrix.terraform_configuration_path }}.snyk"
       - name: Upload Snyk IaC results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6

--- a/.github/workflows/snyk_iac_scan.yml
+++ b/.github/workflows/snyk_iac_scan.yml
@@ -32,6 +32,17 @@ jobs:
   snyk_iac_scan:
     name: Run Snyk IAC scan
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image_name: region
+            terraform_configuration_path: terraform/region/
+          - image_name: account
+            terraform_configuration_path: terraform/account/
+          - image_name: environment
+            terraform_configuration_path: terraform/environment/
+
     steps:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -53,7 +64,7 @@ jobs:
         id: snyk_iac
         uses: ministryofjustice/opg-github-actions/actions/snyk-iac@9e8b7c2fb29c11e77b12913f74459fa48b11829f # v4.8.2
         with:
-          iac_test_directory: "./terraform/environment/"
+          iac_test_directory: "${{ matrix.terraform_configuration_path }}"
           SNYK_TOKEN: ${{ secrets.snyk_token }}
           snyk_test_args: "--severity-threshold=high"
       # - name: Upload Snyk IaC results to GitHub Security tab

--- a/.github/workflows/snyk_iac_scan.yml
+++ b/.github/workflows/snyk_iac_scan.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           iac_test_directory: "./terraform/environment/"
           SNYK_TOKEN: ${{ secrets.snyk_token }}
+          snyk_test_args: "--severity-threshold=high"
       # - name: Upload Snyk IaC results to GitHub Security tab
       #   uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
       #   if: always()

--- a/.github/workflows/snyk_iac_scan.yml
+++ b/.github/workflows/snyk_iac_scan.yml
@@ -29,8 +29,8 @@ permissions:
   statuses: none
 
 jobs:
-  run_seeding_task:
-    name: Run seeding task
+  snyk_iac_scan:
+    name: Run Snyk IAC scan
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/snyk_iac_scan.yml
+++ b/.github/workflows/snyk_iac_scan.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Snyk IaC
         id: snyk_iac
-        uses: ministryofjustice/opg-github-actions/actions/snyk-iac@8dea82fc8b8e7ffca431f0fb83848d523147ccd8 # v4.5.0
+        uses: ministryofjustice/opg-github-actions/actions/snyk-iac@9e8b7c2fb29c11e77b12913f74459fa48b11829f # v4.8.2
         with:
           iac_test_directory: "./terraform/environment/"
           SNYK_TOKEN: ${{ secrets.snyk_token }}

--- a/.github/workflows/snyk_iac_scan.yml
+++ b/.github/workflows/snyk_iac_scan.yml
@@ -37,11 +37,11 @@ jobs:
       matrix:
         include:
           - image_name: region
-            terraform_configuration_path: terraform/region/
+            terraform_configuration_path: "./terraform/region/"
           - image_name: account
-            terraform_configuration_path: terraform/account/
+            terraform_configuration_path: "./terraform/account/"
           - image_name: environment
-            terraform_configuration_path: terraform/environment/
+            terraform_configuration_path: "./terraform/environment/"
 
     steps:
       - name: Checkout
@@ -64,7 +64,8 @@ jobs:
         id: snyk_iac
         uses: ministryofjustice/opg-github-actions/actions/snyk-iac@9e8b7c2fb29c11e77b12913f74459fa48b11829f # v4.8.2
         with:
-          iac_test_directory: "${{ matrix.terraform_configuration_path }}"
+          # iac_test_directory: "./terraform/environment/"
+          iac_test_directory: ${{ matrix.terraform_configuration_path }}
           SNYK_TOKEN: ${{ secrets.snyk_token }}
           snyk_test_args: "--severity-threshold=high"
       # - name: Upload Snyk IaC results to GitHub Security tab

--- a/.github/workflows/snyk_iac_scan.yml
+++ b/.github/workflows/snyk_iac_scan.yml
@@ -1,0 +1,61 @@
+name: "Snyk IAC scan"
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_call:
+    inputs:
+      oidc_role:
+        description: "Role to use to fetch Snyk container"
+        required: true
+        type: string
+    secrets:
+      snyk_token:
+        required: true
+
+permissions:
+  actions: none
+  checks: none
+  contents: write
+  deployments: none
+  id-token: write
+  issues: none
+  packages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: write
+  statuses: none
+
+jobs:
+  run_seeding_task:
+    name: Run seeding task
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ inputs.oidc_role }}
+          role-duration-seconds: 3600
+          role-session-name: OPGLPASnykIACScan
+
+      - name: ECR Login
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        with:
+          registries: 311462405659
+
+      - name: Snyk IaC
+        id: snyk_iac
+        uses: ministryofjustice/opg-github-actions/actions/snyk-iac@8dea82fc8b8e7ffca431f0fb83848d523147ccd8 # v4.5.0
+        with:
+          iac_test_directory: "./terraform/environment/"
+          SNYK_TOKEN: ${{ secrets.snyk_token }}
+      # - name: Upload Snyk IaC results to GitHub Security tab
+      #   uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+      #   if: always()
+      #   with:
+      #     category: "IaC"
+      #     sarif_file: "test-results/snyk.sarif"

--- a/.github/workflows/snyk_iac_scan.yml
+++ b/.github/workflows/snyk_iac_scan.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           iac_test_directory: "${{ matrix.terraform_configuration_path }}"
           SNYK_TOKEN: ${{ secrets.snyk_token }}
-          # snyk_test_args: "--severity-threshold=high"
+          snyk_test_args: "--severity-threshold=medium"
           snyk_policy_path: "${{ matrix.terraform_configuration_path }}.snyk"
       - name: Upload Snyk IaC results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6

--- a/.github/workflows/snyk_iac_scan.yml
+++ b/.github/workflows/snyk_iac_scan.yml
@@ -33,6 +33,8 @@ jobs:
     name: Run seeding task
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:

--- a/.github/workflows/snyk_iac_scan.yml
+++ b/.github/workflows/snyk_iac_scan.yml
@@ -36,11 +36,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image_name: region
+          - name: region
             terraform_configuration_path: ./terraform/region/
-          - image_name: account
+          - name: account
             terraform_configuration_path: ./terraform/account/
-          - image_name: environment
+          - name: environment
             terraform_configuration_path: ./terraform/environment/
 
     steps:
@@ -60,18 +60,17 @@ jobs:
         with:
           registries: 311462405659
 
-      - name: Snyk IaC
+      - name: Snyk IaC ${{ matrix.name }}
         id: snyk_iac
         uses: ministryofjustice/opg-github-actions/actions/snyk-iac@9e8b7c2fb29c11e77b12913f74459fa48b11829f # v4.8.2
         with:
-          # iac_test_directory: "./terraform/environment/"
           iac_test_directory: "${{ matrix.terraform_configuration_path }}"
           SNYK_TOKEN: ${{ secrets.snyk_token }}
-          snyk_test_args: "--severity-threshold=high"
+          # snyk_test_args: "--severity-threshold=high"
           snyk_policy_path: "${{ matrix.terraform_configuration_path }}.snyk"
-      # - name: Upload Snyk IaC results to GitHub Security tab
-      #   uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
-      #   if: always()
-      #   with:
-      #     category: "IaC"
-      #     sarif_file: "test-results/snyk.sarif"
+      - name: Upload Snyk IaC results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        if: always()
+        with:
+          category: "IaC-${{matrix.name}}"
+          sarif_file: "test-results/snyk.sarif"

--- a/.github/workflows/workflow_merge_queue.yml
+++ b/.github/workflows/workflow_merge_queue.yml
@@ -78,6 +78,14 @@ jobs:
     with:
       terraform_version: ${{ needs.set_variables.outputs.environment_terraform_version }}
 
+  snyk_iac_scan:
+    name: Snyk IAC Scan
+    uses: ./.github/workflows/snyk_iac_scan.yml
+    with:
+      oidc_role: ${{ vars.OIDC_DOCKER_ROLE }}
+    secrets:
+      snyk_token: ${{ secrets.SNYK_OPG_ORG_TOKEN }}
+
   docker_build_scan_push:
     name: Docker Build, Scan and Push
     uses: ./.github/workflows/docker_job.yml
@@ -106,6 +114,7 @@ jobs:
     name: TF Preproduction - Account
     needs:
       - set_variables
+      - snyk_iac_scan
     uses: ministryofjustice/opg-github-workflows/.github/workflows/build-infrastructure-terraform-oidc.yml@f567efb2782f73a972073276a00bc4bcf92a3728 # v3.19.2
     with:
       is_ephemeral: false
@@ -124,6 +133,7 @@ jobs:
     uses: ministryofjustice/opg-github-workflows/.github/workflows/build-infrastructure-terraform-oidc.yml@f567efb2782f73a972073276a00bc4bcf92a3728 # v3.19.2
     needs:
       - set_variables
+      - snyk_iac_scan
     with:
       is_ephemeral: false
       oidc_role_to_assume: ${{ vars.OIDC_TERRAFORM_ROLE_PREPRODUCTION }}
@@ -154,6 +164,7 @@ jobs:
       - phpunit_tests
       - psalm_tests
       - set_variables
+      - snyk_iac_scan
       - terraform_region_preproduction
       - terraform_account_preproduction
     secrets:

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -70,6 +70,14 @@ jobs:
           prerelease: ${{ github.ref != 'refs/heads/main' }}
           default_bump: minor
 
+  snyk_iac_scan:
+    name: Snyk IAC Scan
+    uses: ./.github/workflows/snyk_iac_scan.yml
+    with:
+      oidc_role: ${{ vars.OIDC_DOCKER_ROLE }}
+    secrets:
+      snyk_token: ${{ secrets.SNYK_OPG_ORG_TOKEN }}
+
   docker_build_scan_push:
     name: Docker Build, Scan and Push
     uses: ./.github/workflows/docker_job.yml
@@ -86,6 +94,7 @@ jobs:
     name: TF Development - Account
     needs:
       - set_variables
+      - snyk_iac_scan
     uses: ministryofjustice/opg-github-workflows/.github/workflows/build-infrastructure-terraform-oidc.yml@f567efb2782f73a972073276a00bc4bcf92a3728 # v3.19.2
     with:
       is_ephemeral: false
@@ -104,6 +113,7 @@ jobs:
     uses: ministryofjustice/opg-github-workflows/.github/workflows/build-infrastructure-terraform-oidc.yml@f567efb2782f73a972073276a00bc4bcf92a3728 # v3.19.2
     needs:
       - set_variables
+      - snyk_iac_scan
       - terraform_account_development
     with:
       is_ephemeral: false
@@ -182,6 +192,7 @@ jobs:
     uses: ministryofjustice/opg-github-workflows/.github/workflows/build-infrastructure-terraform-oidc.yml@f567efb2782f73a972073276a00bc4bcf92a3728 # v3.19.2
     needs:
       - slack_msg_production_deploy_begin
+      - snyk_iac_scan
       - set_variables
     with:
       is_ephemeral: false
@@ -201,6 +212,7 @@ jobs:
     needs:
       - slack_msg_production_deploy_begin
       - set_variables
+      - snyk_iac_scan
       - terraform_account_production
     with:
       is_ephemeral: false
@@ -231,6 +243,7 @@ jobs:
       - docker_build_scan_push
       - slack_msg_production_deploy_begin
       - set_variables
+      - snyk_iac_scan
       - terraform_region_production
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -75,7 +75,7 @@ jobs:
       terraform_version: ${{ needs.workflow_variables.outputs.environment_terraform_version }}
 
   snyk_iac_scan:
-    name: Docker Build, Scan and Push
+    name: Snyk IAC Scan
     uses: ./.github/workflows/snyk_iac_scan.yml
     with:
       oidc_role: ${{ vars.OIDC_DOCKER_ROLE }}

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -80,7 +80,7 @@ jobs:
     with:
       oidc_role: ${{ vars.OIDC_DOCKER_ROLE }}
     secrets:
-      SNYK_OPG_ORG_TOKEN: ${{ secrets.SNYK_OPG_ORG_TOKEN }}
+      snyk_token: ${{ secrets.SNYK_OPG_ORG_TOKEN }}
 
   docker_build_scan_push:
     name: Docker Build, Scan and Push

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -116,6 +116,7 @@ jobs:
     needs:
       - terraform_lint
       - workflow_variables
+      - snyk_iac_scan
     with:
       terraform_version: ${{ needs.workflow_variables.outputs.account_terraform_version }}
       terraform_workspace: development
@@ -136,6 +137,7 @@ jobs:
     needs:
       - terraform_lint
       - workflow_variables
+      - snyk_iac_scan
     with:
       terraform_version: ${{ needs.workflow_variables.outputs.region_terraform_version }}
       terraform_workspace: development
@@ -158,6 +160,7 @@ jobs:
       - phpunit_tests
       - psalm_tests
       - workflow_variables
+      - snyk_iac_scan
       - terraform_account_development
       - terraform_region_development
     with:

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -74,6 +74,14 @@ jobs:
     with:
       terraform_version: ${{ needs.workflow_variables.outputs.environment_terraform_version }}
 
+  snyk_iac_scan:
+    name: Docker Build, Scan and Push
+    uses: ./.github/workflows/snyk_iac_scan.yml
+    with:
+      oidc_role: ${{ vars.OIDC_DOCKER_ROLE }}
+    secrets:
+      SNYK_OPG_ORG_TOKEN: ${{ secrets.SNYK_OPG_ORG_TOKEN }}
+
   docker_build_scan_push:
     name: Docker Build, Scan and Push
     uses: ./.github/workflows/docker_job.yml

--- a/terraform/account/.snyk
+++ b/terraform/account/.snyk
@@ -1,0 +1,5 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore: {}
+patch: {}

--- a/terraform/account/.snyk
+++ b/terraform/account/.snyk
@@ -1,5 +1,15 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore: {}
+ignore:
+  SNYK-CC-TF-125:
+    - '*':
+        reason: Not required for the workspaces table
+        expires: 9999-06-05T13:28:08.682Z
+        created: 2026-05-06T13:28:08.686Z
+  SNYK-CC-TF-55:
+    - '*':
+        reason: Scheduled for fix LPAL-1095
+        expires: 2026-06-05T13:29:09.493Z
+        created: 2026-05-06T13:29:09.500Z
 patch: {}

--- a/terraform/environment/.snyk
+++ b/terraform/environment/.snyk
@@ -1,0 +1,5 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore: {}
+patch: {}

--- a/terraform/environment/.snyk
+++ b/terraform/environment/.snyk
@@ -1,5 +1,25 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore: {}
+ignore:
+  SNYK-CC-TF-55:
+    - '*':
+        reason: Scheduled for fix LPAL-1095
+        expires: 2026-06-05T13:30:05.884Z
+        created: 2026-05-06T13:30:05.890Z
+  SNYK-CC-TF-37:
+    - '*':
+        reason: These groups are for public facing load balancers
+        expires: 9999-06-05T13:32:00.416Z
+        created: 2026-05-06T13:32:00.423Z
+  SNYK-CC-TF-125:
+    - '*':
+        reason: These tables do not need point in time recovery
+        expires: 9999-06-05T13:35:01.354Z
+        created: 2026-05-06T13:35:01.361Z
+  SNYK-CC-AWS-710:
+    - '*':
+        reason: Not planned
+        expires: 9999-06-05T13:36:16.605Z
+        created: 2026-05-06T13:36:16.613Z
 patch: {}

--- a/terraform/environment/.snyk
+++ b/terraform/environment/.snyk
@@ -7,11 +7,6 @@ ignore:
         reason: Scheduled for fix LPAL-1095
         expires: 2026-06-05T13:30:05.884Z
         created: 2026-05-06T13:30:05.890Z
-  SNYK-CC-TF-37:
-    - '*':
-        reason: These groups are for public facing load balancers
-        expires: 9999-06-05T13:32:00.416Z
-        created: 2026-05-06T13:32:00.423Z
   SNYK-CC-TF-125:
     - '*':
         reason: These tables do not need point in time recovery
@@ -19,7 +14,16 @@ ignore:
         created: 2026-05-06T13:35:01.361Z
   SNYK-CC-AWS-710:
     - '*':
-        reason: Not planned
+        reason: RDS IAM Not planned
         expires: 9999-06-05T13:36:16.605Z
         created: 2026-05-06T13:36:16.613Z
+  SNYK-CC-AWS-37:
+    - 'modules/environment/load_balancer_front.tf > resource > aws_security_group_rule[front_loadbalancer_ingress_production] > cidr_blocks':
+        reason: Required for public loadbalancer
+        expires: 9999-06-05T14:57:34.023Z
+        created: 2026-05-06T14:57:34.026Z
+    - 'modules/environment/load_balancer_front.tf > resource > aws_security_group_rule[front_loadbalancer_ingress_http] > cidr_blocks':
+        reason: Required for public loadbalancer
+        expires: 9999-06-05T14:57:35.563Z
+        created: 2026-05-06T14:57:35.566Z
 patch: {}

--- a/terraform/region/.snyk
+++ b/terraform/region/.snyk
@@ -7,4 +7,24 @@ ignore:
         reason: Policy merged with others to produce more restrictive policy
         expires: 2026-06-05T12:41:53.331Z
         created: 2026-05-06T12:41:53.334Z
+  SNYK-CC-TF-55:
+    - '*':
+        reason: Scheduled for fix LPAL-1095
+        expires: 2026-06-05T13:21:30.702Z
+        created: 2026-05-06T13:21:30.709Z
+  SNYK-CC-TF-215:
+    - '*':
+        reason: Scheduled for fix LPAL-2080
+        expires: 2026-06-05T13:24:01.814Z
+        created: 2026-05-06T13:24:01.821Z
+  SNYK-CC-TF-119:
+    - '*':
+        reason: Policy merged with others to produce more restrictive policy
+        expires: 2026-06-05T13:25:02.332Z
+        created: 2026-05-06T13:25:02.341Z
+  SNYK-CC-TF-40:
+    - '*':
+        reason: Scheduled for fix LPAL-2081
+        expires: 2026-06-05T13:25:27.744Z
+        created: 2026-05-06T13:25:27.752Z
 patch: {}

--- a/terraform/region/.snyk
+++ b/terraform/region/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-CC-TF-69:
+    - '*':
+        reason: Policy merged with others to produce more restrictive policy
+        expires: 2026-06-05T12:41:53.331Z
+        created: 2026-05-06T12:41:53.334Z
+patch: {}

--- a/terraform/region/.snyk
+++ b/terraform/region/.snyk
@@ -27,4 +27,9 @@ ignore:
         reason: Scheduled for fix LPAL-2081
         expires: 2026-06-05T13:25:27.744Z
         created: 2026-05-06T13:25:27.752Z
+  SNYK-CC-AWS-428:
+    - 'modules/region/modules/vpc_endpoints/main.tf > resource > aws_vpc_endpoint[cloudshell_codecatalyst_global]':
+        reason: Codecatalyst endpoints require the full access policy
+        expires: 9999-06-05T14:49:53.608Z
+        created: 2026-05-06T14:49:53.616Z
 patch: {}

--- a/terraform/region/modules/region/modules/vpc_endpoints/main.tf
+++ b/terraform/region/modules/region/modules/vpc_endpoints/main.tf
@@ -154,6 +154,7 @@ resource "aws_vpc_endpoint" "cloudshell" {
   private_dns_enabled = true
   security_group_ids  = aws_security_group.vpc_endpoints_private[*].id
   subnet_ids          = var.application_subnets_id
+  policy              = data.aws_iam_policy_document.allow_account_access.json
   tags                = { Name = "cloudshell-${each.value}-private" }
 }
 
@@ -165,5 +166,6 @@ resource "aws_vpc_endpoint" "cloudshell_codecatalyst_global" {
   private_dns_enabled = true
   security_group_ids  = aws_security_group.vpc_endpoints_private[*].id
   subnet_ids          = var.application_subnets_id
+  policy              = data.aws_iam_policy_document.allow_account_access.json
   tags                = { Name = "cloudshell-aws.api.global.codecatalyst-private" }
 }

--- a/terraform/region/modules/region/modules/vpc_endpoints/main.tf
+++ b/terraform/region/modules/region/modules/vpc_endpoints/main.tf
@@ -166,6 +166,5 @@ resource "aws_vpc_endpoint" "cloudshell_codecatalyst_global" {
   private_dns_enabled = true
   security_group_ids  = aws_security_group.vpc_endpoints_private[*].id
   subnet_ids          = var.application_subnets_id
-  policy              = data.aws_iam_policy_document.allow_account_access.json
   tags                = { Name = "cloudshell-aws.api.global.codecatalyst-private" }
 }

--- a/terraform/region/modules/region/modules/vpc_endpoints/main.tf
+++ b/terraform/region/modules/region/modules/vpc_endpoints/main.tf
@@ -140,6 +140,9 @@ locals {
     "ecs-telemetry",
     "ecs",
     "ssmmessages",
+  ])
+
+  codecatalyst_endpoints = toset([
     "codecatalyst.packages",
     "codecatalyst.git",
   ])
@@ -155,6 +158,18 @@ resource "aws_vpc_endpoint" "cloudshell" {
   security_group_ids  = aws_security_group.vpc_endpoints_private[*].id
   subnet_ids          = var.application_subnets_id
   policy              = data.aws_iam_policy_document.allow_account_access.json
+  tags                = { Name = "cloudshell-${each.value}-private" }
+}
+
+resource "aws_vpc_endpoint" "codecatalyst" {
+  provider            = aws.region
+  for_each            = local.codecatalyst_endpoints
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.${each.value}"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = aws_security_group.vpc_endpoints_private[*].id
+  subnet_ids          = var.application_subnets_id
   tags                = { Name = "cloudshell-${each.value}-private" }
 }
 

--- a/terraform/region/refactor.tf
+++ b/terraform/region/refactor.tf
@@ -17,3 +17,13 @@ moved {
   from = module.aws_backup_cross_account_key.aws_kms_replica_key.eu_west_2
   to   = module.aws_backup_source_account_key.aws_kms_replica_key.replica["eu-west-2"]
 }
+
+moved {
+  from = module.eu-west-1.module.vpc_endpoints.aws_vpc_endpoint.cloudshell["codecatalyst.packages"]
+  to   = module.eu-west-1.module.vpc_endpoints.aws_vpc_endpoint.codecatalyst["codecatalyst.packages"]
+}
+
+moved {
+  from = module.eu-west-1.module.vpc_endpoints.aws_vpc_endpoint.cloudshell["codecatalyst.git"]
+  to   = module.eu-west-1.module.vpc_endpoints.aws_vpc_endpoint.codecatalyst["codecatalyst.git"]
+}


### PR DESCRIPTION
## Purpose

Scan Terraform code for misconfigurations

Fixes LPAL-2076

## Approach

- add workflow_call for IAC scanning
- manage findings at medium or above (tickets created)
- call snyk_iac_scan workflow on pr, merge queue and path to live workflow
- add policy to cloudshell vpc endpoints

## Learning

- https://github.com/ministryofjustice/opg-github-actions/blob/main/actions/snyk-iac/README.md
- https://docs.snyk.io/developer-tools/snyk-cli/commands/ignore#ignore-a-specific-vulnerability-with-a-resource-path-specified-linux-mac-os
- https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-access.html