### PR TITLE
LPAL-2213 500 unhandled response

### DIFF
--- a/service-front/src/App/src/Handler/Lpa/ConfirmDeleteLpaHandler.php
+++ b/service-front/src/App/src/Handler/Lpa/ConfirmDeleteLpaHandler.php
@@ -7,6 +7,7 @@ namespace App\Handler\Lpa;
 use App\Handler\Traits\CommonTemplateVariablesTrait;
 use App\Service\Lpa\Application as LpaApplicationService;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Diactoros\Response\RedirectResponse;
 use Mezzio\Router\RouteResult;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -32,6 +33,10 @@ class ConfirmDeleteLpaHandler implements RequestHandlerInterface
         $lpaId = $routeResult?->getMatchedParams()['lpa-id'] ?? null;
 
         $lpa = $this->lpaApplicationService->getApplication($lpaId);
+
+        if ($lpa === false) {
+            return new RedirectResponse('/user/dashboard');
+        }
 
         $templateParams = [
             'lpa'  => $lpa,

--- a/service-front/src/App/src/Service/Redis/RedisClientFactory.php
+++ b/service-front/src/App/src/Service/Redis/RedisClientFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service\Redis;
 
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use Redis;
 
 class RedisClientFactory
@@ -15,6 +16,9 @@ class RedisClientFactory
         $redisUrl = $config['redis']['url'] ?? (getenv('OPG_LPA_COMMON_REDIS_CACHE_URL') ?: '');
         $ttlMs    = $config['redis']['ttlMs'] ?? (int)(getenv('OPG_LPA_COMMON_REDIS_CACHE_TTL_MS') ?: 604800000);
 
-        return new RedisClient($redisUrl, $ttlMs, new Redis());
+        $client = new RedisClient($redisUrl, $ttlMs, new Redis());
+        $client->setLogger($container->get(LoggerInterface::class));
+
+        return $client;
     }
 }

--- a/service-front/src/App/src/View/Twig/LegacyCompatExtension.php
+++ b/service-front/src/App/src/View/Twig/LegacyCompatExtension.php
@@ -139,8 +139,12 @@ class LegacyCompatExtension extends AbstractExtension
         return $number . 'th';
     }
 
-    public function formatLpaId(int $id): string
+    public function formatLpaId(?int $id): string
     {
+        if ($id === null) {
+            return '';
+        }
+
         return Formatter::id($id);
     }
 

--- a/service-front/test/AppTest/View/Twig/LegacyCompatExtensionTest.php
+++ b/service-front/test/AppTest/View/Twig/LegacyCompatExtensionTest.php
@@ -138,6 +138,27 @@ final class LegacyCompatExtensionTest extends TestCase
         ];
     }
 
+    public function testFormatLpaIdReturnsEmptyStringWhenIdIsNull(): void
+    {
+        $this->assertSame('', $this->extension->formatLpaId(null));
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('formatLpaIdProvider')]
+    public function testFormatLpaIdFormatsInteger(int $id, string $expected): void
+    {
+        $this->assertSame($expected, $this->extension->formatLpaId($id));
+    }
+
+    public static function formatLpaIdProvider(): array
+    {
+        return [
+            [0, 'A000 0000 0000'],
+            [1, 'A000 0000 0001'],
+            [123456789, 'A001 2345 6789'],
+            [98765432101, 'A987 6543 2101'],
+        ];
+    }
+
     // -------------------------------------------------------------------------
     // url
     // -------------------------------------------------------------------------


### PR DESCRIPTION
LPAL-2213 
getApplication() returns false when the API can't find the LPA (e.g., already deleted, no longer owned by user). The handler was passing false directly to the template, causing Twig to resolve lpa.id as null, which crashed formatLpaId(int $id).

RedisClientFactory created a RedisClient but never called setLogger().