### PR TITLE
LPAL-2100| Adding snyk ignore rules for postgres upgrade to unblock pipeline

### DIFF
--- a/service-api/docker/app/.snyk
+++ b/service-api/docker/app/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-ALPINE323-POSTGRESQL18-16722170:
+    - "*":
+        reason: Scheduled for fix LPAL-2100
+        expires: 2026-06-19T13:30:05.884Z
+        created: 2026-05-19T13:30:05.890Z
+patch: {}

--- a/service-api/docker/app/.snyk
+++ b/service-api/docker/app/.snyk
@@ -5,6 +5,6 @@ ignore:
   SNYK-ALPINE323-POSTGRESQL18-16722170:
     - "*":
         reason: Scheduled for fix LPAL-2100
-        expires: 2026-06-19T13:30:05.884Z
-        created: 2026-05-19T13:30:05.890Z
+        expires: 2026-06-19T11:00:05.884Z
+        created: 2026-05-19T11:00:05.890Z
 patch: {}

--- a/service-seeding/docker/app/.snyk
+++ b/service-seeding/docker/app/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-ALPINE323-POSTGRESQL18-16722170:
+    - "*":
+        reason: Scheduled for fix LPAL-2100
+        expires: 2026-06-19T13:30:05.884Z
+        created: 2026-05-19T13:30:05.890Z
+patch: {}

--- a/service-seeding/docker/app/.snyk
+++ b/service-seeding/docker/app/.snyk
@@ -5,6 +5,6 @@ ignore:
   SNYK-ALPINE323-POSTGRESQL18-16722170:
     - "*":
         reason: Scheduled for fix LPAL-2100
-        expires: 2026-06-19T13:30:05.884Z
-        created: 2026-05-19T13:30:05.890Z
+        expires: 2026-06-19T11:00:05.884Z
+        created: 2026-05-19T11:00:05.890Z
 patch: {}


### PR DESCRIPTION
## Purpose

Putting postgres vulnerability to ignore list as LPAL-2101 will fix this later 

Fixes LPAL-2100

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
