### PR TITLE
LPAL-1441| Enabling DNS resolver logs onto shared firewalled network module

### DIFF
--- a/terraform/region/main.tf
+++ b/terraform/region/main.tf
@@ -6,8 +6,8 @@ module "eu-west-1" {
   firewalled_vpc_cidr_range = local.account.firewalled_vpc_cidr_ranges.eu_west_1
   providers = {
     aws            = aws
-    aws.region     = aws.eu-west-1
     aws.management = aws.management
+    aws.region     = aws
   }
 }
 
@@ -19,7 +19,7 @@ module "eu-west-2" {
   firewalled_vpc_cidr_range = local.account.firewalled_vpc_cidr_ranges.eu_west_2
   providers = {
     aws            = aws.eu-west-2
-    aws.region     = aws.eu-west-2
     aws.management = aws.management_eu_west_2
+    aws.region     = aws.eu-west-2
   }
 }

--- a/terraform/region/main.tf
+++ b/terraform/region/main.tf
@@ -7,7 +7,7 @@ module "eu-west-1" {
   providers = {
     aws            = aws
     aws.management = aws.management
-    aws.region     = aws
+    aws.region     = aws.eu-west-1
   }
 }
 

--- a/terraform/region/main.tf
+++ b/terraform/region/main.tf
@@ -6,6 +6,7 @@ module "eu-west-1" {
   firewalled_vpc_cidr_range = local.account.firewalled_vpc_cidr_ranges.eu_west_1
   providers = {
     aws            = aws
+    aws.region     = aws.eu-west-1
     aws.management = aws.management
   }
 }
@@ -18,6 +19,7 @@ module "eu-west-2" {
   firewalled_vpc_cidr_range = local.account.firewalled_vpc_cidr_ranges.eu_west_2
   providers = {
     aws            = aws.eu-west-2
+    aws.region     = aws.eu-west-2
     aws.management = aws.management_eu_west_2
   }
 }

--- a/terraform/region/modules/region/data_sources.tf
+++ b/terraform/region/modules/region/data_sources.tf
@@ -1,3 +1,5 @@
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
+
+data "aws_default_tags" "current" {}

--- a/terraform/region/modules/region/firewalled_network.tf
+++ b/terraform/region/modules/region/firewalled_network.tf
@@ -118,4 +118,4 @@ resource "aws_route53_resolver_query_log_config_association" "main" {
   provider                     = aws.region
 }
 
-# testing dns resolver group logs  is enabled - spinning up new PR env
+# testing dns resolver group logs  is enabled - pushing pr env after secret import - test

--- a/terraform/region/modules/region/firewalled_network.tf
+++ b/terraform/region/modules/region/firewalled_network.tf
@@ -117,3 +117,5 @@ resource "aws_route53_resolver_query_log_config_association" "main" {
   resource_id                  = module.network.vpc.id
   provider                     = aws.region
 }
+
+# testing dns resolver group logs  is enabled

--- a/terraform/region/modules/region/firewalled_network.tf
+++ b/terraform/region/modules/region/firewalled_network.tf
@@ -92,3 +92,28 @@ resource "aws_db_subnet_group" "data" {
   name       = "data"
   subnet_ids = module.network.data_subnets[*].id
 }
+
+# DNS logs
+
+data "aws_kms_alias" "application_log_group_encryption_key" {
+  name = "alias/opg-lpa-${var.account_name}-application-log-group-encryption-key"
+}
+
+resource "aws_cloudwatch_log_group" "route_53_resolver_logs" {
+  name              = "${data.aws_default_tags.current.tags.environment-name}-route53-resolver-logs-${data.aws_region.current.region}"
+  retention_in_days = 400
+  kms_key_id        = data.aws_kms_alias.application_log_group_encryption_key.target_key_arn
+  provider          = aws.region
+}
+
+resource "aws_route53_resolver_query_log_config" "main" {
+  name            = "main"
+  destination_arn = aws_cloudwatch_log_group.route_53_resolver_logs.arn
+  provider        = aws.region
+}
+
+resource "aws_route53_resolver_query_log_config_association" "main" {
+  resolver_query_log_config_id = aws_route53_resolver_query_log_config.main.id
+  resource_id                  = module.network.vpc.id
+  provider                     = aws.region
+}

--- a/terraform/region/modules/region/firewalled_network.tf
+++ b/terraform/region/modules/region/firewalled_network.tf
@@ -118,4 +118,4 @@ resource "aws_route53_resolver_query_log_config_association" "main" {
   provider                     = aws.region
 }
 
-# testing dns resolver group logs  is enabled
+# testing dns resolver group logs  is enabled - spinning up new cluster

--- a/terraform/region/modules/region/firewalled_network.tf
+++ b/terraform/region/modules/region/firewalled_network.tf
@@ -118,4 +118,4 @@ resource "aws_route53_resolver_query_log_config_association" "main" {
   provider                     = aws.region
 }
 
-# testing dns resolver group logs  is enabled - spinning up new cluster
+# testing dns resolver group logs  is enabled - spinning up new PR env

--- a/terraform/region/modules/region/firewalled_network.tf
+++ b/terraform/region/modules/region/firewalled_network.tf
@@ -117,5 +117,3 @@ resource "aws_route53_resolver_query_log_config_association" "main" {
   resource_id                  = module.network.vpc.id
   provider                     = aws.region
 }
-
-# testing dns resolver group logs  is enabled - pushing pr env after secret import - test

--- a/terraform/region/modules/region/versions.tf
+++ b/terraform/region/modules/region/versions.tf
@@ -4,7 +4,8 @@ terraform {
       source  = "hashicorp/aws"
       version = "6.28.0"
       configuration_aliases = [
-        aws.management
+        aws.management,
+        aws.region
       ]
     }
     pagerduty = {

--- a/terraform/region/modules/region/versions.tf
+++ b/terraform/region/modules/region/versions.tf
@@ -5,7 +5,7 @@ terraform {
       version = "6.28.0"
       configuration_aliases = [
         aws.management,
-        aws.region
+        aws.region,
       ]
     }
     pagerduty = {


### PR DESCRIPTION
## Purpose

Enabling DNS resolver logs onto shared firework network module in region 

Fixes LPAL-1441

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
