### PR TITLE
LPAL-1873| Allow ECS to pull new new image tags through the ecr cache

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -43,6 +43,8 @@ jobs:
   otel_image_pull_and_scan:
     name: "Pull OTEL image and scan with SNYK"
     runs-on: ubuntu-latest
+    env:
+      otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Configure AWS Credentials
@@ -61,14 +63,14 @@ jobs:
 
       - name: Pull OTEL image into ECR cache
         env:
-          otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
+          otel_image_version: ${{ env.otel_image_version }}
         run: |
           docker pull $otel_image_version
 
       - name: Scan OTEL image with SNYK
         id: otel_snyk_scan
         env:
-          otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
+          otel_image_version: ${{ env.otel_image_version }}
         continue-on-error: ${{ !inputs.otel_scan_required }}
         uses: ministryofjustice/opg-github-actions/actions/snyk-scan@8dea82fc8b8e7ffca431f0fb83848d523147ccd8 # v4.5.0
         with:

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   otel_image_pull_and_scan:
-    name: "Pull OTEL image and scan with SNYK"
+    name: "OTEL_Image_Pull_and_Scan"
     runs-on: ubuntu-latest
     env:
       otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -188,25 +188,6 @@ jobs:
         with:
           registries: 311462405659
 
-      - name: Pull OTEL image into ECR cache
-        env:
-          OTEL_IMAGE_VERSION: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
-        run: |
-          docker pull $OTEL_IMAGE_VERSION
-
-      - name: Scan OTEL image with SNYK
-        id: otel_snyk_scan
-        env:
-          OTEL_IMAGE_VERSION: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
-        continue-on-error: ${{ !inputs.otel_scan_required }}
-        uses: ministryofjustice/opg-github-actions/actions/snyk-scan@8dea82fc8b8e7ffca431f0fb83848d523147ccd8 # v4.5.0
-        with:
-          SNYK_TEST_IMAGE: ${{ env.OTEL_IMAGE_VERSION }}
-          SNYK_TOKEN: ${{ secrets.SNYK_OPG_ORG_TOKEN }}
-          sarif_filepath: ./test-results
-          sarif_filename: otel_snyk.sarif
-          snyk_test_args: --severity-threshold=high
-
       - name: Build Image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -189,17 +189,19 @@ jobs:
           registries: 311462405659
 
       - name: Pull OTEL image into ECR cache
-        otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
+        env:
+          OTEL_IMAGE_VERSION: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
         run: |
-          docker pull $otel_image_version
+          docker pull $OTEL_IMAGE_VERSION
 
       - name: Scan OTEL image with SNYK
         id: otel_snyk_scan
-        otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
+        env:
+          OTEL_IMAGE_VERSION: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
         continue-on-error: ${{ !inputs.otel_scan_required }}
         uses: ministryofjustice/opg-github-actions/actions/snyk-scan@8dea82fc8b8e7ffca431f0fb83848d523147ccd8 # v4.5.0
         with:
-          SNYK_TEST_IMAGE: ${{ otel_image_version }}
+          SNYK_TEST_IMAGE: ${{ env.OTEL_IMAGE_VERSION }}
           SNYK_TOKEN: ${{ secrets.SNYK_OPG_ORG_TOKEN }}
           sarif_filepath: ./test-results
           sarif_filename: otel_snyk.sarif

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -183,11 +183,11 @@ jobs:
         with:
           registries: 311462405659
 
-      # - name: Pull otel image into ECR cache
-      #   env:
-      #     otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
-      #   run: |
-      #     docker pull $otel_image_version
+      - name: Pull otel image into ECR cache
+        env:
+          otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
+        run: |
+          docker pull $otel_image_version
 
       - name: Build Image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -183,6 +183,12 @@ jobs:
         with:
           registries: 311462405659
 
+      - name: Pull otel image into ECR cache
+        env:
+          otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
+        run: |
+          docker pull $otel_image_version
+
       - name: Build Image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -183,11 +183,11 @@ jobs:
         with:
           registries: 311462405659
 
-      - name: Pull otel image into ECR cache
-        env:
-          otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
-        run: |
-          docker pull $otel_image_version
+      # - name: Pull otel image into ECR cache
+      #   env:
+      #     otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
+      #   run: |
+      #     docker pull $otel_image_version
 
       - name: Build Image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -40,6 +40,44 @@ permissions:
   statuses: none
 
 jobs:
