### PR TITLE
Group PHP composer updates with dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -336,7 +336,8 @@
         "minor"
       ],
       "matchManagers": [
-        "dockerfile"
+        "dockerfile",
+        "composer"
       ],
       "matchPackageNames": [
         "php"


### PR DESCRIPTION
This will update the expected PHP version in `composer.json` when the Dockerfile is updated, rather than doing so in the minor/patch Composer PR.

Example of this currently going badly:

<img width="473" height="365" alt="image" src="https://github.com/user-attachments/assets/72c4ceb8-7b70-48fc-8352-a0abc3a1103d" />

#patch
