### PR TITLE
LPAL-1720 - Encrypt secrets with key that has a policy

### DIFF
--- a/terraform/region/.terraform.lock.hcl
+++ b/terraform/region/.terraform.lock.hcl
@@ -3,22 +3,9 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.28.0"
-  constraints = ">= 5.5.0, 6.28.0"
+  constraints = ">= 5.5.0, >= 6.28.0, 6.28.0"
   hashes = [
-    "h1:0aLYWoSJohXeijeD/nB/8wh++Ge2nI/BfsxdZZJf8LI=",
-    "h1:2bDndcCvti7hgXw4MkMo37cyAAu1gk+JvsU9/UbRJNQ=",
-    "h1:4xwnb3NQWg9A3SGIYjvhd5WmFbBP++9fLhvcokAKzKc=",
-    "h1:HYhZgZXKnPKQfV8EFrlKXi4M9YW/RVZ30PpJPKt6Tes=",
     "h1:RwoFuX1yGMVaKJaUmXDKklEaQ/yUCEdt5k2kz+/g08c=",
-    "h1:XOuWba4Jt7rm+TLlLUhIp8m9i5jbA1K9Ab1FUL1PEjE=",
-    "h1:aGqTvbGcexw1rDeneRME44suXtkM6QKHXEmfEiM8gjc=",
-    "h1:bMiTeecRXGBmx/btqJX57X0KuJ3j9BmM/ph3KZ3FGj0=",
-    "h1:dVGoEW/F1Xb7k2bm+O3IG2eCoe/Dxid4p81yy3lbwqs=",
-    "h1:pAg//+BvaDrvVtw5xgijtsKXAYQGLn2mKl0LBUf6aO8=",
-    "h1:tsoMkB0xujvKt6jQuRlOGVI++eLTLCYqnVAOAeiNoQQ=",
-    "h1:we7AZ0oyoO4dyZtYSoAE5nbbGyDrwyc9+99LbnCrb7I=",
-    "h1:wzZdGs0FFmNqIgPyo9tKnGKJ37BGNSgwRrEXayL29+0=",
-    "h1:xBJIpfIyvY8aCtkbZM/Om23s7bfNqkpe4pTnBlLiAws=",
     "zh:0ba0d5eb6e0c6a933eb2befe3cdbf22b58fbc0337bf138f95bf0e8bb6e6df93e",
     "zh:23eacdd4e6db32cf0ff2ce189461bdbb62e46513978d33c5de4decc4670870ec",
     "zh:307b06a15fc00a8e6fd243abde2cbe5112e9d40371542665b91bec1018dd6e3c",
@@ -41,19 +28,7 @@ provider "registry.terraform.io/pagerduty/pagerduty" {
   version     = "3.30.9"
   constraints = "~> 3.0, 3.30.9"
   hashes = [
-    "h1:+Mj6CdRgIZjw81PkBTFOnBafdhjpQBnazzl9dFyG9w4=",
-    "h1:0DmU/Syyvtf0bu5kkAp8FBh2xP0p+/RaWrs7qZixRDQ=",
     "h1:1BDIoKLH4Ta1m+bddYvLbjnrnA+DaP5pnbd92JGwdFg=",
-    "h1:I9t2cdxXK187LewOqNcmVS87KY6OszotP96huzsHzno=",
-    "h1:QHa8cxauMnMfTuQZKhf6E+mMfYR2Tib6Y3AEonpIy/k=",
-    "h1:UGaxdM7NwR4R5nmOHDRlSL0lOjQ49C5FmsNQrZPEwNc=",
-    "h1:W2QB2M8hwbkSZUJbNz44s/zTZMxLRSgOVqSzGXcjD98=",
-    "h1:bvcIj+l+Ok1KksUAYr7eyhkfWJvolZTOBDFbyaxyslE=",
-    "h1:i02vpsiWrimpQ7SHe6ZNNDYgjuMwyQUN/VT2pCVGyLI=",
-    "h1:kSWSX3l4O4NB+DClZiGbGoaqpF9pI1WywAOr4v7A/ew=",
-    "h1:nm9lvRDNFEj9qMqoPhrdW9bGHyiy+/0aKnp8WGtnj2E=",
-    "h1:uEe3RhggOPCgI5bQbuB9vQLVNKpln4HanF72jzbCXM0=",
-    "h1:wn8lfnUbErDDxEPg3P3u3gqkZPH/h9KwQxumMmPzVR0=",
     "zh:045ccead16193b91eef257f9fc14621ccfab87a6c9073d73e47ed0989b644d8b",
     "zh:0795ff87aea77e27924658c01f09c403c46df201f000877b1814abe1fc570d2f",
     "zh:21b2671fee3ee4eaab6c0191f46b4cca30ea827cf14e46ad1c55c89015b9ed1e",

--- a/terraform/region/kms_modules.tf
+++ b/terraform/region/kms_modules.tf
@@ -1,5 +1,5 @@
 module "aws_backup_cross_account_key" {
-  source             = "git::https://github.com/ministryofjustice/opg-terraform-aws-kms-key.git?ref=v0.0.5"
+  source             = "git::https://github.com/ministryofjustice/opg-terraform-aws-kms-key.git?ref=v0.0.10"
   description        = "Encryption keys for Make an LPA backups copied into the backup account"
   alias              = "opg-lpa-${local.account_name}-aws-backup-key"
   primary_region     = "eu-west-1"
@@ -31,7 +31,7 @@ module "aws_backup_cross_account_key" {
 }
 
 module "aws_backup_source_account_key" {
-  source             = "git::https://github.com/ministryofjustice/opg-terraform-aws-kms-key.git?ref=v0.0.5"
+  source             = "git::https://github.com/ministryofjustice/opg-terraform-aws-kms-key.git?ref=v0.0.10"
   description        = "Encryption keys for Make an LPA backups copied into the backup account"
   alias              = "opg-lpa-${local.account_name}-aws-backup-source-account-key"
   primary_region     = "eu-west-1"
@@ -63,7 +63,7 @@ module "aws_backup_source_account_key" {
 }
 
 module "aurora_database_encryption_key" {
-  source      = "git::https://github.com/ministryofjustice/opg-terraform-aws-kms-key.git?ref=v0.0.5"
+  source      = "git::https://github.com/ministryofjustice/opg-terraform-aws-kms-key.git?ref=v0.0.10"
   description = "Customer managed encryption key for Aurora RDS database"
   alias       = "opg-lpa-${local.account_name}-rds-encryption-key"
   usage_services = [

--- a/terraform/region/kms_modules.tf
+++ b/terraform/region/kms_modules.tf
@@ -110,7 +110,7 @@ module "aurora_database_encryption_key" {
 }
 
 module "secrets_manager_encryption_key" {
-  source             = "git::https://github.com/ministryofjustice/opg-terraform-aws-kms-key.git?ref=v0.0.5"
+  source             = "git::https://github.com/ministryofjustice/opg-terraform-aws-kms-key.git?ref=v0.0.10"
   description        = "Customer managed encryption key for Secrets Manager"
   alias              = "opg-lpa-${local.account_name}-secrets-manager-encryption-key"
   usage_services     = []

--- a/terraform/region/secrets.tf
+++ b/terraform/region/secrets.tf
@@ -9,7 +9,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_common_admin_accounts" {
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }
 
@@ -21,7 +21,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_common_account_cleanup_notificatio
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }
 
@@ -34,7 +34,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_front_csrf_salt" {
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }
 
@@ -46,7 +46,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_api_notify_api_key" {
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }
 
@@ -59,7 +59,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_admin_jwt_secret" {
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }
 
@@ -72,7 +72,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_front_gov_pay_key" {
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }
 
@@ -84,7 +84,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_front_os_places_hub_license_key" {
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }
 
@@ -97,7 +97,7 @@ resource "aws_secretsmanager_secret" "opg_lpa_pdf_owner_password" {
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }
 
@@ -110,7 +110,7 @@ resource "aws_secretsmanager_secret" "api_rds_username" {
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }
 
@@ -122,7 +122,7 @@ resource "aws_secretsmanager_secret" "api_rds_password" {
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }
 
@@ -134,7 +134,7 @@ resource "aws_secretsmanager_secret" "api_rds_credentials" {
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }
 
@@ -147,7 +147,7 @@ resource "aws_secretsmanager_secret" "performance_platform_db_username" {
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }
 
@@ -159,6 +159,6 @@ resource "aws_secretsmanager_secret" "performance_platform_db_password" {
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys.eu-west-2.arn
   }
 }

