### PR TITLE
LPAL-2080|  updating elasticache kms key module version to fix provider error

### DIFF
--- a/terraform/region/kms_modules.tf
+++ b/terraform/region/kms_modules.tf
@@ -229,7 +229,7 @@ module "dynamodb_encryption_key" {
 
 
 module "elasticache_encryption_key" {
-  source             = "git::https://github.com/ministryofjustice/opg-terraform-aws-kms-key.git?ref=v0.0.10"
+  source             = "git::https://github.com/ministryofjustice/opg-terraform-aws-kms-key.git?ref=v1.0.0"
   description        = "Customer managed encryption key for ElastiCache at rest encryption"
   alias              = "opg-lpa-${local.account_name}-elasticache-encryption-key"
   usage_services     = ["elasticache.amazonaws.com"]


### PR DESCRIPTION
## Purpose

Changes to kms key module version added in this PR 
Elasticache kms key was pending merge so did not get upgraded module - provider error now occurring on LPAL-2080 (kms key usage in environment)  as a result 

Fixes LPAL-2080

## Approach

Elasticache KMS key module source updated to v1.0.0

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
