### PR TITLE
Remove direct dependency on hamcrest/hamcrest-php

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -219,7 +219,6 @@
       <path value="$PROJECT_DIR$/service-api/vendor/guzzlehttp/guzzle" />
       <path value="$PROJECT_DIR$/service-api/vendor/guzzlehttp/promises" />
       <path value="$PROJECT_DIR$/service-api/vendor/guzzlehttp/psr7" />
-      <path value="$PROJECT_DIR$/service-api/vendor/hamcrest/hamcrest-php" />
       <path value="$PROJECT_DIR$/service-api/vendor/kelunik/certificate" />
       <path value="$PROJECT_DIR$/service-api/vendor/laminas-api-tools/api-tools-api-problem" />
       <path value="$PROJECT_DIR$/service-api/vendor/laminas/laminas-authentication" />
@@ -368,7 +367,6 @@
       <path value="$PROJECT_DIR$/service-front/vendor/guzzlehttp/guzzle" />
       <path value="$PROJECT_DIR$/service-front/vendor/guzzlehttp/promises" />
       <path value="$PROJECT_DIR$/service-front/vendor/guzzlehttp/psr7" />
-      <path value="$PROJECT_DIR$/service-front/vendor/hamcrest/hamcrest-php" />
       <path value="$PROJECT_DIR$/service-front/vendor/kelunik/certificate" />
       <path value="$PROJECT_DIR$/service-front/vendor/kokspflanze/zfc-twig" />
       <path value="$PROJECT_DIR$/service-front/vendor/laminas/laminas-authentication" />
@@ -506,7 +504,6 @@
       <path value="$PROJECT_DIR$/service-pdf/vendor/guzzlehttp/guzzle" />
       <path value="$PROJECT_DIR$/service-pdf/vendor/guzzlehttp/promises" />
       <path value="$PROJECT_DIR$/service-pdf/vendor/guzzlehttp/psr7" />
-      <path value="$PROJECT_DIR$/service-pdf/vendor/hamcrest/hamcrest-php" />
       <path value="$PROJECT_DIR$/service-pdf/vendor/kelunik/certificate" />
       <path value="$PROJECT_DIR$/service-pdf/vendor/laminas/laminas-barcode" />
       <path value="$PROJECT_DIR$/service-pdf/vendor/laminas/laminas-filter" />
@@ -604,7 +601,6 @@
       <path value="$PROJECT_DIR$/shared/vendor/felixfbecker/advanced-json-rpc" />
       <path value="$PROJECT_DIR$/shared/vendor/felixfbecker/language-server-protocol" />
       <path value="$PROJECT_DIR$/shared/vendor/fidry/cpu-core-counter" />
-      <path value="$PROJECT_DIR$/shared/vendor/hamcrest/hamcrest-php" />
       <path value="$PROJECT_DIR$/shared/vendor/kelunik/certificate" />
       <path value="$PROJECT_DIR$/shared/vendor/laminas/laminas-config" />
       <path value="$PROJECT_DIR$/shared/vendor/laminas/laminas-diactoros" />

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -934,42 +934,42 @@
         "filename": "service-front/module/Application/tests/Model/Service/User/DetailsTest.php",
         "hashed_secret": "2969a5503562a2776ef5842b2020ba390def6012",
         "is_verified": false,
