### PR TITLE
LPAL-1585 - Count suspicious URI patterns at WAF

### DIFF
--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -35,9 +35,70 @@ resource "aws_wafv2_web_acl" "main" {
       metric_name                = "allow-on-keyword"
       sampled_requests_enabled   = true
     }
-
   }
+  rule {
+    name     = "BlockSuspiciousURIPatterns"
+    priority = 6
 
+    action {
+      block {}
+    }
+
+    statement {
+      regex_pattern_set_reference_statement {
+        arn = aws_wafv2_regex_pattern_set.suspicious_uri_patterns.arn
+
+        field_to_match {
+          uri_path {}
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "LOWERCASE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockSuspiciousURIPatterns"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "RateLimitSuspiciousURIPatterns"
+    priority = 7
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 10
+        aggregate_key_type = "IP"
+
+        scope_down_statement {
+          regex_pattern_set_reference_statement {
+            arn = aws_wafv2_regex_pattern_set.suspicious_uri_patterns.arn
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitSuspiciousURIPatterns"
+      sampled_requests_enabled   = true
+    }
+  }
   rule {
     name     = "AWS-AWSManagedRulesPHPRuleSet"
     priority = 10
@@ -193,8 +254,18 @@ resource "aws_wafv2_regex_pattern_set" "allow_on_keyword" {
   regular_expression {
     regex_string = ".*[oO][nN].*=.*$"
   }
-
 }
+
+resource "aws_wafv2_regex_pattern_set" "suspicious_uri_patterns" {
+  name        = "suspicious-uri-patterns"
+  description = "Regex pattern set for suspicious URI patterns"
+  scope       = "REGIONAL"
+
+  regular_expression {
+    regex_string = "(?i)\\.(env|git|sql|bak|php|asp|aspx|cgi|sh|exe|tar|gz|tgz|zip|rar|7z|z|bz2|lz|xz|db|sqlite|sqlitedb|war|jar|config|conf|ini|log|pem|key|p12|pfx|crt|ovpn|htaccess|htpasswd|DS_Store|swp)$"
+  }
+}
+
 
 resource "aws_wafv2_web_acl_logging_configuration" "main" {
   log_destination_configs = [aws_cloudwatch_log_group.waf_web_acl.arn]

--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -41,7 +41,7 @@ resource "aws_wafv2_web_acl" "main" {
     priority = 6
 
     action {
-      block {}
+      count {}
     }
 
     statement {
@@ -70,7 +70,7 @@ resource "aws_wafv2_web_acl" "main" {
     priority = 7
 
     action {
-      block {}
+      count {}
     }
 
     statement {
@@ -265,7 +265,6 @@ resource "aws_wafv2_regex_pattern_set" "suspicious_uri_patterns" {
     regex_string = "(?i)\\.(env|git|sql|bak|php|asp|aspx|cgi|sh|exe|tar|gz|tgz|zip|rar|7z|z|bz2|lz|xz|db|sqlite|sqlitedb|war|jar|config|conf|ini|log|pem|key|p12|pfx|crt|ovpn|htaccess|htpasswd|DS_Store|swp)$"
   }
 }
-
 
 resource "aws_wafv2_web_acl_logging_configuration" "main" {
   log_destination_configs = [aws_cloudwatch_log_group.waf_web_acl.arn]


### PR DESCRIPTION
## Purpose

Prevent scanning noise and probing.

Fixes LPAL-1585

## Approach

- add regex for suspicious URI patterns
- set to count mode for evaluation

## Learning

- https://github.com/ministryofjustice/opg-use-an-lpa/blob/main/terraform/account/region/waf.tf
