### PR TITLE
LPAL-174| ENV - attaching kms key to dynamodb resources 

### DIFF
--- a/terraform/environment/modules/environment/dynamo_db.tf
+++ b/terraform/environment/modules/environment/dynamo_db.tf
@@ -11,7 +11,7 @@ resource "aws_dynamodb_table" "lpa-locks" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = data.aws_kms_key.dynamodb_encryption_key.arn
+    kms_key_arn = data.aws_kms_alias.dynamodb_encryption_key.target_key_arn
   }
 
   tags = local.dynamodb_component_tag
@@ -30,7 +30,7 @@ resource "aws_dynamodb_table" "lpa-properties" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = data.aws_kms_key.dynamodb_encryption_key.arn
+    kms_key_arn = data.aws_kms_alias.dynamodb_encryption_key.target_key_arn
   }
 
   tags = local.dynamodb_component_tag
@@ -54,7 +54,7 @@ resource "aws_dynamodb_table" "lpa-sessions" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = data.aws_kms_key.dynamodb_encryption_key.arn
+    kms_key_arn = data.aws_kms_alias.dynamodb_encryption_key.target_key_arn
   }
 
   tags = local.dynamodb_component_tag

--- a/terraform/environment/modules/environment/dynamo_db.tf
+++ b/terraform/environment/modules/environment/dynamo_db.tf
@@ -1,4 +1,4 @@
-#tfsec:ignore:aws-dynamodb-enable-recovery #tfsec:ignore:aws-dynamodb-table-customer-key #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption short lived dynamo table doesn't hold customer data
+#tfsec:ignore:aws-dynamodb-enable-recovery
 resource "aws_dynamodb_table" "lpa-locks" {
   name         = "lpa-locks-${var.environment_name}"
   billing_mode = "PAY_PER_REQUEST"
@@ -9,10 +9,15 @@ resource "aws_dynamodb_table" "lpa-locks" {
     type = "S"
   }
 
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = data.aws_kms_key.dynamodb_encryption_key.arn
+  }
+
   tags = local.dynamodb_component_tag
 }
 
-#tfsec:ignore:aws-dynamodb-enable-recovery #tfsec:ignore:aws-dynamodb-table-customer-key #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption short lived dynamo table doesn't hold customer data
+#tfsec:ignore:aws-dynamodb-enable-recovery
 resource "aws_dynamodb_table" "lpa-properties" {
   name         = "lpa-properties-${var.environment_name}"
   billing_mode = "PAY_PER_REQUEST"
@@ -23,10 +28,15 @@ resource "aws_dynamodb_table" "lpa-properties" {
     type = "S"
   }
 
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = data.aws_kms_key.dynamodb_encryption_key.arn
+  }
+
   tags = local.dynamodb_component_tag
 }
 