-        "line_number": 108
+        "line_number": 106
       },
       {
         "type": "Secret Keyword",
         "filename": "service-front/module/Application/tests/Model/Service/User/DetailsTest.php",
         "hashed_secret": "4f18148f379e9dd0665c1d700b00381e2d5cc1f6",
         "is_verified": false,
-        "line_number": 412
+        "line_number": 410
       },
       {
         "type": "Secret Keyword",
         "filename": "service-front/module/Application/tests/Model/Service/User/DetailsTest.php",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 413
+        "line_number": 411
       },
       {
         "type": "Secret Keyword",
         "filename": "service-front/module/Application/tests/Model/Service/User/DetailsTest.php",
         "hashed_secret": "2bb37e83782f5cadebd6d2ead7aa6b7b441050c9",
         "is_verified": false,
-        "line_number": 577
+        "line_number": 575
       },
       {
         "type": "Secret Keyword",
         "filename": "service-front/module/Application/tests/Model/Service/User/DetailsTest.php",
         "hashed_secret": "28e2bca89d8c60c5115a5b9e6663519ec2c9903c",
         "is_verified": false,
-        "line_number": 751
+        "line_number": 749
       },
       {
         "type": "Secret Keyword",
         "filename": "service-front/module/Application/tests/Model/Service/User/DetailsTest.php",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 798
+        "line_number": 796
       }
     ],
     "service-front/module/Application/tests/fixtures/hw.json": [
@@ -1054,5 +1054,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-18T17:28:38Z"
+  "generated_at": "2026-06-26T07:55:02Z"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,7 @@
         "laminas/laminas-cache-storage-adapter-memory",
         "laminas/laminas-filter",
         "laminas/laminas-paginator",
+        "laminas/laminas-view",
         "symfony/console"
       ],
       "enabled": false

--- a/service-front/mezzio/test/AppTest/Service/Lpa/CommunicationTest.php
+++ b/service-front/mezzio/test/AppTest/Service/Lpa/CommunicationTest.php
@@ -9,8 +9,6 @@ use App\Service\Mail\Exception\InvalidArgumentException;
 use App\Service\Mail\MailParameters;
 use App\Service\Mail\Transport\MailTransportInterface;
 use DateTime;
-use Hamcrest\MatcherAssert;
-use Hamcrest\Matchers;
 use MakeShared\DataModel\Common\EmailAddress;
 use MakeShared\DataModel\Common\LongName;
 use MakeShared\DataModel\Lpa\Document\Document;
@@ -97,7 +95,7 @@ final class CommunicationTest extends MockeryTestCase
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
 
@@ -140,7 +138,7 @@ final class CommunicationTest extends MockeryTestCase
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
 
@@ -192,7 +190,7 @@ final class CommunicationTest extends MockeryTestCase
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
 
@@ -235,7 +233,7 @@ final class CommunicationTest extends MockeryTestCase
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
 
@@ -287,7 +285,7 @@ final class CommunicationTest extends MockeryTestCase
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
 
@@ -330,7 +328,7 @@ final class CommunicationTest extends MockeryTestCase
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
 
@@ -382,7 +380,7 @@ final class CommunicationTest extends MockeryTestCase
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
 
@@ -425,7 +423,7 @@ final class CommunicationTest extends MockeryTestCase
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
 
@@ -483,7 +481,7 @@ final class CommunicationTest extends MockeryTestCase
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -533,7 +531,7 @@ final class CommunicationTest extends MockeryTestCase
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -593,7 +591,7 @@ final class CommunicationTest extends MockeryTestCase
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -644,7 +642,7 @@ final class CommunicationTest extends MockeryTestCase
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -698,7 +696,7 @@ final class CommunicationTest extends MockeryTestCase
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -742,7 +740,7 @@ final class CommunicationTest extends MockeryTestCase
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -796,7 +794,7 @@ final class CommunicationTest extends MockeryTestCase
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -842,7 +840,7 @@ final class CommunicationTest extends MockeryTestCase
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 

--- a/service-front/mezzio/test/AppTest/Service/Lpa/ReplacementAttorneyCleanupTest.php
+++ b/service-front/mezzio/test/AppTest/Service/Lpa/ReplacementAttorneyCleanupTest.php
@@ -8,7 +8,6 @@ use App\Service\Lpa\Application as LpaApplicationService;
 use App\Service\Lpa\ReplacementAttorneyCleanup;
 use DateTime;
 use Exception;
-use Hamcrest\Matchers;
 use MakeShared\DataModel\Lpa\Document\Decisions\ReplacementAttorneyDecisions;
 use MakeShared\DataModel\Lpa\Lpa;
 use Mockery;