+  otel_image_pull_and_scan:
+    name: "Pull OTEL image and scan with SNYK"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ inputs.oidc_docker_role }}
+          role-duration-seconds: 3600
+          role-session-name: OPGMakeaLPAECRGithubAction
+
+      - name: ECR Login
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        with:
+          registries: 311462405659
+
+      - name: Pull OTEL image into ECR cache
+        env:
+          otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
+        run: |
+          docker pull $otel_image_version
+
+      - name: Scan OTEL image with SNYK
+        id: otel_snyk_scan
+        env:
+          otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
+        continue-on-error: ${{ !inputs.otel_scan_required }}
+        uses: ministryofjustice/opg-github-actions/actions/snyk-scan@8dea82fc8b8e7ffca431f0fb83848d523147ccd8 # v4.5.0
+        with:
+          SNYK_TEST_IMAGE: ${{ env.otel_image_version }}
+          SNYK_TOKEN: ${{ secrets.SNYK_OPG_ORG_TOKEN }}
+          sarif_filepath: ./test-results
+          sarif_filename: otel_snyk.sarif
+          snyk_test_args: --severity-threshold=high
+
   docker_build_scan_push:
     name: "docker build"
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -188,19 +188,18 @@ jobs:
         with:
           registries: 311462405659
 
-      - name: Pull otel image into ECR cache
-        env:
-          otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
+      - name: Pull OTEL image into ECR cache
+        otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
         run: |
           docker pull $otel_image_version
-      - name: scan otel image with snyk
+
+      - name: Scan OTEL image with SNYK
         id: otel_snyk_scan
-        env:
-          otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
+        otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
         continue-on-error: ${{ !inputs.otel_scan_required }}
         uses: ministryofjustice/opg-github-actions/actions/snyk-scan@8dea82fc8b8e7ffca431f0fb83848d523147ccd8 # v4.5.0
         with:
-          SNYK_TEST_IMAGE: ${{ env.otel_image_version }}
+          SNYK_TEST_IMAGE: ${{ otel_image_version }}
           SNYK_TOKEN: ${{ secrets.SNYK_OPG_ORG_TOKEN }}
           sarif_filepath: ./test-results
           sarif_filename: otel_snyk.sarif

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -193,9 +193,10 @@ jobs:
           otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
         run: |
           docker pull $otel_image_version
-
       - name: scan otel image with snyk
         id: otel_snyk_scan
+        env:
+          otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
         continue-on-error: ${{ !inputs.otel_scan_required }}
         uses: ministryofjustice/opg-github-actions/actions/snyk-scan@8dea82fc8b8e7ffca431f0fb83848d523147ccd8 # v4.5.0
         with:

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -15,6 +15,11 @@ on:
         description: "OIDC role to assume for ecr permissions"
         required: true
         type: string
+      otel_scan_required:
+        description: "Fail workflow when OTEL Snyk scan fails"
+        required: false
+        type: boolean
+        default: false
     secrets:
       SLACK_BOT_TOKEN:
         required: true
@@ -188,6 +193,17 @@ jobs:
           otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
         run: |
           docker pull $otel_image_version
+
+      - name: scan otel image with snyk
+        id: otel_snyk_scan
+        continue-on-error: ${{ !inputs.otel_scan_required }}
+        uses: ministryofjustice/opg-github-actions/actions/snyk-scan@8dea82fc8b8e7ffca431f0fb83848d523147ccd8 # v4.5.0
+        with:
+          SNYK_TEST_IMAGE: ${{ env.otel_image_version }}
+          SNYK_TOKEN: ${{ secrets.SNYK_OPG_ORG_TOKEN }}
+          sarif_filepath: ./test-results
+          sarif_filename: otel_snyk.sarif
+          snyk_test_args: --severity-threshold=high
 
       - name: Build Image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -62,15 +62,11 @@ jobs:
           registries: 311462405659
 
       - name: Pull OTEL image into ECR cache
-        env:
-          otel_image_version: ${{ env.otel_image_version }}
         run: |
           docker pull $otel_image_version
 
       - name: Scan OTEL image with SNYK
         id: otel_snyk_scan
-        env:
-          otel_image_version: ${{ env.otel_image_version }}
         continue-on-error: ${{ !inputs.otel_scan_required }}
         uses: ministryofjustice/opg-github-actions/actions/snyk-scan@8dea82fc8b8e7ffca431f0fb83848d523147ccd8 # v4.5.0
         with:

--- a/terraform/environment/modules/environment/iam_ecs_permissions.tf
+++ b/terraform/environment/modules/environment/iam_ecs_permissions.tf
@@ -22,7 +22,15 @@ data "aws_iam_policy_document" "execution_role" {
     actions = [
       "ecr:BatchCheckLayerAvailability",
       "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage"
+      "ecr:BatchGetImage",
+      "ecr:BatchImportUpstreamImage",
+      "ecr:GetImageCopyStatus",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:PutImage"
+
+
     ]
   }
   statement {


### PR DESCRIPTION

## Purpose

- Adding a step for Otel Image to be pulled into ECR cache before service docker images are built
- Scanning image with Snyk to detect vulnerabilities as we do not build this ourselves 
- Currently the scan is set to continue on error but flag any critical/high vulnerabilities so we can track these

Fixes LPAL-1873

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
