### PR TITLE
remove persistent diff in blocked encryption types for s3 bucket

### DIFF
--- a/terraform/region/.snyk
+++ b/terraform/region/.snyk
@@ -10,22 +10,22 @@ ignore:
   SNYK-CC-TF-55:
     - '*':
         reason: Scheduled for fix LPAL-1095
-        expires: 2026-06-05T13:21:30.702Z
+        expires: 2026-07-05T13:21:30.702Z
         created: 2026-05-06T13:21:30.709Z
   SNYK-CC-TF-215:
     - '*':
         reason: Scheduled for fix LPAL-2080
-        expires: 2026-06-05T13:24:01.814Z
+        expires: 2026-07-05T13:24:01.814Z
         created: 2026-05-06T13:24:01.821Z
   SNYK-CC-TF-119:
     - '*':
         reason: Policy merged with others to produce more restrictive policy
-        expires: 2026-06-05T13:25:02.332Z
+        expires: 9999-06-05T13:25:02.332Z
         created: 2026-05-06T13:25:02.341Z
   SNYK-CC-TF-40:
     - '*':
         reason: Scheduled for fix LPAL-2081
-        expires: 2026-06-05T13:25:27.744Z
+        expires: 2026-07-05T13:25:27.744Z
         created: 2026-05-06T13:25:27.752Z
   SNYK-CC-AWS-428:
     - 'modules/region/modules/vpc_endpoints/main.tf > resource > aws_vpc_endpoint[cloudshell_codecatalyst_global]':

--- a/terraform/region/.snyk
+++ b/terraform/region/.snyk
@@ -5,7 +5,7 @@ ignore:
   SNYK-CC-TF-69:
     - '*':
         reason: Policy merged with others to produce more restrictive policy
-        expires: 2026-06-05T12:41:53.331Z
+        expires: 9999-06-05T12:41:53.331Z
         created: 2026-05-06T12:41:53.334Z
   SNYK-CC-TF-55:
     - '*':

--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -63,6 +63,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "access_log" {
   bucket = aws_s3_bucket.access_log.id
 
   rule {
+    bucket_key_enabled       = false
+    blocked_encryption_types = ["SSE-C"]
+
     apply_server_side_encryption_by_default {
       sse_algorithm = "aws:kms"
     }
@@ -112,6 +115,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "lpa_pdf_cache" {
   bucket = aws_s3_bucket.lpa_pdf_cache.id
 
   rule {
+    bucket_key_enabled       = false
+    blocked_encryption_types = ["SSE-C"]
+
     apply_server_side_encryption_by_default {
       kms_master_key_id = aws_kms_key.lpa_pdf_cache.arn
       sse_algorithm     = "aws:kms"
@@ -192,6 +198,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "redacted_logs" {
   bucket = aws_s3_bucket.redacted_logs.id
 
   rule {
+    bucket_key_enabled       = false
+    blocked_encryption_types = ["SSE-C"]
+
     apply_server_side_encryption_by_default {
       kms_master_key_id = aws_kms_key.redacted_logs.arn
       sse_algorithm     = "aws:kms"


### PR DESCRIPTION
## Purpose

Make sure the terraform is enforcing the blocked encryption types for s3 buckets to prevent persistent diffs in plans

## Approach

- update snyk ignores
- set bucket key enabled to false
- block SSE-C (customer supplied encryption keys) being used as encryption keys