@@ -37,9 +36,9 @@ final class ReplacementAttorneyCleanupTest extends MockeryTestCase
 
         $this->lpaApplicationService
             ->shouldReceive('setReplacementAttorneyDecisions')
-            ->withArgs([Matchers::equalTo(new Lpa([
+            ->withArgs([$this->equalTo(new Lpa([
                 'document' => ['replacementAttorneyDecisions' => new ReplacementAttorneyDecisions()],
-            ])), Matchers::equalTo(new ReplacementAttorneyDecisions())])
+            ])), $this->equalTo(new ReplacementAttorneyDecisions())])
             ->once();
 
         $this->service->cleanUp($lpa);
@@ -51,9 +50,9 @@ final class ReplacementAttorneyCleanupTest extends MockeryTestCase
 
         $this->lpaApplicationService
             ->shouldReceive('setReplacementAttorneyDecisions')
-            ->withArgs([Matchers::equalTo(new Lpa([
+            ->withArgs([$this->equalTo(new Lpa([
                 'document' => ['replacementAttorneyDecisions' => new ReplacementAttorneyDecisions()],
-            ])), Matchers::equalTo(new ReplacementAttorneyDecisions())])
+            ])), $this->equalTo(new ReplacementAttorneyDecisions())])
             ->once();
 
         $this->service->cleanUp($lpa);

--- a/service-front/module/Application/tests/Model/Service/AbstractEmailServiceTest.php
+++ b/service-front/module/Application/tests/Model/Service/AbstractEmailServiceTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace ApplicationTest\Model\Service;
 
 use Application\Model\Service\Mail\Transport\MailTransportInterface;
-use Hamcrest\MatcherAssert;
-use Hamcrest\Matchers;
 use Laminas\View\HelperPluginManager;
 use Mockery;
 use Mockery\MockInterface;
