### PR TITLE
Catch exceptions from OS API status check

### DIFF
--- a/service-front/module/Application/src/Model/Service/System/Status.php
+++ b/service-front/module/Application/src/Model/Service/System/Status.php
@@ -224,7 +224,12 @@ class Status extends AbstractService implements ApiClientAwareInterface
 
     private function callOrdnanceSurvey(int $currentUnixTime)
     {
-        $os = $this->ordnanceSurveyClient->lookupPostcode('SW1A 1AA');
+        $os = null;
+        try {
+            $os = $this->ordnanceSurveyClient->lookupPostcode('SW1A 1AA');
+        } catch (Exception $e) {
+            $this->getLogger()->error('Error calling Ordnance Survey API: ' . $e->getMessage());
+        }
 
         // Update redis with timestamp of the call to os
         $this->redisClient->write('os_last_call', strval($currentUnixTime));
@@ -233,7 +238,7 @@ class Status extends AbstractService implements ApiClientAwareInterface
         $alive = false;
         $details = '';
 
-        if ($this->ordnanceSurveyClient->verify($os)) {
+        if (!is_null($os) && $this->ordnanceSurveyClient->verify($os)) {
             $alive = true;
             $details = $os[0];
         }

--- a/service-front/module/Application/tests/Model/Service/System/StatusTest.php
+++ b/service-front/module/Application/tests/Model/Service/System/StatusTest.php
@@ -18,6 +18,8 @@ use Laminas\Session\SaveHandler\SaveHandlerInterface;
 use MakeShared\Constants;
 use Mockery;
 use Mockery\MockInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 final class StatusTest extends AbstractServiceTest
 {
@@ -628,6 +630,74 @@ final class StatusTest extends AbstractServiceTest
                 'status' => Constants::STATUS_FAIL,
                 'cached' => false,
                 'details' => ''
+            ],
+            'mail' => [
+                'ok' => true,
+                'status' => Constants::STATUS_PASS,
+            ],
+            // Unlike the other tests, when os fails it doesn't fail the overall health check as it's not vital to the service
+            'ok' => true,
+            'status' => Constants::STATUS_WARN,
+        ], $result);
+    }
+
+    public function testCheckOrdnanceSurveyException(): void
+    {
+        $this->apiClient
+            ->shouldReceive('httpGet')
+            ->withArgs(['/ping'])
+            ->once()
+            ->andReturn([
+                'ok' => true,
+                'status' => Constants::STATUS_PASS,
+            ]);
+
+        $this->dynamoDbClient
+            ->shouldReceive('describeTable')
+            ->withArgs([['TableName' => 'admin-test-table']])
+            ->once()
+            ->andReturn(new AwsResult(['@metadata' => ['statusCode' => 200],'Table' => ['TableStatus' => 'ACTIVE']]));
+
+        $this->sessionSaveHandler->shouldReceive('open')->once()->andReturn(true);
+
+        $this->redisClient->shouldReceive('open')->once()->andReturn(true);
+        $this->redisClient->shouldReceive('read')->once()->andReturn('');
+        $this->redisClient->shouldReceive('write')->times(3)->andReturn(true);
+        $this->redisClient->shouldReceive('close')->once()->andReturn(true);
+        $this->ordnanceSurveyClient->shouldReceive('lookupPostcode')->once()->andThrow(new RuntimeException('hostname not found'));
+
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')
+            ->withArgs(['Error calling Ordnance Survey API: hostname not found'])
+            ->once();
+        $this->service->setLogger($logger);
+
+        $this->mailTransport->shouldReceive('healthcheck')
+            ->andReturn(['ok' => true, 'status' => Constants::STATUS_PASS]);
+
+        $result = $this->service->check();
+
+        $this->assertEquals([
+            'dynamo' => [
+                'ok' => true,
+                'status' => Constants::STATUS_PASS,
+            ],
+            'api' => [
+                'ok' => true,
+                'status' => Constants::STATUS_PASS,
+                'details' => [
+                    'response_code' => '200',
+                ]
+            ],
+            'sessionSaveHandler' => [
+                'ok' => true,
+                'status' => Constants::STATUS_PASS,
+            ],
+            'ordnanceSurvey' => [
+                'ok' => false,
+                'status' => Constants::STATUS_FAIL,
+                'cached' => false,
+                'details' => '',
             ],
             'mail' => [
                 'ok' => true,


### PR DESCRIPTION
## Purpose

To ensure we get meaningful information back from the status page rather than failing with a 500.

Fixes LPAL-2146 #patch

## Approach

Add a try..catch and log the error
