### PR TITLE
LPAL-2167| removing ebs snapshot from state as resource being managed on account level

### DIFF
--- a/terraform/region/modules/region/securityhub.tf
+++ b/terraform/region/modules/region/securityhub.tf
@@ -1,3 +1,0 @@
-resource "aws_ebs_snapshot_block_public_access" "this" {
-  state = "block-all-sharing"
-}

--- a/terraform/region/refactor.tf
+++ b/terraform/region/refactor.tf
@@ -27,3 +27,17 @@ moved {
   from = module.eu-west-1.module.vpc_endpoints.aws_vpc_endpoint.cloudshell["codecatalyst.git"]
   to   = module.eu-west-1.module.vpc_endpoints.aws_vpc_endpoint.codecatalyst["codecatalyst.git"]
 }
+
+removed {
+  from = module.eu-west-1.aws_ebs_snapshot_block_public_access.this
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.eu-west-2.aws_ebs_snapshot_block_public_access.this
+  lifecycle {
+    destroy = false
+  }
+}


### PR DESCRIPTION


## Purpose

- Removing ebs_snapshot from state because this is now being managed on account level
- updated terraform account version in [Org-Infra](https://github.com/ministryofjustice/opg-org-infra/actions/runs/27704621766)  to match release for the change in [Andy's PR](https://github.com/ministryofjustice/opg-terraform-aws-account/pull/140)


Fixes LPAL-2167


## Learning

https://developer.hashicorp.com/terraform/language/state/remove