--- a/terraform/region/secrets.tf
+++ b/terraform/region/secrets.tf
@@ -4,24 +4,24 @@
 resource "aws_secretsmanager_secret" "opg_lpa_common_admin_accounts" {
   name                           = "${local.account_name}/opg_lpa_common_admin_accounts"
   tags                           = local.admin_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }
 
 resource "aws_secretsmanager_secret" "opg_lpa_common_account_cleanup_notification_recipients" {
   name                           = "${local.account_name}/opg_lpa_common_account_cleanup_notification_recipients"
   tags                           = local.admin_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }
 
@@ -29,24 +29,24 @@ resource "aws_secretsmanager_secret" "opg_lpa_common_account_cleanup_notificatio
 resource "aws_secretsmanager_secret" "opg_lpa_front_csrf_salt" {
   name                           = "${local.account_name}/opg_lpa_front_csrf_salt"
   tags                           = local.api_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }
 
 resource "aws_secretsmanager_secret" "opg_lpa_api_notify_api_key" {
   name                           = "${local.account_name}/opg_lpa_api_notify_api_key"
   tags                           = local.api_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }
 
@@ -54,12 +54,12 @@ resource "aws_secretsmanager_secret" "opg_lpa_api_notify_api_key" {
 resource "aws_secretsmanager_secret" "opg_lpa_admin_jwt_secret" {
   name                           = "${local.account_name}/opg_lpa_admin_jwt_secret"
   tags                           = local.admin_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }
 
@@ -67,24 +67,24 @@ resource "aws_secretsmanager_secret" "opg_lpa_admin_jwt_secret" {
 resource "aws_secretsmanager_secret" "opg_lpa_front_gov_pay_key" {
   name                           = "${local.account_name}/opg_lpa_front_gov_pay_key"
   tags                           = local.front_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }
 
 resource "aws_secretsmanager_secret" "opg_lpa_front_os_places_hub_license_key" {
   name                           = "${local.account_name}/opg_lpa_front_os_places_hub_license_key"
   tags                           = local.front_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }
 
@@ -92,12 +92,12 @@ resource "aws_secretsmanager_secret" "opg_lpa_front_os_places_hub_license_key" {
 resource "aws_secretsmanager_secret" "opg_lpa_pdf_owner_password" {
   name                           = "${local.account_name}/opg_lpa_pdf_owner_password"
   tags                           = local.pdf_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }
 
@@ -105,36 +105,36 @@ resource "aws_secretsmanager_secret" "opg_lpa_pdf_owner_password" {
 resource "aws_secretsmanager_secret" "api_rds_username" {
   name                           = "${local.account_name}/api_rds_username"
   tags                           = local.db_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }
 
 resource "aws_secretsmanager_secret" "api_rds_password" {
   name                           = "${local.account_name}/api_rds_password"
   tags                           = local.db_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }
 
 resource "aws_secretsmanager_secret" "api_rds_credentials" {
   name                           = "${local.account_name}/api_rds_credentials"
   tags                           = local.db_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }
 
@@ -142,23 +142,23 @@ resource "aws_secretsmanager_secret" "api_rds_credentials" {
 resource "aws_secretsmanager_secret" "performance_platform_db_username" {
   name                           = "${local.account_name}/performance_platform_db_username"
   tags                           = local.performance_platform_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }
 
 resource "aws_secretsmanager_secret" "performance_platform_db_password" {
   name                           = "${local.account_name}/performance_platform_db_password"
   tags                           = local.performance_platform_component_tag
-  kms_key_id                     = aws_kms_key.multi_region_secrets_encryption_key.key_id
+  kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn
   force_overwrite_replica_secret = true
 
   replica {
     region     = "eu-west-2"
-    kms_key_id = aws_kms_key.multi_region_secrets_encryption_key.key_id
+    kms_key_id = module.secrets_manager_encryption_key.replica_keys["eu-west-2"].arn
   }
 }


### PR DESCRIPTION
## Purpose

Control who can encrypt and decrypt secrets in aws secrets manager

Fixes LPAL-1720

## Approach

- use new key for secret encryption in region

## Learning

- https://github.com/ministryofjustice/opg-terraform-aws-kms-key
