### PR TITLE
LPAL-2096| enabling circuit breaker to ecs deployments

### DIFF
--- a/terraform/environment/modules/environment/ecs_admin.tf
+++ b/terraform/environment/modules/environment/ecs_admin.tf
@@ -31,6 +31,11 @@ resource "aws_ecs_service" "admin" {
     ]
   }
 
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
   timeouts {
     create = var.environment_name == "production" ? "20m" : "10m"
     update = var.environment_name == "production" ? "20m" : "6m"

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -31,6 +31,11 @@ resource "aws_ecs_service" "front" {
     ]
   }
 
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
   timeouts {
     create = var.environment_name == "production" ? "20m" : "10m"
     update = var.environment_name == "production" ? "20m" : "6m"

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -24,6 +24,11 @@ resource "aws_ecs_service" "pdf" {
     ]
   }
 
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
   timeouts {
     create = var.environment_name == "production" ? "20m" : "10m"
     update = var.environment_name == "production" ? "20m" : "6m"


### PR DESCRIPTION
## Purpose

When a deployment fails, ECS will automatically abort the rollout and revert the tasks back to last successfully deployed image.  This will prevent conflict in terraform resource creations  that were stopped abruptly due to pipeline failures

Fixes LPAL-2096

## Approach

Using circuit breaker config 

## Learning

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-circuit-breaker.html

https://registry.terraform.io/providers/hashicorp/aws/4.4.0/docs/resources/ecs_service

https://dev.to/gokcedemirdurkut/preventing-silent-ecs-deployment-failures-with-circuit-breaker-2k5j#:~:text=The%20deployment%20circuit%20breaker%20can,main.id%20task_definition%20%3D%20aws_ecs_task_definition.