### PR TITLE
renovate: target PHP upgrade groups at packagist, not composer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -195,8 +195,8 @@
     {
       "groupName": "admin minor and patch updates (PHP)",
       "groupSlug": "admin-minor-patch-updates-php",
-      "matchManagers": [
-        "composer"
+      "matchDatasources": [
+        "packagist"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -210,8 +210,8 @@
     {
       "groupName": "front minor and patch updates (PHP)",
       "groupSlug": "front-minor-patch-updates-php",
-      "matchManagers": [
-        "composer"
+      "matchDatasources": [
+        "packagist"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -225,8 +225,8 @@
     {
       "groupName": "front mezzio minor and patch updates (PHP)",
       "groupSlug": "front-mezzio-minor-patch-updates-php",
-      "matchManagers": [
-        "composer"
+      "matchDatasources": [
+        "packagist"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -240,8 +240,8 @@
     {
       "groupName": "api minor and patch updates (PHP)",
       "groupSlug": "api-minor-patch-updates-php",
-      "matchManagers": [
-        "composer"
+      "matchDatasources": [
+        "packagist"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -255,8 +255,8 @@
     {
       "groupName": "pdf minor and patch updates (PHP)",
       "groupSlug": "pdf-minor-patch-updates-php",
-      "matchManagers": [
-        "composer"
+      "matchDatasources": [
+        "packagist"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -270,8 +270,8 @@
     {
       "groupName": "shared minor and patch updates (PHP)",
       "groupSlug": "shared-minor-patch-updates-php",
-      "matchManagers": [
-        "composer"
+      "matchDatasources": [
+        "packagist"
       ],
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
## Purpose

Ensure that Renovate PRs to update composer dependencies don't also try to update the version of PHP.

#patch

## Approach

Alter our Renovate PHP groups so that they match the datasource (packagist) rather than the manager (composer), to avoid Renovate trying to update the PHP version in the composer.json file.

## Learning

This distinction isn't obvious, but something we should continue to be careful about when crafting complex Renovate files like this.

NB: on my test repo, I also found that the "PHP major/minor upgrade" group doesn't work as expected because Renovate refuses to add dockerfile updates to it. The logs correctly identify and classify the dockerfile update, it just doesn't show up in the PR. However, I've left the group as it is in for two reasons:
- It might be a blip in my test repo, or a bug that Renovate later fixes
- It's a useful placeholder to remind us that we're not on the latest version of the package

If we end up with an unplayble Renovate PHP PR, we can ignore it, add the `stop-updating` tag or close it.
