### PR TITLE
LPAL-2097| Region - adding custom policies for application log group encryption key

### DIFF
--- a/terraform/region/data_sources.tf
+++ b/terraform/region/data_sources.tf
@@ -3,3 +3,5 @@ data "aws_caller_identity" "current" {}
 data "aws_caller_identity" "backup" {
   provider = aws.backup
 }
+
+data "aws_region" "current" {}

--- a/terraform/region/kms_modules.tf
+++ b/terraform/region/kms_modules.tf
@@ -148,13 +148,13 @@ module "secrets_manager_encryption_key" {
 }
 
 module "application_log_group_encryption_key" {
-  source             = "git::https://github.com/ministryofjustice/opg-terraform-aws-kms-key.git?ref=v0.0.10"
-  description        = "Customer managed encryption key for application CloudWatch log groups"
-  alias              = "opg-lpa-${local.account_name}-application-log-group-encryption-key"
-  usage_services     = []
-  primary_region     = "eu-west-1"
-  replicas_to_create = ["eu-west-2"]
-
+  source                      = "git::https://github.com/ministryofjustice/opg-terraform-aws-kms-key.git?ref=v1.0.0"
+  description                 = "Customer managed encryption key for application CloudWatch log groups"
+  alias                       = "opg-lpa-${local.account_name}-application-log-group-encryption-key"
+  usage_services              = []
+  primary_region              = "eu-west-1"
+  replicas_to_create          = ["eu-west-2"]
+  additional_policy_documents = data.aws_iam_policy_document.application_log_group_kms_policy.json
   administrator_roles = [
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass",
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/opg-lpa-ci",

--- a/terraform/region/kms_policies_custom.tf
+++ b/terraform/region/kms_policies_custom.tf
@@ -1,20 +1,6 @@
 
-# custom application log group encryption key policy document
-
+# additional custom policy document for application_log_group kms_key
 data "aws_iam_policy_document" "application_log_group_kms_policy" {
-  statement {
-    sid    = "Allow root to manage application log key policies"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
-    }
-
-    actions   = ["kms:*"]
-    resources = ["*"]
-  }
-
   statement {
     sid    = "Allow CloudWatch access to application log encryption key"
     effect = "Allow"

--- a/terraform/region/kms_policies_custom.tf
+++ b/terraform/region/kms_policies_custom.tf
@@ -1,0 +1,42 @@
+
+# custom application log group encryption key policy document
+
+data "aws_iam_policy_document" "application_log_group_kms_policy" {
+  statement {
+    sid    = "Allow root to manage application log key policies"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow CloudWatch access to application log encryption key"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+    }
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "ArnLike"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+      values   = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:*"]
+    }
+  }
+}

--- a/terraform/region/kms_policies_custom.tf
+++ b/terraform/region/kms_policies_custom.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "application_log_group_kms_policy" {
 
     principals {
       type        = "Service"
-      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+      identifiers = ["logs.${data.aws_region.current.region}.amazonaws.com"]
     }
 
     actions = [


### PR DESCRIPTION
## Purpose


- Updating application_log_group kms_key with new custom policies attribute from kms module update. 
- Added permissions for cloudwatch to use kms key for encyrption on logs. 


Fixes LPAL-2097

## Approach

- Added custom kms key policies document with additional policy.
- Called new custom policy into key module via "additional_policy_documents" variable.


## Learning

`Multiple documents can be combined using the source_policy_documents or override_policy_documents attributes. source_policy_documents requires that all documents have unique Sids, while override_policy_documents will iteratively override matching Sids.
`
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#example-with-both-source-and-override-documents