@@ -15,7 +13,7 @@ class AbstractEmailServiceTest extends AbstractServiceTest
 {
     protected array $config;
     protected HelperPluginManager|MockInterface $helperPluginManager;
-    protected MailTransportInterface $mailTransport;
+    protected MailTransportInterface|MockInterface $mailTransport;
 
     public function setUp(): void
     {
@@ -71,9 +69,9 @@ class AbstractEmailServiceTest extends AbstractServiceTest
         $this->helperPluginManager->shouldReceive('get')
             ->with('url')
             ->andReturn(function ($name, $params, $options): string {
-                MatcherAssert::assertThat($name, Matchers::equalTo('/a/route'));
-                MatcherAssert::assertThat($params, Matchers::equalTo(['token' => 'foo']));
-                MatcherAssert::assertThat($options, Matchers::equalTo(['force_canonical' => true]));
+                $this->assertEquals('/a/route', $name);
+                $this->assertEquals(['token' => 'foo'], $params);
+                $this->assertEquals(['force_canonical' => true], $options);
                 return 'https://some.url/';
             });
 

--- a/service-front/module/Application/tests/Model/Service/ApiClient/ClientTest.php
+++ b/service-front/module/Application/tests/Model/Service/ApiClient/ClientTest.php
@@ -9,7 +9,6 @@ use Application\Model\Service\ApiClient\Client;
 use Application\Model\Service\ApiClient\Exception\ApiException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
-use Hamcrest\Matchers;
 use Http\Client\HttpClient;
 use MakeShared\Telemetry\Tracer;
 use Mockery;
@@ -63,14 +62,14 @@ final class ClientTest extends MockeryTestCase
 
         if ($requestData == null) {
             $this->httpClient->shouldReceive('sendRequest')
-                ->withArgs(
-                    [Matchers::equalTo(
+                ->with(
+                    $this->equalTo(
                         new Request(
                             $verb,
                             new Uri($url),
                             $expectedHeaders,
                         )
-                    )]
+                    )
                 )
                 ->once()
                 ->andReturn($this->response);

--- a/service-front/module/Application/tests/Model/Service/Feedback/FeedbackTest.php
+++ b/service-front/module/Application/tests/Model/Service/Feedback/FeedbackTest.php
@@ -10,8 +10,6 @@ use Application\Model\Service\Feedback\Feedback;
 use Application\Model\Service\Feedback\FeedbackValidationException;
 use ApplicationTest\Model\Service\AbstractEmailServiceTest;
 use GuzzleHttp\Psr7\Response;
-use Hamcrest\Matchers;
-use Hamcrest\MatcherAssert;
 use Mockery;
 use Mockery\MockInterface;
 use Psr\Log\LoggerInterface;
@@ -57,29 +55,23 @@ final class FeedbackTest extends AbstractEmailServiceTest
             'agent' => 'Mozilla',
         ];
 
-        $expectedData = [
-            'currentDateTime' => Matchers::matchesPattern('/\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}/'),
-            'rating' => Matchers::equalTo($templateData['rating']),
-            'details' => Matchers::equalTo($templateData['details']),
-            'email' => Matchers::equalTo($templateData['email']),
-            'phone' => Matchers::equalTo($templateData['phone']),
-            'fromPage' => Matchers::equalTo($templateData['fromPage']),
-            'agent' => Matchers::equalTo($templateData['agent']),
-        ];
-
         // Check the data we interpolate into the template looks right
         $this->mailTransport->shouldReceive('send')
-            ->with(Mockery::on(function ($mailParams) use ($expectedData): true {
+            ->with(Mockery::on(function ($mailParams) use ($templateData): true {
                 $actualData = $mailParams->getData();
 
-                foreach ($expectedData as $key => $matcher) {
-                    MatcherAssert::assertThat($actualData[$key], $matcher);
-                }
-
-                MatcherAssert::assertThat(
-                    array_keys($actualData),
-                    Matchers::equalTo(array_keys($expectedData))
+                $this->assertEqualsCanonicalizing(
+                    [...array_keys($templateData), 'currentDateTime'],
+                    array_keys($actualData)
                 );
+
+                $this->assertMatchesRegularExpression('/\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}/', $actualData['currentDateTime']);
+                $this->assertEquals($templateData['rating'], $actualData['rating']);
+                $this->assertEquals($templateData['details'], $actualData['details']);
+                $this->assertEquals($templateData['email'], $actualData['email']);
+                $this->assertEquals($templateData['phone'], $actualData['phone']);
+                $this->assertEquals($templateData['fromPage'], $actualData['fromPage']);
+                $this->assertEquals($templateData['agent'], $actualData['agent']);
 
                 return true;
             }))

--- a/service-front/module/Application/tests/Model/Service/Lpa/CommunicationTest.php
+++ b/service-front/module/Application/tests/Model/Service/Lpa/CommunicationTest.php
@@ -12,8 +12,6 @@ use Application\Model\Service\Session\SessionUtility;
 use ApplicationTest\Model\Service\AbstractEmailServiceTest;
 use MakeShared\DataModel\Lpa\Document\NotifiedPerson;
 use DateTime;
-use Hamcrest\MatcherAssert;
-use Hamcrest\Matchers;
 use Mockery;
 use MakeShared\DataModel\Common\EmailAddress;
 use MakeShared\DataModel\Common\LongName;
@@ -21,14 +19,12 @@ use MakeShared\DataModel\Lpa\Document\Document;
 use MakeShared\DataModel\Lpa\Lpa;
 use MakeShared\DataModel\Lpa\Payment\Payment;
 use Application\Model\Service\Mail\Exception\InvalidArgumentException;
+use Mockery\MockInterface;
 use Psr\Log\LoggerInterface;
 
 final class CommunicationTest extends AbstractEmailServiceTest
 {
-    /**
-     * @var $service Communication
-     */
-    private $service;
+    private Communication&MockInterface $service;
 
     public function setUp(): void
     {
@@ -119,7 +115,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         // Call test method
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
@@ -182,7 +178,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         // Call test method
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
@@ -254,7 +250,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         // Call test method
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
@@ -317,7 +313,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         // Call test method
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
@@ -389,7 +385,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         // Call test method
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
@@ -452,7 +448,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         // Call test method
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
@@ -525,7 +521,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         // Call test method
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
@@ -588,7 +584,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParams));
+            ->with($this->equalTo($expectedMailParams));
 
         // Call test method
         $result = $this->service->sendRegistrationCompleteEmail($lpa);
@@ -658,7 +654,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -721,7 +717,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -793,7 +789,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -856,7 +852,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -920,7 +916,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -976,7 +972,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -1041,7 +1037,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 
@@ -1097,7 +1093,7 @@ final class CommunicationTest extends AbstractEmailServiceTest
 
         $this->mailTransport->shouldReceive('send')
             ->with(Mockery::on(function ($actualMailParams) use ($expectedMailParams): true {
-                MatcherAssert::assertThat($expectedMailParams, Matchers::equalTo($actualMailParams));
+                $this->assertEquals($expectedMailParams, $actualMailParams);
                 return true;
             }));
 

--- a/service-front/module/Application/tests/Model/Service/Lpa/ReplacementAttorneyCleanupTest.php
+++ b/service-front/module/Application/tests/Model/Service/Lpa/ReplacementAttorneyCleanupTest.php
@@ -9,7 +9,6 @@ use Application\Model\Service\Lpa\ReplacementAttorneyCleanup;
 use ApplicationTest\Model\Service\AbstractServiceTest;
 use DateTime;
 use Exception;
-use Hamcrest\Matchers;
 use Mockery;
 use MakeShared\DataModel\Lpa\Document\Decisions\ReplacementAttorneyDecisions;
 use MakeShared\DataModel\Lpa\Lpa;
@@ -39,9 +38,9 @@ final class ReplacementAttorneyCleanupTest extends AbstractServiceTest
 
         $this->lpaApplicationService
             ->shouldReceive('setReplacementAttorneyDecisions')
-            ->withArgs([Matchers::equalTo(new Lpa([
+            ->withArgs([$this->equalTo(new Lpa([
                 'document' => ['replacementAttorneyDecisions' => new ReplacementAttorneyDecisions()]
-            ])), Matchers::equalTo(new ReplacementAttorneyDecisions())])
+            ])), $this->equalTo(new ReplacementAttorneyDecisions())])
             ->once();
 
         $this->service->cleanUp($lpa);
@@ -53,9 +52,9 @@ final class ReplacementAttorneyCleanupTest extends AbstractServiceTest
 
         $this->lpaApplicationService
             ->shouldReceive('setReplacementAttorneyDecisions')
-            ->withArgs([Matchers::equalTo(new Lpa([
+            ->withArgs([$this->equalTo(new Lpa([
                 'document' => ['replacementAttorneyDecisions' => new ReplacementAttorneyDecisions()]
-            ])), Matchers::equalTo(new ReplacementAttorneyDecisions())])
+            ])), $this->equalTo(new ReplacementAttorneyDecisions())])
             ->once();
 
         $this->service->cleanUp($lpa);

--- a/service-front/module/Application/tests/Model/Service/User/DetailsTest.php
+++ b/service-front/module/Application/tests/Model/Service/User/DetailsTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ApplicationTest\Model\Service\User;
 
 use Application\Model\Service\Session\ContainerNamespace;
-use Hamcrest\MatcherAssert;
 use Application\Model\Service\Mail\Exception\InvalidArgumentException;
 use Application\Model\Service\Session\SessionUtility;
 use Psr\Log\LoggerInterface;
@@ -19,7 +18,6 @@ use ApplicationTest\Model\Service\AbstractEmailServiceTest;
 use ApplicationTest\Model\Service\ServiceTestHelper;
 use MakeShared\DataModel\User\User;
 use MakeSharedTest\DataModel\FixturesData;
-use Hamcrest\Matchers;
 use Mockery;
 use Mockery\MockInterface;
 
@@ -225,7 +223,7 @@ final class DetailsTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedOldMailParameters));
+            ->with($this->equalTo($expectedOldMailParameters));
 
         $expectedNewMailParameters = new MailParameters(
             'new@email.address',
@@ -234,7 +232,7 @@ final class DetailsTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedNewMailParameters));
+            ->with($this->equalTo($expectedNewMailParameters));
 
         $result = $this->service->requestEmailUpdate('new@email.address', 'old@email.address');
 
@@ -430,7 +428,7 @@ final class DetailsTest extends AbstractEmailServiceTest
         $this->service->setSessionUtility($sessionUtility);
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParameters))
+            ->with($this->equalTo($expectedMailParameters))
             ->once();
 
         $result = $this->service->updatePassword('old-password', 'new-password');
@@ -463,7 +461,7 @@ final class DetailsTest extends AbstractEmailServiceTest
         $this->service->setSessionUtility($sessionUtility);
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::anInstanceOf(MailParameters::class))
+            ->with($this->isInstanceOf(MailParameters::class))
             ->once()
             ->andThrow(new InvalidArgumentException());
 
@@ -532,11 +530,11 @@ final class DetailsTest extends AbstractEmailServiceTest
 
         $result = $this->service->getTokenInfo('test-token');
 
-        MatcherAssert::assertThat([
+        $this->assertEquals([
             'success' => false,
             'failureCode' => 500,
             'expiresIn' => null,
-        ], Matchers::equalTo($result));
+        ], $result);
     }
 
     public function testDelete(): void
