### PR TITLE
LPAL-2025| ENV- Update backup module to add cross account backup permissions - backup to primary 

### DIFF
--- a/terraform/environment/modules/rds_cross_region_backup/backup_vaults_new.tf
+++ b/terraform/environment/modules/rds_cross_region_backup/backup_vaults_new.tf
@@ -25,6 +25,7 @@ resource "aws_backup_vault_policy" "backup_cross_account" {
   policy            = data.aws_iam_policy_document.backup_cross_account_permissions.json
 }
 
+# permissions for source account to copy backups into the backup account vault
 data "aws_iam_policy_document" "backup_cross_account_permissions" {
   provider = aws.backup
   statement {
@@ -40,4 +41,22 @@ data "aws_iam_policy_document" "backup_cross_account_permissions" {
     actions   = ["backup:CopyIntoBackupVault"]
     resources = [aws_backup_vault.backup_cross_account.arn]
   }
+}
+
+# permissions for backup account to restore into the source account vault
+data "aws_iam_policy_document" "primary_cross_account_permissions" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.backup.account_id}:root"]
+    }
+    actions   = ["backup:CopyIntoBackupVault"]
+    resources = [aws_backup_vault.backup_primary.arn]
+  }
+}
+resource "aws_backup_vault_policy" "primary_allow_cross_account" {
+  count             = var.cross_account_backup_enabled ? 1 : 0
+  backup_vault_name = aws_backup_vault.backup_primary.name
+  policy            = data.aws_iam_policy_document.primary_cross_account_permissions.json
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -24,7 +24,7 @@
       "database": {
         "cluster_identifier": "api2",
         "aurora_cross_region_backup_enabled": false,
-        "cross_account_backup_enabled": false,
+        "cross_account_backup_enabled": true,
         "aurora_restore_testing_enabled": false,
         "enable_backup_vault_lock":  false,
         "daily_backup_deletion": 1,

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -23,7 +23,7 @@
       "mezzio_frontend_enabled": false,
       "database": {
         "cluster_identifier": "api2",
-        "aurora_cross_region_backup_enabled": false,
+        "aurora_cross_region_backup_enabled": true,
         "cross_account_backup_enabled": true,
         "aurora_restore_testing_enabled": false,
         "enable_backup_vault_lock":  false,

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -23,8 +23,8 @@
       "mezzio_frontend_enabled": false,
       "database": {
         "cluster_identifier": "api2",
-        "aurora_cross_region_backup_enabled": true,
-        "cross_account_backup_enabled": true,
+        "aurora_cross_region_backup_enabled": false,
+        "cross_account_backup_enabled": false,
         "aurora_restore_testing_enabled": false,
         "enable_backup_vault_lock":  false,
         "daily_backup_deletion": 1,


### PR DESCRIPTION


## Purpose

- Backup module needs cross account permissions added for backup account to copy into primary/source account. 
- Envrionment level changes 
- Region changes to backup kms key found on this [PR ](https://github.com/ministryofjustice/opg-lpa/pull/3557)

Fixes LPAL-2025

