### PR TITLE
Update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,9 @@
   ],
   "branchPrefix": "renovate-",
   "labels": [
-    "Renovate",
-    "Dependencies"
+    "Renovate"
   ],
   "ignoreDeps": [
-    "php",
     "github.com/ministryofjustice/opg-terraform-aws-moj-ip-allow-list"
   ],
   "commitMessageAction": "Renovate update",
@@ -22,11 +20,6 @@
   "minimumReleaseAge": "7 days",
   "vulnerabilityAlerts": {
     "groupName": "Security Alerts",
-    "labels": [
-      "Dependencies",
-      "Renovate",
-      "SecurityAlert"
-    ],
     "dependencyDashboardApproval": false,
     "minimumReleaseAge": null,
     "rangeStrategy": "update-lockfile",
@@ -35,9 +28,9 @@
     "prCreation": "immediate"
   },
   "prConcurrentLimit": 3,
+  "schedule": ["* 6 1,15 * *"],
   "packageRules": [
     {
-      "schedule": ["* 6 1,15 * *"],
       "description": [
         "Lock versions of managed services",
         "Our local images need to match the managed services that we have in AWS"
@@ -55,7 +48,6 @@
       "enabled": false
     },
     {
-      "schedule": ["* 6 1,15 * *"],
       "description": [
         "laminas-servicemanager network blockages (major)",
         "None of these packages can be (major) upgraded until everything supports laminas-servicemanager v4",
@@ -80,7 +72,6 @@
       "enabled": false
     },
     {
-      "schedule": ["* 6 1,15 * *"],
       "description": [
         "laminas-servicemanager network blockages (minor)",
         "robmorgan/phinx has a nested dependency on psr/simple-cache:^2.0, which in turn requires laminas-cache v4 so is blocked by the v4 servicemanager blockage above"
@@ -97,15 +88,9 @@
       "enabled": false
     },
     {
-      "schedule": ["* 6 1,15 * *"],
       "description": [
         "cypress: bundle updates to package.json and dockerfile",
         "allow major version updates"
-      ],
-      "labels": [
-        "devDependencies",
-        "Renovate",
-        "Cypress"
       ],
       "groupName": "Cypress",
       "matchUpdateTypes": [
@@ -121,15 +106,9 @@
       ]
     },
     {
-      "schedule": ["* 6 1,15 * *"],
       "description": [
         "dev tools: allow major updates only for dev tools and aws-sdk",
         "note: this may fail if other packages depend on existing versions"
-      ],
-      "labels": [
-        "devDependencies",
-        "Renovate",
-        "DevTools"
       ],
       "matchUpdateTypes": [
         "major"
@@ -144,17 +123,10 @@
       ]
     },
     {
-      "schedule": ["* 6 1,15 * *"],
       "description": [
         "Github Actions: bundle all updates together"
       ],
-      "labels": [
-        "devDependencies",
-        "Renovate",
-        "GithubActions"
-      ],
       "groupName": "Github Actions",
-      "automerge": true,
       "matchUpdateTypes": [
         "minor",
         "patch",
@@ -165,14 +137,8 @@
       ]
     },
     {
-      "schedule": ["* 6 1,15 * *"],
       "description": [
         "Terraform: bundle all updates together"
-      ],
-      "labels": [
-        "devDependencies",
-        "Renovate",
-        "Terraform"
       ],
       "groupName": "Terraform",
       "matchUpdateTypes": [
@@ -184,7 +150,6 @@
       ]
     },
     {
-      "schedule": ["* 6 1,15 * *"],
       "description": [
         "No updates to postgres, redis, php or python docker images",
         "postgres: keep in sync with live",
@@ -210,7 +175,6 @@
       "enabled": false
     },
     {
-      "schedule": ["* 6 1,15 * *"],
       "description": [
         "No updates to PHP PDF libraries (too sensitive and risky)"
       ],
@@ -229,19 +193,8 @@
       "enabled": false
     },
     {
-      "schedule": ["* 6 1,15 * *"],
-      "description": [
-        "admin composer minor and patch updates (PHP, stable for 3 days)",
-        "These might be automerged once we're comfortable with Renovate"
-      ],
-      "automerge": false,
       "groupName": "admin minor and patch updates (PHP)",
       "groupSlug": "admin-minor-patch-updates-php",
-      "labels": [
-        "Dependencies",
-        "Renovate",
-        "PHP"
-      ],
       "matchManagers": [
         "composer"
       ],
@@ -252,23 +205,11 @@
       "matchFileNames": [
         "service-admin/composer.json"
       ],
-      "prCreation": "immediate",
       "prPriority": 4
     },
     {
-      "schedule": ["* 6 1,15 * *"],
-      "description": [
-        "front composer minor and patch updates (PHP, stable for 3 days)",
-        "These might be automerged once we're comfortable with Renovate"
-      ],
-      "automerge": false,
       "groupName": "front minor and patch updates (PHP)",
       "groupSlug": "front-minor-patch-updates-php",
-      "labels": [
-        "Dependencies",
-        "Renovate",
-        "PHP"
-      ],
       "matchManagers": [
         "composer"
       ],
@@ -279,23 +220,11 @@
       "matchFileNames": [
         "service-front/composer.json"
       ],
-      "prCreation": "immediate",
       "prPriority": 4
     },
     {
-      "schedule": ["* 6 1,15 * *"],
-      "description": [
-        "front mezzio composer minor and patch updates (PHP, stable for 3 days)",
-        "These might be automerged once we're comfortable with Renovate"
-      ],
-      "automerge": false,
       "groupName": "front mezzio minor and patch updates (PHP)",
       "groupSlug": "front-mezzio-minor-patch-updates-php",
-      "labels": [
-        "Dependencies",
-        "Renovate",
-        "PHP"
-      ],
       "matchManagers": [
         "composer"
       ],
@@ -306,23 +235,11 @@
       "matchFileNames": [
         "service-front/mezzio/composer.json"
       ],
-      "prCreation": "immediate",
       "prPriority": 4
     },
     {
-      "schedule": ["* 6 1,15 * *"],
-      "description": [
-        "api composer minor and patch updates (PHP, stable for 3 days)",
-        "These might be automerged once we're comfortable with Renovate"
-      ],
-      "automerge": false,
       "groupName": "api minor and patch updates (PHP)",
       "groupSlug": "api-minor-patch-updates-php",
-      "labels": [
-        "Dependencies",
-        "Renovate",
-        "PHP"
-      ],
       "matchManagers": [
         "composer"
       ],
@@ -333,23 +250,11 @@
       "matchFileNames": [
         "service-api/composer.json"
       ],
-      "prCreation": "immediate",
       "prPriority": 4
     },
     {
-      "schedule": ["* 6 1,15 * *"],
-      "description": [
-        "pdf composer minor and patch updates (PHP, stable for 3 days)",
-        "These might be automerged once we're comfortable with Renovate"
-      ],
-      "automerge": false,
       "groupName": "pdf minor and patch updates (PHP)",
       "groupSlug": "pdf-minor-patch-updates-php",
-      "labels": [
-        "Dependencies",
-        "Renovate",
-        "PHP"
-      ],
       "matchManagers": [
         "composer"
       ],
@@ -360,23 +265,11 @@
       "matchFileNames": [
         "service-pdf/composer.json"
       ],
-      "prCreation": "immediate",
       "prPriority": 4
     },
     {
-      "schedule": ["* 6 1,15 * *"],
-      "description": [
-        "shared composer minor and patch updates (PHP, stable for 3 days)",
-        "These might be automerged once we're comfortable with Renovate"
-      ],
-      "automerge": false,
       "groupName": "shared minor and patch updates (PHP)",
       "groupSlug": "shared-minor-patch-updates-php",
-      "labels": [
-        "Dependencies",
-        "Renovate",
-        "PHP"
-      ],
       "matchManagers": [
         "composer"
       ],
@@ -387,23 +280,11 @@
       "matchFileNames": [
         "shared/composer.json"
       ],
-      "prCreation": "immediate",
       "prPriority": 4
     },
     {
-      "schedule": ["* 6 1,15 * *"],
-      "description": [
-        "npm minor and patch updates (stable for 3 days)",
-        "These might be automerged once we're comfortable with Renovate"
-      ],
-      "automerge": false,
       "groupName": "minor and patch updates (npm)",
       "groupSlug": "all-minor-patch-updates-npm",
-      "labels": [
-        "Dependencies",
-        "Renovate",
-        "nodejs"
-      ],
       "matchManagers": [
         "npm"
       ],
@@ -415,21 +296,11 @@
         "package.json",
         "service-front/package.json"
       ],
-      "prCreation": "immediate",
       "prPriority": 4
     },
     {
-      "schedule": ["* 6 1,15 * *"],
-      "description": [
-        "python minor and patch updates (stable for 3 days)"
-      ],
-      "automerge": false,
       "groupName": "minor and patch updates (Python)",
       "groupSlug": "all-minor-patch-updates-python",
-      "labels": [
-        "Dependencies",
-        "Renovate"
-      ],
       "matchManagers": [
         "pep621",
         "pip_requirements",
@@ -443,17 +314,11 @@
         "minor",
         "patch"
       ],
-      "prCreation": "immediate",
       "prPriority": 4
     },
     {
       "groupName": "Docker images",
       "groupSlug": "docker-images",
-      "description": "Update Docker images and digests",
-      "labels": [
-        "Dependencies",
-        "Renovate"
-      ],
       "matchUpdateTypes": [
         "minor",
         "patch",
@@ -462,8 +327,20 @@
       "matchDatasources": [
         "docker"
       ],
-      "prCreation": "not-pending",
       "prPriority": 4
+    },
+    {
+      "groupName": "PHP major/minor upgrade",
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchPackageNames": [
+        "php"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Purpose

Improve the Renovate config to make sure all our docker images are covered and remove unnecessary configuration.

Fixes LPAL-1913 #patch

## Approach

The main change here is removing PHP from `ignoreDeps`, since that's preventing us from getting essential patch/digest updates. Since PHP upgrades are more complicated, I've added a separate rule for this so it can be properly managed (and closed/ignored if appropriate). Patch/digest updates will be caught by the "Docker images" rule.

I've also made a few other changes to clean up the file a bit:
- Removed all labels except "Renovate" since we don't use them for anything else
- Moved `schedule` to the top-level rather than having it in every package rule
- Removed `automerge: false` and `prCreation: immediate` since they're the default values
  - Removed `automerge: true` from GitHub Actions since it doesn't seem sensible to have this enabled for one (impactful) rule
  - Removed `prCreation: not-pending` from Docker images for consistency with other rules
- Removed `description` properties where they don't add any extra information

## Learning

I thought the reason PHP wasn't being updated was compound tags, until I caught it [doing so for nginx](https://github.com/ministryofjustice/opg-lpa/pull/3494). Then I thought it might be because PHP tags also have `-fpm` or `-cli` in them and. that might be confusing the versioning, but realised they didn't even show up in the Dependency Dashboard. Which led to spotting the `ignoreDeps: [php]` configuration that was the actual blocker.