@@ -588,7 +586,7 @@ final class DetailsTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParameters))
+            ->with($this->equalTo($expectedMailParameters))
             ->once();
 
         $result = $this->service->requestPasswordResetEmail('test@email.com');
@@ -630,7 +628,7 @@ final class DetailsTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParameters))
+            ->with($this->equalTo($expectedMailParameters))
             ->once();
 
         $result = $this->service->requestPasswordResetEmail('test@email.com');
@@ -665,7 +663,7 @@ final class DetailsTest extends AbstractEmailServiceTest
             });
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::anInstanceOf(MailParameters::class))
+            ->with($this->isInstanceOf(MailParameters::class))
             ->once();
 
         $result = $this->service->requestPasswordResetEmail('test@email.com');
@@ -688,7 +686,7 @@ final class DetailsTest extends AbstractEmailServiceTest
             });
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::anInstanceOf(MailParameters::class))
+            ->with($this->isInstanceOf(MailParameters::class))
             ->once()
             ->andThrow(new InvalidArgumentException());
 
@@ -712,7 +710,7 @@ final class DetailsTest extends AbstractEmailServiceTest
             });
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::anInstanceOf(MailParameters::class))
+            ->with($this->isInstanceOf(MailParameters::class))
             ->once()
             ->andThrow(new InvalidArgumentException());
 
