### PR TITLE
Ensure tokens are always 20 characters long

### DIFF
--- a/shared/src/functions/make_token.php
+++ b/shared/src/functions/make_token.php
@@ -7,5 +7,6 @@ function make_token(int $length = 16): string
     $token = sprintf("0x%s", bin2hex(random_bytes($length)));
 
     // Use base62 for shorter tokens
-    return gmp_strval($token, 62);
+    $strBase62 = gmp_strval($token, 62);
+    return str_pad($strBase62, 20, '0', STR_PAD_LEFT);
 }


### PR DESCRIPTION
## Purpose

If the generated token starts with 0s, `gmp_strval` will generate a string shorter than 20 characters:

```php
echo gmp_strval('0xffff', 62) === 'H31';
```

The string is no less random (10% of numbers under 1,000,000 are 6 numbers of fewer) but might cause confusion and occasionally causes tests to fail.

Fixes LPAL-1520 #patch

## Approach

Therefore, if the token string is less than 20 characters we pad it with 0s to make them all 20 chars long.

