### PR TITLE
LPAL-1585 - Reduce scanning noise

### DIFF
--- a/terraform/region/main.tf
+++ b/terraform/region/main.tf
@@ -1,9 +1,10 @@
 #manual only right now - take this out later.
 module "eu-west-1" {
-  source                    = "./modules/region"
-  account                   = local.account
-  account_name              = local.account_name
-  firewalled_vpc_cidr_range = local.account.firewalled_vpc_cidr_ranges.eu_west_1
+  source                                                 = "./modules/region"
+  account                                                = local.account
+  account_name                                           = local.account_name
+  aws_waf_amazon_managed_ip_reputation_list_rule_enabled = local.account.web_application_firewall.amazon_managed_ip_reputation_list_rule_enabled
+  firewalled_vpc_cidr_range                              = local.account.firewalled_vpc_cidr_ranges.eu_west_1
   providers = {
     aws            = aws
     aws.management = aws.management
@@ -11,11 +12,12 @@ module "eu-west-1" {
 }
 
 module "eu-west-2" {
-  source                    = "./modules/region"
-  count                     = local.account.dr_enabled && local.account_name == "development" ? 1 : 0
-  account                   = local.account
-  account_name              = local.account_name
-  firewalled_vpc_cidr_range = local.account.firewalled_vpc_cidr_ranges.eu_west_2
+  source                                                 = "./modules/region"
+  count                                                  = local.account.dr_enabled && local.account_name == "development" ? 1 : 0
+  account                                                = local.account
+  account_name                                           = local.account_name
+  aws_waf_amazon_managed_ip_reputation_list_rule_enabled = local.account.web_application_firewall.amazon_managed_ip_reputation_list_rule_enabled
+  firewalled_vpc_cidr_range                              = local.account.firewalled_vpc_cidr_ranges.eu_west_2
   providers = {
     aws            = aws.eu-west-2
     aws.management = aws.management_eu_west_2

--- a/terraform/region/modules/region/variables.tf
+++ b/terraform/region/modules/region/variables.tf
@@ -40,3 +40,9 @@ variable "firewalled_vpc_cidr_range" {
   type        = string
   description = "The IPv4 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using ipv4_netmask_length."
 }
+
+variable "aws_waf_amazon_managed_ip_reputation_list_rule_enabled" {
+  type        = bool
+  description = "enable AWSManagedRulesAmazonIpReputationList in this account"
+  default     = false
+}

--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -71,6 +71,7 @@ resource "aws_wafv2_web_acl" "main" {
       sampled_requests_enabled   = true
     }
   }
+
   rule {
     name     = "BlockSuspiciousURIPatterns"
     priority = 6

--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -36,35 +36,7 @@ resource "aws_wafv2_web_acl" "main" {
       sampled_requests_enabled   = true
     }
   }
-  rule {
-    name     = "BlockSuspiciousURIPatternsCandidates"
-    priority = 5
 
-    action {
-      count {}
-    }
-
-    statement {
-      regex_pattern_set_reference_statement {
-        arn = aws_wafv2_regex_pattern_set.suspicious_uri_patterns_candidates.arn
-
-        field_to_match {
-          uri_path {}
-        }
-
-        text_transformation {
-          priority = 0
-          type     = "LOWERCASE"
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "RateLimitSuspiciousURIPatterns"
-      sampled_requests_enabled   = true
-    }
-  }
   rule {
     name     = "RateLimitSuspiciousURIPatterns"
     priority = 6
@@ -276,8 +248,9 @@ resource "aws_wafv2_web_acl" "main" {
 
     statement {
       rate_based_statement {
-        limit              = 200
-        aggregate_key_type = "IP"
+        limit                 = 200
+        aggregate_key_type    = "IP"
+        evaluation_window_sec = 60
       }
     }
 
@@ -313,17 +286,7 @@ resource "aws_wafv2_regex_pattern_set" "suspicious_uri_patterns" {
   scope       = "REGIONAL"
 
   regular_expression {
-    regex_string = "(?i)\\.(env|git|sql|bak|php|asp|aspx|cgi|sh|exe|tar|gz|tgz|zip|rar|7z|z|bz2|lz|xz|db|sqlite|sqlitedb|war|jar|config|conf|ini|log|pem|key|p12|pfx|crt|ovpn|htaccess|htpasswd|DS_Store|swp)$"
-  }
-}
-
-resource "aws_wafv2_regex_pattern_set" "suspicious_uri_patterns_candidates" {
-  name        = "suspicious-uri-patterns-candidates"
-  description = "Regex pattern set for suspicious URI patterns"
-  scope       = "REGIONAL"
-
-  regular_expression {
-    regex_string = "(?i)\\.(dump|aws|xml|json|c|err|staging)$"
+    regex_string = "(?i)\\.(env|git|sql|bak|php|asp|aspx|cgi|sh|exe|tar|gz|tgz|zip|rar|7z|z|bz2|lz|xz|db|sqlite|sqlitedb|war|jar|config|conf|ini|log|pem|key|p12|pfx|crt|ovpn|htaccess|htpasswd|DS_Store|swp|dump|aws|xml|c|err|staging)$"
   }
 }
 

--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -245,27 +245,30 @@ resource "aws_wafv2_web_acl" "main" {
       sampled_requests_enabled   = true
     }
   }
-  rule {
-    name     = "AWS-AWSManagedRulesAmazonIpReputationList"
-    priority = 50
 
-    override_action {
-      none {}
-    }
+  dynamic "rule" {
+    for_each = var.aws_waf_amazon_managed_ip_reputation_list_rule_enabled ? [1] : []
+    content {
+      name     = "AWS-AWSManagedRulesAmazonIpReputationList"
+      priority = 50
+      override_action {
+        none {}
+      }
+      statement {
+        managed_rule_group_statement {
+          name        = "AWSManagedRulesAmazonIpReputationList"
+          vendor_name = "AWS"
+        }
+      }
 
-    statement {
-      managed_rule_group_statement {
-        name        = "AWSManagedRulesAmazonIpReputationList"
-        vendor_name = "AWS"
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "AWS-AWSManagedRulesAmazonIpReputationList"
+        sampled_requests_enabled   = true
       }
     }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "AWS-AWSManagedRulesAmazonIpReputationList"
-      sampled_requests_enabled   = true
-    }
   }
+
   rule {
     name     = "RateLimitByIP"
     priority = 60

--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -290,7 +290,6 @@ resource "aws_wafv2_web_acl" "main" {
       metric_name                = "RateLimitByIP"
       sampled_requests_enabled   = true
     }
-
   }
 
   visibility_config {

--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -36,7 +36,35 @@ resource "aws_wafv2_web_acl" "main" {
       sampled_requests_enabled   = true
     }
   }
+  rule {
+    name     = "BlockSuspiciousURIPatterns2"
+    priority = 5
 
+    action {
+      block {}
+    }
+
+    statement {
+      regex_pattern_set_reference_statement {
+        arn = aws_wafv2_regex_pattern_set.suspicious_uri_patterns_2.arn
+
+        field_to_match {
+          uri_path {}
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "LOWERCASE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitSuspiciousURIPatterns"
+      sampled_requests_enabled   = true
+    }
+  }
   rule {
     name     = "RateLimitSuspiciousURIPatterns"
     priority = 6
@@ -286,7 +314,17 @@ resource "aws_wafv2_regex_pattern_set" "suspicious_uri_patterns" {
   scope       = "REGIONAL"
 
   regular_expression {
-    regex_string = "(?i)\\.(env|git|sql|bak|php|asp|aspx|cgi|sh|exe|tar|gz|tgz|zip|rar|7z|z|bz2|lz|xz|db|sqlite|sqlitedb|war|jar|config|conf|ini|log|pem|key|p12|pfx|crt|ovpn|htaccess|htpasswd|DS_Store|swp|dump|aws|xml|c|err|staging)$"
+    regex_string = "(?i)\\.(env|git|sql|bak|php|asp|aspx|cgi|sh|exe|tar|gz|tgz|zip|rar|7z|z|bz2|lz|xz|db|sqlite|sqlitedb|war|jar|config|conf|ini|log|pem|key|p12|pfx|crt|ovpn|htaccess|htpasswd|DS_Store|swp)$"
+  }
+}
+
+resource "aws_wafv2_regex_pattern_set" "suspicious_uri_patterns_2" {
+  name        = "suspicious-uri-patterns-2"
+  description = "Regex pattern set for suspicious URI patterns"
+  scope       = "REGIONAL"
+
+  regular_expression {
+    regex_string = "(?i)\\.(dump|aws|xml|c|err|staging)$"
   }
 }
 

--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -36,38 +36,10 @@ resource "aws_wafv2_web_acl" "main" {
       sampled_requests_enabled   = true
     }
   }
-  rule {
-    name     = "BlockSuspiciousURIPatterns2"
-    priority = 5
 
-    action {
-      block {}
-    }
-
-    statement {
-      regex_pattern_set_reference_statement {
-        arn = aws_wafv2_regex_pattern_set.suspicious_uri_patterns_2.arn
-
-        field_to_match {
-          uri_path {}
-        }
-
-        text_transformation {
-          priority = 0
-          type     = "LOWERCASE"
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "RateLimitSuspiciousURIPatterns"
-      sampled_requests_enabled   = true
-    }
-  }
   rule {
     name     = "RateLimitSuspiciousURIPatterns"
-    priority = 6
+    priority = 5
 
     action {
       block {}
@@ -101,7 +73,7 @@ resource "aws_wafv2_web_acl" "main" {
   }
   rule {
     name     = "BlockSuspiciousURIPatterns"
-    priority = 7
+    priority = 6
 
     action {
       block {}
@@ -125,6 +97,35 @@ resource "aws_wafv2_web_acl" "main" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "BlockSuspiciousURIPatterns"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "BlockSuspiciousURIPatterns2"
+    priority = 7
+
+    action {
+      block {}
+    }
+
+    statement {
+      regex_pattern_set_reference_statement {
+        arn = aws_wafv2_regex_pattern_set.suspicious_uri_patterns_2.arn
+
+        field_to_match {
+          uri_path {}
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "LOWERCASE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitSuspiciousURIPatterns"
       sampled_requests_enabled   = true
     }
   }

--- a/terraform/region/terraform.tfvars.json
+++ b/terraform/region/terraform.tfvars.json
@@ -56,6 +56,9 @@
           "account_id": "679638075911",
           "account_name": "development"
         }
+      },
+      "web_application_firewall": {
+        "amazon_managed_ip_reputation_list_rule_enabled": false
       }
     },
     "preproduction": {
@@ -109,6 +112,9 @@
           "account_id": "679638075911",
           "account_name": "development"
         }
+      },
+      "web_application_firewall": {
+        "amazon_managed_ip_reputation_list_rule_enabled": false
       }
     },
     "production": {
@@ -161,6 +167,9 @@
           "account_id": "997462338508",
           "account_name": "production"
         }
+      },
+      "web_application_firewall": {
+        "amazon_managed_ip_reputation_list_rule_enabled": true
       }
     }
   }

--- a/terraform/region/variables.tf
+++ b/terraform/region/variables.tf
@@ -46,6 +46,9 @@ variable "accounts" {
           account_name = string
         })
       })
+      web_application_firewall = object({
+        amazon_managed_ip_reputation_list_rule_enabled = bool
+      })
 
       regions = map(
         object({


### PR DESCRIPTION
## Purpose

Block unwanted traffic at the application firewall

Fixes LPAL-1585

## Approach

- apply candidates to block rule and allow json file requests
- shorten rate limit evaluation window to 1 minute
- don't use IP Reputation WAF rule outside of production

## Learning

- https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based-high-level-settings.html
- https://developer.hashicorp.com/terraform/language/expressions/dynamic-blocks