@@ -736,7 +734,7 @@ final class DetailsTest extends AbstractEmailServiceTest
             });
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::anInstanceOf(MailParameters::class))
+            ->with($this->isInstanceOf(MailParameters::class))
             ->once()
             ->andThrow(new InvalidArgumentException());
 
@@ -815,7 +813,7 @@ final class DetailsTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParameters))
+            ->with($this->equalTo($expectedMailParameters))
             ->once();
 
         $result = $this->service->registerAccount('test@email.com', 'test-password');
@@ -851,7 +849,7 @@ final class DetailsTest extends AbstractEmailServiceTest
             });
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::anInstanceOf(MailParameters::class))
+            ->with($this->isInstanceOf(MailParameters::class))
             ->once()
             ->andThrow(new InvalidArgumentException());
 
@@ -880,7 +878,7 @@ final class DetailsTest extends AbstractEmailServiceTest
             ->andThrow(ServiceTestHelper::createApiException('username-already-exists'));
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::anInstanceOf(MailParameters::class))
+            ->with($this->isInstanceOf(MailParameters::class))
             ->once();
 
         $result = $this->service->registerAccount('test@email.com', 'test-password');
@@ -896,7 +894,7 @@ final class DetailsTest extends AbstractEmailServiceTest
             ->andThrow(ServiceTestHelper::createApiException('username-already-exists'));
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::anInstanceOf(MailParameters::class))
+            ->with($this->isInstanceOf(MailParameters::class))
             ->once()
             ->andThrow(new InvalidArgumentException());
 
