### PR TITLE
LPAL-1366| setting ecs log config  mode to non-blocking

### DIFF
--- a/terraform/environment/modules/environment/ecs_admin.tf
+++ b/terraform/environment/modules/environment/ecs_admin.tf
@@ -154,7 +154,9 @@ locals {
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
           awslogs-region        = var.region_name,
-          awslogs-stream-prefix = "${var.environment_name}.admin-web.online-lpa"
+          awslogs-stream-prefix = "${var.environment_name}.admin-web.online-lpa",
+          mode                  = "non-blocking",
+          max-buffer-size       = "25m",
         }
       },
       environment = [
@@ -199,7 +201,9 @@ locals {
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
           awslogs-region        = var.region_name,
-          awslogs-stream-prefix = "${var.environment_name}.admin-app.online-lpa"
+          awslogs-stream-prefix = "${var.environment_name}.admin-app.online-lpa",
+          mode                  = "non-blocking",
+          max-buffer-size       = "25m",
         }
       },
       secrets = [

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -212,6 +212,8 @@ locals {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
           awslogs-region        = var.region_name,
           awslogs-stream-prefix = "${var.environment_name}.api-web.online-lpa",
+          mode                  = "non-blocking",
+          max-buffer-size       = "25m",
         }
       },
       environment = [
@@ -258,7 +260,9 @@ locals {
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
           awslogs-region        = var.region_name,
-          awslogs-stream-prefix = "${var.environment_name}.api-app.online-lpa"
+          awslogs-stream-prefix = "${var.environment_name}.api-app.online-lpa",
+          mode                  = "non-blocking",
+          max-buffer-size       = "25m",
         }
       },
       secrets = [

--- a/terraform/environment/modules/environment/ecs_api_migrations.tf
+++ b/terraform/environment/modules/environment/ecs_api_migrations.tf
@@ -83,7 +83,9 @@ locals {
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
           awslogs-region        = var.region_name,
-          awslogs-stream-prefix = "${var.environment_name}.migrations.online-lpa"
+          awslogs-stream-prefix = "${var.environment_name}.migrations.online-lpa",
+          mode                  = "non-blocking",
+          max-buffer-size       = "25m",
         }
       },
       secrets = [

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -163,7 +163,9 @@ locals {
       options = {
         awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
         awslogs-region        = "eu-west-1",
-        awslogs-stream-prefix = "${var.environment_name}.front-web.online-lpa"
+        awslogs-stream-prefix = "${var.environment_name}.front-web.online-lpa",
+        mode                  = "non-blocking",
+        max-buffer-size       = "25m",
       }
     },
     environment = [
@@ -210,7 +212,9 @@ locals {
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
           awslogs-region        = var.region_name,
-          awslogs-stream-prefix = "${var.environment_name}.front-app.online-lpa"
+          awslogs-stream-prefix = "${var.environment_name}.front-app.online-lpa",
+          mode                  = "non-blocking",
+          max-buffer-size       = "25m",
         }
       },
       secrets = [

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -118,7 +118,9 @@ locals {
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
           awslogs-region        = var.region_name,
-          awslogs-stream-prefix = "${var.environment_name}.pdf-app.online-lpa"
+          awslogs-stream-prefix = "${var.environment_name}.pdf-app.online-lpa",
+          mode                  = "non-blocking",
+          max-buffer-size       = "25m",
         }
       },
       secrets = [

--- a/terraform/environment/modules/environment/ecs_seeding.tf
+++ b/terraform/environment/modules/environment/ecs_seeding.tf
@@ -73,7 +73,9 @@ locals {
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
           awslogs-region        = var.region_name,
-          awslogs-stream-prefix = "${var.environment_name}.seeding.online-lpa"
+          awslogs-stream-prefix = "${var.environment_name}.seeding.online-lpa",
+          mode                  = "non-blocking",
+          max-buffer-size       = "25m",
         }
       },
       secrets = [

--- a/terraform/environment/modules/environment/locals.tf
+++ b/terraform/environment/modules/environment/locals.tf
@@ -67,7 +67,9 @@ locals {
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
           awslogs-region        = var.region_name,
-          awslogs-stream-prefix = "${var.environment_name}.otel.online-lpa"
+          awslogs-stream-prefix = "${var.environment_name}.otel.online-lpa",
+          mode                  = "non-blocking",
+          max-buffer-size       = "25m",
         }
       }
     }


### PR DESCRIPTION
## Purpose
Preventing log loss with non-blocking mode in the AWSLogs container log driver

Fixes LPAL-1366

## Approach

https://aws.amazon.com/blogs/containers/preventing-log-loss-with-non-blocking-mode-in-the-awslogs-container-log-driver/

## Learning

https://aws.amazon.com/about-aws/whats-new/2025/04/amazon-ecs-set-default-log-driver-blocking-mode
