### PR TITLE
LPAL-2095| adding opg_lpa_api_aurh_log_salt secret to execution role

### DIFF
--- a/terraform/environment/modules/environment/iam_ecs_permissions.tf
+++ b/terraform/environment/modules/environment/iam_ecs_permissions.tf
@@ -79,7 +79,8 @@ data "aws_iam_policy_document" "execution_role" {
       data.aws_secretsmanager_secret.api_rds_username.arn,
       data.aws_secretsmanager_secret.api_rds_password.arn,
       data.aws_secretsmanager_secret.performance_platform_db_username.arn,
-      data.aws_secretsmanager_secret.performance_platform_db_password.arn
+      data.aws_secretsmanager_secret.performance_platform_db_password.arn,
+      data.aws_secretsmanager_secret.opg_lpa_api_auth_log_salt.arn,
     ]
   }
 

--- a/terraform/environment/modules/environment/secrets.tf
+++ b/terraform/environment/modules/environment/secrets.tf
@@ -61,6 +61,10 @@ data "aws_secretsmanager_secret" "performance_platform_db_password" {
   name = "${var.account_name}/performance_platform_db_password"
 }
 
+data "aws_secretsmanager_secret" "opg_lpa_api_auth_log_salt" {
+  name = "${var.account_name}/opg_lpa_api_auth_log_salt"
+}
+
 resource "aws_secretsmanager_secret" "api_rds_credentials" {
   name                    = "${var.environment_name}/api_rds_credentials"
   recovery_window_in_days = 0


### PR DESCRIPTION
## Purpose

Adding data source for new secret and adding to execution role secret allow list to unblock preprod ecs get-secret-value failure. 

Fixes LPAL-2095

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