-#tfsec:ignore:aws-dynamodb-enable-recovery #tfsec:ignore:aws-dynamodb-table-customer-key #tfsec:ignore:aws-dynamodb-enable-at-rest-encryption To be removed soon as session table deprecated
+#tfsec:ignore:aws-dynamodb-enable-recovery
 resource "aws_dynamodb_table" "lpa-sessions" {
   name         = "lpa-sessions-${var.environment_name}"
   billing_mode = "PAY_PER_REQUEST"
@@ -40,6 +50,11 @@ resource "aws_dynamodb_table" "lpa-sessions" {
   ttl {
     attribute_name = "expires"
     enabled        = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = data.aws_kms_key.dynamodb_encryption_key.arn
   }
 
   tags = local.dynamodb_component_tag

--- a/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
+++ b/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
@@ -78,14 +78,17 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
   }
   statement {
-    sid    = "DynamoDBKeyDecrypt"
+    sid    = "lpaCacheDecrypt"
     effect = "Allow"
     actions = [
       "kms:Decrypt",
       "kms:GenerateDataKey",
     ]
     resources = [
+      data.aws_s3_bucket.lpa_pdf_cache.arn,
+      data.aws_kms_key.lpa_pdf_cache.arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
+
     ]
   }
   statement {
@@ -98,20 +101,6 @@ data "aws_iam_policy_document" "api_permissions_role" {
     resources = [
       data.aws_kms_key.lpa_pdf_sqs.arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
-    ]
-  }
-  statement {
-    sid    = "lpaCacheDecrypt"
-    effect = "Allow"
-    actions = [
-      "kms:Decrypt",
-      "kms:GenerateDataKey",
-    ]
-    resources = [
-      data.aws_s3_bucket.lpa_pdf_cache.arn,
-      data.aws_kms_key.lpa_pdf_cache.arn,
-      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
-
     ]
   }
   statement {
@@ -171,17 +160,6 @@ data "aws_iam_policy_document" "admin_permissions_role" {
     ]
   }
   statement {
-    sid    = "DynamoDBKeyDecrypt"
-    effect = "Allow"
-    actions = [
-      "kms:Decrypt",
-      "kms:GenerateDataKey",
-    ]
-    resources = [
-      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
-    ]
-  }
-  statement {
     effect = "Allow"
     sid    = "ApiXrayDaemon"
     #tfsec:ignore:aws-iam-no-policy-wildcards - Wildcard required for Xray
@@ -237,17 +215,6 @@ data "aws_iam_policy_document" "front_permissions_role" {
     ]
   }
   statement {
-    sid    = "DynamoDBKeyDecrypt"
-    effect = "Allow"
-    actions = [
-      "kms:Decrypt",
-      "kms:GenerateDataKey",
-    ]
-    resources = [
-      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
-    ]
-  }
-  statement {
     sid    = "lpaCacheDecrypt"
     effect = "Allow"
     actions = [
@@ -257,6 +224,7 @@ data "aws_iam_policy_document" "front_permissions_role" {
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
       data.aws_kms_key.lpa_pdf_cache.arn,
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
   statement {
@@ -337,18 +305,6 @@ data "aws_iam_policy_document" "pdf_permissions_role" {
       data.aws_s3_bucket.lpa_pdf_cache.arn,
     ]
   }
-
-  statement {
-    sid    = "DynamoDBKeyDecrypt"
-    effect = "Allow"
-    actions = [
-      "kms:Decrypt",
-      "kms:GenerateDataKey",
-    ]
-    resources = [
-      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
-    ]
-  }
   statement {
     sid    = "lpaCacheDecrypt"
     effect = "Allow"
@@ -359,6 +315,7 @@ data "aws_iam_policy_document" "pdf_permissions_role" {
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
       data.aws_kms_key.lpa_pdf_cache.arn,
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
   statement {

--- a/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
+++ b/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
@@ -84,7 +84,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "kms:GenerateDataKey",
     ]
     resources = [
-      data.aws_kms_key.dynamodb_encryption_key.arn,
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
   statement {
@@ -162,7 +162,7 @@ data "aws_iam_policy_document" "admin_permissions_role" {
       "kms:GenerateDataKey",
     ]
     resources = [
-      data.aws_kms_key.dynamodb_encryption_key.arn,
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
   statement {
@@ -228,7 +228,7 @@ data "aws_iam_policy_document" "front_permissions_role" {
       "kms:GenerateDataKey",
     ]
     resources = [
-      data.aws_kms_key.dynamodb_encryption_key.arn,
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
   statement {
@@ -330,7 +330,7 @@ data "aws_iam_policy_document" "pdf_permissions_role" {
       "kms:GenerateDataKey",
     ]
     resources = [
-      data.aws_kms_key.dynamodb_encryption_key.arn,
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
   statement {

--- a/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
+++ b/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
@@ -173,6 +173,17 @@ data "aws_iam_policy_document" "admin_permissions_role" {
       "xray:GetSamplingStatisticSummaries",
     ]
   }
+  statement {
+    sid    = "DynamoDBAccessDecrypt"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "front_permissions_role" {

--- a/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
+++ b/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
@@ -77,15 +77,14 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
   }
   statement {
-    sid    = "lpaCacheDecrypt"
+    sid    = "DynamoDBKeyDecrypt"
     effect = "Allow"
     actions = [
       "kms:Decrypt",
       "kms:GenerateDataKey",
     ]
     resources = [
-      data.aws_s3_bucket.lpa_pdf_cache.arn,
-      data.aws_kms_key.lpa_pdf_cache.arn,
+      data.aws_kms_key.dynamodb_encryption_key.arn,
     ]
   }
   statement {
@@ -156,6 +155,17 @@ data "aws_iam_policy_document" "admin_permissions_role" {
     ]
   }
   statement {
+    sid    = "DynamoDBKeyDecrypt"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [
+      data.aws_kms_key.dynamodb_encryption_key.arn,
+    ]
+  }
+  statement {
     effect = "Allow"
     sid    = "ApiXrayDaemon"
     #tfsec:ignore:aws-iam-no-policy-wildcards - Wildcard required for Xray
@@ -208,6 +218,17 @@ data "aws_iam_policy_document" "front_permissions_role" {
       aws_dynamodb_table.lpa-locks.arn,
       aws_dynamodb_table.lpa-properties.arn,
       aws_dynamodb_table.lpa-sessions.arn,
+    ]
+  }
+  statement {
+    sid    = "DynamoDBKeyDecrypt"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [
+      data.aws_kms_key.dynamodb_encryption_key.arn,
     ]
   }
   statement {
@@ -301,6 +322,17 @@ data "aws_iam_policy_document" "pdf_permissions_role" {
     ]
   }
 
+  statement {
+    sid    = "DynamoDBKeyDecrypt"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [
+      data.aws_kms_key.dynamodb_encryption_key.arn,
+    ]
+  }
   statement {
     sid    = "lpaCacheDecrypt"
     effect = "Allow"

--- a/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
+++ b/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
@@ -101,6 +101,20 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
   }
   statement {
+    sid    = "lpaCacheDecrypt"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [
+      data.aws_s3_bucket.lpa_pdf_cache.arn,
+      data.aws_kms_key.lpa_pdf_cache.arn,
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
+
+    ]
+  }
+  statement {
     effect = "Allow"
     sid    = "ApiXrayDaemon"
     #tfsec:ignore:aws-iam-no-policy-wildcards - Wildcard required for Xray
@@ -243,7 +257,6 @@ data "aws_iam_policy_document" "front_permissions_role" {
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
       data.aws_kms_key.lpa_pdf_cache.arn,
-      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
   statement {

--- a/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
+++ b/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
@@ -74,6 +74,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
 
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
   statement {
@@ -96,6 +97,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
     resources = [
       data.aws_kms_key.lpa_pdf_sqs.arn,
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
   statement {
@@ -241,6 +243,7 @@ data "aws_iam_policy_document" "front_permissions_role" {
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
       data.aws_kms_key.lpa_pdf_cache.arn,
+      data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
   statement {

--- a/terraform/environment/modules/environment/shared_data_sources.tf
+++ b/terraform/environment/modules/environment/shared_data_sources.tf
@@ -63,6 +63,6 @@ data "aws_kms_alias" "application_log_group_encryption_alias" {
   name = "alias/opg-lpa-${var.account_name}-application-log-group-encryption-key"
 }
 
-data "aws_kms_key" "dynamodb_encryption_key" {
-  key_id = "alias/opg-lpa-${var.account_name}-dynamodb-encryption-key"
+data "aws_kms_alias" "dynamodb_encryption_key" {
+  name = "alias/opg-lpa-${var.account_name}-dynamodb-encryption-key"
 }

--- a/terraform/environment/modules/environment/shared_data_sources.tf
+++ b/terraform/environment/modules/environment/shared_data_sources.tf
@@ -62,3 +62,7 @@ data "aws_default_tags" "current" {}
 data "aws_kms_alias" "application_log_group_encryption_alias" {
   name = "alias/opg-lpa-${var.account_name}-application-log-group-encryption-key"
 }
+
+data "aws_kms_key" "dynamodb_encryption_key" {
+  key_id = "alias/opg-lpa-${var.account_name}-dynamodb-encryption-key"
+}


### PR DESCRIPTION
## Purpose

Encrypt dynamodb resources with customer manager key

Fixes LPAL-1714

## Approach
- Used kms key module to create new kms key for dynamodb in separate [PR](https://github.com/ministryofjustice/opg-lpa/pull/3553)
- Attached key to dynamodb tables 
- Granted admin-task-role, api-task-role, pdf-task-role and front-task-role permissions to decrypt on kms key. 
- Granted S3 access to kms key for table storage

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