@@ -927,7 +925,7 @@ final class DetailsTest extends AbstractEmailServiceTest
         );
 
         $this->mailTransport->shouldReceive('send')
-            ->with(Matchers::equalTo($expectedMailParameters))
+            ->with($this->equalTo($expectedMailParameters))
             ->once();
 
         $result = $this->service->resendActivateEmail('test@email.com');

--- a/shared/composer.json
+++ b/shared/composer.json
@@ -23,7 +23,6 @@
         "symfony/validator": "^8.0"
     },
     "require-dev": {
-        "hamcrest/hamcrest-php": "^2.0",
         "mockery/mockery": "^1.5",
         "phpunit/phpunit": "^9.5.10",
         "vimeo/psalm": "^6.0"

--- a/shared/composer.lock
+++ b/shared/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d37f0c116e54532c8b72e19f1aa61dd",
+    "content-hash": "406c5a198820d4542ea65b18f01d4b60",
     "packages": [
         {
             "name": "brick/varexporter",

--- a/shared/module/MakeShared/tests/Telemetry/Exporter/XrayExporterTest.php
+++ b/shared/module/MakeShared/tests/Telemetry/Exporter/XrayExporterTest.php
@@ -2,7 +2,6 @@
 
 namespace MakeSharedTest\Telemetry\Exporter;
 
-use Hamcrest\Matchers;
 use MakeShared\Telemetry\Exporter\XrayExporter;
 use MakeShared\Telemetry\Segment;
 use Mockery;
@@ -16,7 +15,7 @@ class XrayExporterTest extends TestCase
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('error')
             ->withArgs([
-                Matchers::startsWith('Segment too large to export')
+                $this->stringStartsWith('Segment too large to export')
             ])
             ->andReturn()
             ->once();

--- a/shared/module/MakeShared/tests/Telemetry/ModuleTest.php
+++ b/shared/module/MakeShared/tests/Telemetry/ModuleTest.php
@@ -2,7 +2,6 @@
 
 namespace MakeSharedTest\Telemetry;
 
-use Hamcrest\Core\IsInstanceOf;
 use Laminas\EventManager\EventManager;
 use Laminas\Http\Request;
 use Laminas\Http\Response;
@@ -38,7 +37,7 @@ class ModuleTest extends TestCase
 
         $rootSegment = Mockery::mock(Segment::class);
         $rootSegment->shouldReceive('setAttribute')
-            ->with('http', IsInstanceOf::anInstanceOf(Http::class));
+            ->with('http', $this->isInstanceOf(Http::class));
 
         $tracer = Mockery::mock(Tracer::class);
         $tracer->shouldReceive('startRootSegment')->once();


### PR DESCRIPTION
## Purpose

Hamcrest provides some additional assertion methods, but these are all things we can already do with PHPUnit. Replace our few usages with the PHPUnit equivalents and remove the direct dependency on hamcrest in shared.

This doesn't fully remove hamcrest because it's still used by Mockery, but it will be removed in v3.

Triggered by #3541, which will autoclose after this

#patch

## Approach


- `MatcherAssert::assertThat(..., Matchers::equalTo(...))` can be replaced with `$this->assertEquals`
- `Matchers::equalTo` can be replaced with `$this->equalTo`
  - This is useful for comparing two objects that are different instances of the same class but should have identical values
- `Matchers::anInstanceOf` can be replaced with `$this->isInstanceOf`
- `Matchers::startsWith` can be replaced with `$this->stringStartsWith`
- The iterative approach in FeedbackTest can be replaced with direct assertions

I also added laminas-view to the majors ignorelist due to its dependency on laminas-servicemanager v4.