### PR TITLE
Increase ECS Front Resources

### DIFF
--- a/terraform/environment/modules/environment/ecs_cluster.tf
+++ b/terraform/environment/modules/environment/ecs_cluster.tf
@@ -4,7 +4,7 @@ resource "aws_ecs_cluster" "online-lpa" {
 
   setting {
     name  = "containerInsights"
-    value = "enabled"
+    value = "enhanced"
   }
 
   depends_on = [aws_iam_role_policy.execution_role]

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -96,8 +96,8 @@ resource "aws_ecs_task_definition" "front" {
   family                   = "${var.environment_name}-front"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 512
-  memory                   = 1024
+  cpu                      = 1024
+  memory                   = 2048
   container_definitions    = "[${local.front_web}, ${local.front_app}, ${local.aws_otel_collector}]"
   task_role_arn            = var.ecs_iam_task_roles.front.arn
   execution_role_arn       = var.ecs_execution_role.arn


### PR DESCRIPTION
## Purpose

ECS front service started reporting 5xx errors at each deployment

## Approach

- Enable enhanced cluster insights
- increase cpu and memory allocation for ecs front tasks
