### PR TITLE
LPAL-2025 | region- updating backup kms key to allow cross account copy and restore from backup to primary

### DIFF
--- a/terraform/region/kms_modules.tf
+++ b/terraform/region/kms_modules.tf
@@ -17,16 +17,19 @@ module "aws_backup_cross_account_key" {
     aws_iam_role.aurora_backup_role.arn,
     "arn:aws:iam::${data.aws_caller_identity.backup.account_id}:role/breakglass",
     "arn:aws:iam::${data.aws_caller_identity.backup.account_id}:role/aws-service-role/backup.amazonaws.com/AWSServiceRoleForBackup",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/backup.amazonaws.com/AWSServiceRoleForBackup",
   ]
   encryption_roles = [
     aws_iam_role.aurora_backup_role.arn,
     "arn:aws:iam::${data.aws_caller_identity.backup.account_id}:role/breakglass",
     "arn:aws:iam::${data.aws_caller_identity.backup.account_id}:role/aws-service-role/backup.amazonaws.com/AWSServiceRoleForBackup",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/backup.amazonaws.com/AWSServiceRoleForBackup",
   ]
   grant_roles = [
     aws_iam_role.aurora_backup_role.arn,
     "arn:aws:iam::${data.aws_caller_identity.backup.account_id}:role/breakglass",
     "arn:aws:iam::${data.aws_caller_identity.backup.account_id}:role/aws-service-role/backup.amazonaws.com/AWSServiceRoleForBackup",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/backup.amazonaws.com/AWSServiceRoleForBackup",
   ]
 }
 


### PR DESCRIPTION


## Purpose

Cross account backup restore needs to have the  `role/aws-service-role/backup.amazonaws.com/AWSServiceRoleForBackup` permitted on the backup kms key in addition to cross account permissions being added to backup module.

Fixes LPAL-2025

## Approach

Adding `role/aws-service-role/backup.amazonaws.com/AWSServiceRoleForBackup` to encryption & decryption 


## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
