### PR TITLE
LPAL-2064 migrate to govuk frontend

### DIFF
--- a/service-front/assets/sass/extensions/elements/_elements-typography.scss
+++ b/service-front/assets/sass/extensions/elements/_elements-typography.scss
@@ -11,7 +11,7 @@
     margin-top: govuk-spacing(6);
     margin-bottom: govuk-spacing(3);
 
-    @media (min-width: 641px) {
+    @include govuk-media-query($from: tablet) {
         margin-top: govuk-spacing(9);
         margin-bottom: govuk-spacing(6);
     }
@@ -25,7 +25,7 @@
     margin-top: govuk-spacing(6);
     margin-bottom: govuk-spacing(3);
 
-    @media (min-width: 641px) {
+    @include govuk-media-query($from: tablet) {
         margin-top: govuk-spacing(9);
         margin-bottom: govuk-spacing(6);
     }
@@ -45,7 +45,7 @@
     margin-top: govuk-spacing(5);
     margin-bottom: govuk-spacing(2);
 
-    @media (min-width: 641px) {
+    @include govuk-media-query($from: tablet) {
         margin-top: 45px;
         margin-bottom: govuk-spacing(4);
     }
@@ -65,7 +65,7 @@
     margin-top: govuk-spacing(5);
     margin-bottom: govuk-spacing(2);
 
-    @media (min-width: 641px) {
+    @include govuk-media-query($from: tablet) {
         margin-top: 45px;
         margin-bottom: govuk-spacing(4);
     }
@@ -78,7 +78,7 @@
     margin-top: govuk-spacing(2);
     margin-bottom: govuk-spacing(1);
 
-    @media (min-width: 641px) {
+    @include govuk-media-query($from: tablet) {
         margin-top: govuk-spacing(4);
     }
 

--- a/service-front/assets/sass/extensions/elements/_elements-typography.scss
+++ b/service-front/assets/sass/extensions/elements/_elements-typography.scss
@@ -8,78 +8,78 @@
 }
 
 .heading-xlarge {
-    margin-top: em(30, 32);
-    margin-bottom: em(15, 32);
+    margin-top: govuk-spacing(6);
+    margin-bottom: govuk-spacing(3);
 
-    @include media(tablet) {
-        margin-top: em(60, 48);
-        margin-bottom: em(30, 48);
+    @media (min-width: 641px) {
+        margin-top: govuk-spacing(9);
+        margin-bottom: govuk-spacing(6);
     }
 }
 
 // Duplicating heading classes as placeholders to enable proper extending
 // Headings
 %heading-xlarge {
-    @include bold-48();
+    @include govuk-font($size: 48, $weight: bold);
 
-    margin-top: em(30, 32);
-    margin-bottom: em(15, 32);
+    margin-top: govuk-spacing(6);
+    margin-bottom: govuk-spacing(3);
 
-    @include media(tablet) {
-        margin-top: em(60, 48);
-        margin-bottom: em(30, 48);
+    @media (min-width: 641px) {
+        margin-top: govuk-spacing(9);
+        margin-bottom: govuk-spacing(6);
     }
 
     .heading-secondary {
-        @include heading-27();
+        @include govuk-font($size: 27);
 
         display: block;
-        color: $secondary-text-colour;
+        color: $govuk-secondary-text-colour;
     }
 
 }
 
 %heading-large {
-    @include bold-36();
+    @include govuk-font($size: 36, $weight: bold);
 
-    margin-top: em(25, 24);
-    margin-bottom: em(10, 24);
+    margin-top: govuk-spacing(5);
+    margin-bottom: govuk-spacing(2);
 
-    @include media(tablet) {
-        margin-top: em(45, 36);
-        margin-bottom: em(20, 36);
+    @media (min-width: 641px) {
+        margin-top: 45px;
+        margin-bottom: govuk-spacing(4);
     }
 
     .heading-secondary {
-        @include heading-24();
+        @include govuk-font($size: 24);
 
         display: block;
-        color: $secondary-text-colour;
+        color: $govuk-secondary-text-colour;
     }
 
 }
 
 %heading-medium {
-    @include bold-24();
+    @include govuk-font($size: 24, $weight: bold);
 
-    margin-top: em(25, 20);
-    margin-bottom: em(10, 20);
+    margin-top: govuk-spacing(5);
+    margin-bottom: govuk-spacing(2);
 
-    @include media(tablet) {
-        margin-top: em(45, 24);
-        margin-bottom: em(20, 24);
+    @media (min-width: 641px) {
+        margin-top: 45px;
+        margin-bottom: govuk-spacing(4);
     }
 
 }
 
 %heading-small {
-    @include bold-19();
+    @include govuk-font($size: 19, $weight: bold);
 
-    margin-top: em(10, 16);
-    margin-bottom: em(5, 16);
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(1);
 
-    @include media(tablet) {
-        margin-top: em(20, 19);
+    @media (min-width: 641px) {
+        margin-top: govuk-spacing(4);
     }
 
 }

--- a/service-front/assets/sass/extensions/elements/_forms.scss
+++ b/service-front/assets/sass/extensions/elements/_forms.scss
@@ -41,7 +41,7 @@
 
 .form-hint--strong {
     margin-top: 10px;
-    color: $black;
+    color: govuk-colour("black");
 }
 
 .form-group-checkbox {

--- a/service-front/assets/sass/extensions/elements/_icons.scss
+++ b/service-front/assets/sass/extensions/elements/_icons.scss
@@ -41,7 +41,7 @@
     @include icon(icon-question, 52, 50);
     margin-right: 10px;
 
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
         @include icon(icon-question, 31, 30);
         margin-right: 6px;
         background-size: contain;
@@ -54,7 +54,7 @@
 
 .icon-tick {
     @include icon(icon-tick, 22, 22);
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
         @include icon(icon-tick, 16, 16);
         margin-right: 6px;
         background-size: contain;
@@ -63,7 +63,7 @@
 
 .icon-cross {
     @include icon(icon-cross, 22, 22);
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
         @include icon(icon-cross, 16, 16);
         margin-right: 6px;
         background-size: contain;
@@ -77,7 +77,7 @@
 
 .icon-person {
     @include icon(icon-person, 27, 27);
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
         @include icon(icon-person, 27, 27);
         margin-right: 6px;
         background-size: contain;
@@ -86,7 +86,7 @@
 
 .icon-phone {
     @include icon(icon-phone, 36, 36);
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
         @include icon(icon-phone, 27, 27);
         background-size: contain;
     }
@@ -94,7 +94,7 @@
 
 .icon-email {
     @include icon(icon-email, 36, 36);
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
         @include icon(icon-email, 27, 27);
         background-size: contain;
     }
@@ -102,7 +102,7 @@
 
 .icon-post {
     @include icon(icon-post, 36, 36);
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
         @include icon(icon-post, 27, 27);
         background-size: contain;
     }
@@ -110,7 +110,7 @@
 
 .icon-fax {
     @include icon(icon-fax, 36, 36);
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
         @include icon(icon-fax, 27, 27);
         background-size: contain;
     }
@@ -118,7 +118,7 @@
 
 .icon-bin {
     @include icon(icon-bin, 27, 27);
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
         @include icon(icon-bin, 27, 27);
         background-size: contain;
     }
@@ -126,7 +126,7 @@
 
 .icon-print {
     @include icon(icon-print, 36, 36);
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
         @include icon(icon-print, 27, 27);
         background-size: contain;
     }

--- a/service-front/assets/sass/extensions/elements/_icons.scss
+++ b/service-front/assets/sass/extensions/elements/_icons.scss
@@ -41,20 +41,20 @@
     @include icon(icon-question, 52, 50);
     margin-right: 10px;
 
-    @include media(mobile) {
+    @media (max-width: 640px) {
         @include icon(icon-question, 31, 30);
         margin-right: 6px;
         background-size: contain;
     }
 
-    @include media($max-width: 360px) {
+    @media (max-width: 360px) {
         display: none;
     }
 }
 
 .icon-tick {
     @include icon(icon-tick, 22, 22);
-    @include media(mobile) {
+    @media (max-width: 640px) {
         @include icon(icon-tick, 16, 16);
         margin-right: 6px;
         background-size: contain;
@@ -63,7 +63,7 @@
 
 .icon-cross {
     @include icon(icon-cross, 22, 22);
-    @include media(mobile) {
+    @media (max-width: 640px) {
         @include icon(icon-cross, 16, 16);
         margin-right: 6px;
         background-size: contain;
@@ -77,7 +77,7 @@
 
 .icon-person {
     @include icon(icon-person, 27, 27);
-    @include media(mobile) {
+    @media (max-width: 640px) {
         @include icon(icon-person, 27, 27);
         margin-right: 6px;
         background-size: contain;
@@ -86,7 +86,7 @@
 
 .icon-phone {
     @include icon(icon-phone, 36, 36);
-    @include media(mobile) {
+    @media (max-width: 640px) {
         @include icon(icon-phone, 27, 27);
         background-size: contain;
     }
@@ -94,7 +94,7 @@
 
 .icon-email {
     @include icon(icon-email, 36, 36);
-    @include media(mobile) {
+    @media (max-width: 640px) {
         @include icon(icon-email, 27, 27);
         background-size: contain;
     }
@@ -102,7 +102,7 @@
 
 .icon-post {
     @include icon(icon-post, 36, 36);
-    @include media(mobile) {
+    @media (max-width: 640px) {
         @include icon(icon-post, 27, 27);
         background-size: contain;
     }
@@ -110,7 +110,7 @@
 
 .icon-fax {
     @include icon(icon-fax, 36, 36);
-    @include media(mobile) {
+    @media (max-width: 640px) {
         @include icon(icon-fax, 27, 27);
         background-size: contain;
     }
@@ -118,7 +118,7 @@
 
 .icon-bin {
     @include icon(icon-bin, 27, 27);
-    @include media(mobile) {
+    @media (max-width: 640px) {
         @include icon(icon-bin, 27, 27);
         background-size: contain;
     }
@@ -126,7 +126,7 @@
 
 .icon-print {
     @include icon(icon-print, 36, 36);
-    @include media(mobile) {
+    @media (max-width: 640px) {
         @include icon(icon-print, 27, 27);
         background-size: contain;
     }

--- a/service-front/assets/sass/utilities/_helpers.scss
+++ b/service-front/assets/sass/utilities/_helpers.scss
@@ -28,24 +28,24 @@
 
 // Adding spacing
 // Add margins
-.push           { margin:       $gutter !important; }
-.push--top      { margin-top:   $gutter !important; }
-.push--right    { margin-right: $gutter !important; }
-.push--bottom   { margin-bottom:$gutter !important; }
-.push--left     { margin-left:  $gutter !important; }
-.push--ends     { margin-top:   $gutter !important; margin-bottom:$gutter !important; }
-.push--sides    { margin-right: $gutter !important; margin-left:  $gutter !important; }
+.push           { margin:       govuk-spacing(6) !important; }
+.push--top      { margin-top:   govuk-spacing(6) !important; }
+.push--right    { margin-right: govuk-spacing(6) !important; }
+.push--bottom   { margin-bottom:govuk-spacing(6) !important; }
+.push--left     { margin-left:  govuk-spacing(6) !important; }
+.push--ends     { margin-top:   govuk-spacing(6) !important; margin-bottom:govuk-spacing(6) !important; }
+.push--sides    { margin-right: govuk-spacing(6) !important; margin-left:  govuk-spacing(6) !important; }
 
 // scss-lint:enable SpaceBeforeBrace, SpaceAfterPropertyColon
 
 //Further down
 .divorced {
-    margin-top: $gutter;
+    margin-top: govuk-spacing(6);
 }
 
 // Simple handling of overflowing tables on mobile
 .mobile-scroll {
-    @include media(mobile) {
+    @media (max-width: 640px) {
         overflow: auto;
 
         table {
@@ -56,13 +56,13 @@
 
 // Responsive helper classes
 .mobile {
-    @include media(tablet) {
+    @media (min-width: 641px) {
         display: none !important;
     }
 }
 
 .tablet-and-up {
-    @include media(mobile) {
+    @media (max-width: 640px) {
         display: none !important;
     }
 }

--- a/service-front/assets/sass/utilities/_helpers.scss
+++ b/service-front/assets/sass/utilities/_helpers.scss
@@ -45,7 +45,7 @@
 
 // Simple handling of overflowing tables on mobile
 .mobile-scroll {
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
         overflow: auto;
 
         table {
@@ -56,13 +56,13 @@
 
 // Responsive helper classes
 .mobile {
-    @media (min-width: 641px) {
+    @include govuk-media-query($from: tablet) {
         display: none !important;
     }
 }
 
 .tablet-and-up {
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
         display: none !important;
     }
 }

--- a/tests/python-api-client/lpaapi.py
+++ b/tests/python-api-client/lpaapi.py
@@ -182,7 +182,7 @@ def setDonor(lpaId):
             "postcode": "PO38 1UL",
         },
         "dob": {"date": "1988-10-22T00:00:00.000000+0000"},
-        "email": {"address": "opglpademo+NancyGarrison@gmail.com"},
+        "email": {"address": "opglpademo+nancygarrison@gmail.com"},
         "canSign": False,
     }
     putToAPI(lpaId, donorDetails, "donor")
@@ -288,7 +288,7 @@ def addPrimaryAttorney(lpaId):
             "address3": "Marchington, Uttoxeter, Staffordshire",
             "postcode": "ST14 8NX",
         },
-        "email": {"address": "opglpademo+AmyWheeler@gmail.com"},
+        "email": {"address": "opglpademo+amywheeler@gmail.com"},
         "type": "human",
     }
     postToAPI(lpaId, primaryAttorneyDetails, "primary-attorneys")
@@ -306,7 +306,7 @@ def addSecondPrimaryAttorney(lpaId, lpaType="health-and-welfare"):
                 "address3": "Marchington, Uttoxeter, Staffordshire",
                 "postcode": "ST14 8NX",
             },
-            "email": {"address": "opglpademo+DavidWheeler@gmail.com"},
+            "email": {"address": "opglpademo+davidwheeler@gmail.com"},
             "type": "human",
         }
     else:
@@ -422,7 +422,7 @@ def addCorrespondent(lpaId):
             "address3": "Ventnor, Isle of Wight",
             "postcode": "PO38 1UL",
         },
-        "email": {"address": "opglpademo+NancyGarrison@gmail.com"},
+        "email": {"address": "opglpademo+nancygarrison@gmail.com"},
         "phone": None,
         "contactByPost": False,
         "contactInWelsh": False,


### PR DESCRIPTION
## Purpose

_Migrating from legacy moj frontend to govuk frontend_

## Approach

Changes to extensions/elements/_elements-typography.scss
-------
  @ include bold-48()          ->  @ include govuk-font($size: 48, $weight: bold)
  @ include bold-36()          ->  @ include govuk-font($size: 36, $weight: bold)
  @ include bold-24()          ->  @ include govuk-font($size: 24, $weight: bold)
  @ include bold-19()          ->  @ include govuk-font($size: 19, $weight: bold)
  @ include heading-27()       ->  @ include govuk-font($size: 27)
  @ include heading-24()       ->  @ include govuk-font($size: 24)
  $secondary-text-colour (x2) ->  $govuk-secondary-text-colour   (#505a5f)
  @ include media(tablet) (x5) ->  @ include govuk-media-query($from: tablet)

em() values replaced with govuk-spacing() or px
------------------------------------------------
  The toolkit em(pixels, context) function converts a pixel value to ems relative to a context font-size. For the migration, the first argument (the intended pixel value) is used to find the equivalent govuk-spacing() token, or a literal px value where no token exists.

  em(30, 32)  ->  govuk-spacing(6)   = 30px   (.heading-xlarge / %heading-xlarge margin-top mobile)
  em(15, 32)  ->  govuk-spacing(3)   = 15px   (.heading-xlarge / %heading-xlarge margin-bottom mobile)
  em(60, 48)  ->  govuk-spacing(9)   = 60px   (.heading-xlarge / %heading-xlarge margin-top tablet)
  em(30, 48)  ->  govuk-spacing(6)   = 30px   (.heading-xlarge / %heading-xlarge margin-bottom tablet)
  em(25, 24)  ->  govuk-spacing(5)   = 25px   (%heading-large margin-top mobile)
  em(10, 24)  ->  govuk-spacing(2)   = 10px   (%heading-large margin-bottom mobile)
  em(45, 36)  ->  45px               (no token — %heading-large margin-top tablet)
  em(20, 36)  ->  govuk-spacing(4)   = 20px   (%heading-large margin-bottom tablet)
  em(25, 20)  ->  govuk-spacing(5)   = 25px   (%heading-medium margin-top mobile)
  em(10, 20)  ->  govuk-spacing(2)   = 10px   (%heading-medium margin-bottom mobile)
  em(45, 24)  ->  45px               (no token — %heading-medium margin-top tablet)
  em(20, 24)  ->  govuk-spacing(4)   = 20px   (%heading-medium margin-bottom tablet)
  em(10, 16)  ->  govuk-spacing(2)   = 10px   (%heading-small margin-top mobile)
  em(5,  16)  ->  govuk-spacing(1)   = 5px    (%heading-small margin-bottom mobile)
  em(20, 19)  ->  govuk-spacing(4)   = 20px   (%heading-small margin-top tablet)

Notes
-----
  The bold-NN() and heading-NN() mixins are govuk_frontend_toolkit mixins that set responsive font-size, line-height, and (for bold-*) font-weight.  govuk-font($size, $weight) is the govuk-frontend v5 equivalent, applying the same responsive type scale from the design system.

  em() values are replaced with absolute px equivalents (govuk-spacing tokens or literal px). This is an intended shift from em-relative to px-absolute spacing, matching the govuk-frontend v5 design system convention. The rendered sizes are identical at the default browser base font-size.

  The two 45px values (em(45,36) and em(45,24)) have no govuk-spacing() token — the scale jumps from govuk-spacing(7)=40px to govuk-spacing(8)=50px — so 45px is used as a literal.

  The placeholders %heading-xlarge, %heading-large, %heading-medium, %heading-small are still present and still extended by _help-system.scss and other pattern files.  Their internals are now fully toolkit-free.


Changes to extensions/elements/_icons.scss
-------
  @ include media(mobile) (x11)          ->  @i nclude govuk-media-query($until: tablet)
  @ include media($max-width: 360px) (x1) ->  @ media (max-width: 360px)

What was NOT changed
--------------------
  @ include icon(name, w, h) — this is a project-local mixin (not from the toolkit) that generates background-image declarations using the $path variable from settings/_variables.scss. It is left unchanged.

  Hardcoded hex values (#0b0c0c, #fff) in .govuk-warning-text__icon — these are already literal values, not toolkit variables.

  box-sizing: border-box in .govuk-warning-text__icon — already written as native CSS (no @ include box-sizing mixin).


Changes to extensions/elements/_forms.scss
-------
  $black  ->  govuk-colour("black")   resolves to #0b0c0c

Notes
-----
  $black has no project-local definition; it came from govuk_frontend_toolkit.  govuk-colour("black") is the v5 equivalent and resolves to the same hex value (#0b0c0c).

  All other values in this file were already plain CSS or project-local classes with no toolkit dependency.


Changes to utilities/_helpers.scss
-------
  $gutter (x8)             ->  govuk-spacing(6)           resolves to 30px
  @ include media(mobile)   ->  @include govuk-media-query($until: tablet)  (x2 occurrences)
  @ include media(tablet)   ->  @include govuk-media-query($from: tablet)  (x1 occurrence)

Occurrences of $gutter
----------------------
  .push           margin
  .push--top      margin-top
  .push--right    margin-right
  .push--bottom   margin-bottom
  .push--left     margin-left
  .push--ends     margin-top + margin-bottom
  .push--sides    margin-right + margin-left
  .divorced       margin-top

Occurrences of media mixins
---------------------------
  .mobile-scroll  @ include media(mobile) -> @ media (max-width: 640px)
  .mobile         @ include media(tablet) -> @ media (min-width: 641px)
  .tablet-and-up  @ include media(mobile) -> @ media (max-width: 640px)


What was NOT changed (across all files)

  @ include icon()           — project-local mixin, not a toolkit dependency
  $white                    — defined in settings/_variables.scss
  $turquoise-with-contrast  — defined in settings/_variables.scss
  Hardcoded hex values      — #0b0c0c, #fff already literals, not variables
  box-sizing: border-box    — already native CSS in _icons.scss
  .flush / .hard classes    — use literal 0, no toolkit dependency

Cypress test fix
-------
And finally.... during testing, ran some cypress sceanarios locally and needed to change lpaapi.py to save all emails in fixtures as lowercase as this is what the system now does and tests are expecting that. (This issue was only seen when running locally because, when doing a stitched run the emails will automatically be lowercase)

_
