### PR TITLE
LPAL-1218 restrict IaP to no words longer than 85 chars and no http

### DIFF
--- a/cypress/e2e/InstructionsPreferencesPF.feature
+++ b/cypress/e2e/InstructionsPreferencesPF.feature
@@ -58,4 +58,3 @@ Feature: Specify Instructions and Preferences for a Property and Finance LPA
         When I click "save"
         Then I am taken to the applicant page
         When I visit link containing "preview the LPA"
-

--- a/cypress/e2e/InstructionsPreferencesPF.feature
+++ b/cypress/e2e/InstructionsPreferencesPF.feature
@@ -18,10 +18,43 @@ Feature: Specify Instructions and Preferences for a Property and Finance LPA
         When I click "add-extra-preferences"
         Then I can find "instruction" and it is visible
         And I can find "preferences" and it is visible
+        # Test word > 85 chars in instruction is rejected
         And I fill out
-            | instruction | Some instructions |
+            | instruction | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
             | preferences | Some preferences |
         When I click "save"
+        Then I see in the page text
+            | There is a problem |
+            | No single word in your instructions can be more than 85 characters long |
+        # Test word > 85 chars in preference is rejected
+        When I fill out
+            | instruction | Some instructions |
+            | preferences | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb |
+        And I click "save"
+        Then I see in the page text
+            | There is a problem |
+            | No single word in your preferences can be more than 85 characters long |
+        # Test http link in instruction is rejected
+        When I fill out
+            | instruction | See http://example.com for details |
+            | preferences | Some preferences |
+        And I click "save"
+        Then I see in the page text
+            | There is a problem |
+            | Web links (http:// and https://) are not allowed in instructions |
+        # Test https link in preference is rejected
+        When I fill out
+            | instruction | Some instructions |
+            | preferences | See https://example.com for details |
+        And I click "save"
+        Then I see in the page text
+            | There is a problem |
+            | Web links (http:// and https://) are not allowed in preferences |
+        # Submit valid data and continue
+        When I fill out
+            | instruction | Some instructions |
+            | preferences | Some preferences |
+        And I click "save"
         Then I am taken to the applicant page
         When I click the last occurrence of "accordion-view-change"
         Then I see in the page text
@@ -30,44 +63,4 @@ Feature: Specify Instructions and Preferences for a Property and Finance LPA
         When I click "save"
         Then I am taken to the applicant page
         When I visit link containing "preview the LPA"
-
-    @focus @CleanupFixtures
-    Scenario: Instructions and Preferences rejects words longer than 85 characters
-        When I log in as appropriate test user
-        And I visit the instructions page for the test fixture lpa
-        When I click "add-extra-preferences"
-        And I fill out
-            | instruction | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
-            | preferences | Some preferences |
-        When I click "save"
-        Then I see in the page text
-            | There is a problem |
-            | No single word in your instructions can be more than 85 characters long |
-        When I fill out
-            | instruction | Some instructions |
-            | preferences | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb |
-        When I click "save"
-        Then I see in the page text
-            | There is a problem |
-            | No single word in your preferences can be more than 85 characters long |
-
-    @focus @CleanupFixtures
-    Scenario: Instructions and Preferences rejects http and https links
-        When I log in as appropriate test user
-        And I visit the instructions page for the test fixture lpa
-        When I click "add-extra-preferences"
-        And I fill out
-            | instruction | See http://example.com for details |
-            | preferences | Some preferences |
-        When I click "save"
-        Then I see in the page text
-            | There is a problem |
-            | Web links (http:// and https://) are not allowed in instructions |
-        When I fill out
-            | instruction | Some instructions |
-            | preferences | See https://example.com for details |
-        When I click "save"
-        Then I see in the page text
-            | There is a problem |
-            | Web links (http:// and https://) are not allowed in preferences |
 

--- a/cypress/e2e/InstructionsPreferencesPF.feature
+++ b/cypress/e2e/InstructionsPreferencesPF.feature
@@ -18,7 +18,6 @@ Feature: Specify Instructions and Preferences for a Property and Finance LPA
         When I click "add-extra-preferences"
         Then I can find "instruction" and it is visible
         And I can find "preferences" and it is visible
-        # Test word > 85 chars in instruction is rejected
         And I fill out
             | instruction | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
             | preferences | Some preferences |
@@ -26,7 +25,6 @@ Feature: Specify Instructions and Preferences for a Property and Finance LPA
         Then I see in the page text
             | There is a problem |
             | No single word in your instructions can be more than 85 characters long |
-        # Test word > 85 chars in preference is rejected
         When I fill out
             | instruction | Some instructions |
             | preferences | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb |
@@ -34,7 +32,6 @@ Feature: Specify Instructions and Preferences for a Property and Finance LPA
         Then I see in the page text
             | There is a problem |
             | No single word in your preferences can be more than 85 characters long |
-        # Test http link in instruction is rejected
         When I fill out
             | instruction | See http://example.com for details |
             | preferences | Some preferences |
@@ -42,7 +39,6 @@ Feature: Specify Instructions and Preferences for a Property and Finance LPA
         Then I see in the page text
             | There is a problem |
             | Web links (http:// and https://) are not allowed in instructions |
-        # Test https link in preference is rejected
         When I fill out
             | instruction | Some instructions |
             | preferences | See https://example.com for details |
@@ -50,7 +46,6 @@ Feature: Specify Instructions and Preferences for a Property and Finance LPA
         Then I see in the page text
             | There is a problem |
             | Web links (http:// and https://) are not allowed in preferences |
-        # Submit valid data and continue
         When I fill out
             | instruction | Some instructions |
             | preferences | Some preferences |

--- a/cypress/e2e/InstructionsPreferencesPF.feature
+++ b/cypress/e2e/InstructionsPreferencesPF.feature
@@ -30,3 +30,44 @@ Feature: Specify Instructions and Preferences for a Property and Finance LPA
         When I click "save"
         Then I am taken to the applicant page
         When I visit link containing "preview the LPA"
+
+    @focus @CleanupFixtures
+    Scenario: Instructions and Preferences rejects words longer than 85 characters
+        When I log in as appropriate test user
+        And I visit the instructions page for the test fixture lpa
+        When I click "add-extra-preferences"
+        And I fill out
+            | instruction | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
+            | preferences | Some preferences |
+        When I click "save"
+        Then I see in the page text
+            | There is a problem |
+            | No single word in your instructions can be more than 85 characters long |
+        When I fill out
+            | instruction | Some instructions |
+            | preferences | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb |
+        When I click "save"
+        Then I see in the page text
+            | There is a problem |
+            | No single word in your preferences can be more than 85 characters long |
+
+    @focus @CleanupFixtures
+    Scenario: Instructions and Preferences rejects http and https links
+        When I log in as appropriate test user
+        And I visit the instructions page for the test fixture lpa
+        When I click "add-extra-preferences"
+        And I fill out
+            | instruction | See http://example.com for details |
+            | preferences | Some preferences |
+        When I click "save"
+        Then I see in the page text
+            | There is a problem |
+            | Web links (http:// and https://) are not allowed in instructions |
+        When I fill out
+            | instruction | Some instructions |
+            | preferences | See https://example.com for details |
+        When I click "save"
+        Then I see in the page text
+            | There is a problem |
+            | Web links (http:// and https://) are not allowed in preferences |
+

--- a/service-front/src/App/templates/application/authenticated/lpa/instructions/index.twig
+++ b/service-front/src/App/templates/application/authenticated/lpa/instructions/index.twig
@@ -73,7 +73,9 @@
     {{ form().openTag( form )|raw }}
     <input type="hidden" name="__csrf" value="{{ csrfToken }}">
 
-        <details{{ instructions.getValue() or preferences.getValue() ? ' open' : '' }} class="govuk-details" data-module="govuk-details">
+    {{ macros.formErrorSummary(error,form) }}
+
+        <details{{ instructions.getValue() or preferences.getValue() or form.getMessages|length > 0 ? ' open' : '' }} class="govuk-details" data-module="govuk-details">
             <summary class="govuk-details__summary" data-analytics-click="page:link.reveal:Add extra preferences or instructions for the attorneys? (optional)" data-cy="add-extra-preferences">
                 <span class="govuk-details__summary-text">Add extra preferences or instructions for the attorneys? (optional)</span>
             </summary>

--- a/service-front/src/App/templates/application/authenticated/lpa/instructions/index.twig
+++ b/service-front/src/App/templates/application/authenticated/lpa/instructions/index.twig
@@ -10,10 +10,14 @@
 {% set form = formErrorTextExchange(form, {
     'instruction' : {
         'must-be-less-than-or-equal:10000' : 'Limit your instructions to 10,000 characters',
+        'word-must-be-less-than-or-equal:85' : 'No single word in your instructions can be more than 85 characters long',
+        'no-links-allowed' : 'Web links (http:// and https://) are not allowed in instructions',
         'expected-type:string-or-bool=false' : 'Re-enter your instructions'
     },
     'preference' : {
         'must-be-less-than-or-equal:10000' : 'Limit your preferences to 10,000 characters',
+        'word-must-be-less-than-or-equal:85' : 'No single word in your preferences can be more than 85 characters long',
+        'no-links-allowed' : 'Web links (http:// and https://) are not allowed in preferences',
         'expected-type:string-or-bool=false' : 'Re-enter your preferences'
     }
 }) %}

--- a/service-front/test/AppTest/Form/Lpa/InstructionsAndPreferencesFormTest.php
+++ b/service-front/test/AppTest/Form/Lpa/InstructionsAndPreferencesFormTest.php
@@ -61,4 +61,49 @@ final class InstructionsAndPreferencesFormTest extends TestCase
         $this->assertStringNotContainsString('<b>', $data['instruction']);
         $this->assertStringContainsString('My instruction', $data['instruction']);
     }
+
+    public function testWordLongerThan85CharsInInstructionIsInvalid(): void
+    {
+        $longWord = str_repeat('a', 86);
+        $this->form->setData(['instruction' => "Some {$longWord} text", 'preference' => '']);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testWordExactly85CharsInInstructionIsValid(): void
+    {
+        $exactWord = str_repeat('a', 85);
+        $this->form->setData(['instruction' => "Some {$exactWord} text", 'preference' => '']);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testWordLongerThan85CharsInPreferenceIsInvalid(): void
+    {
+        $longWord = str_repeat('b', 86);
+        $this->form->setData(['instruction' => '', 'preference' => "Some {$longWord} text"]);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testHttpLinkInInstructionIsInvalid(): void
+    {
+        $this->form->setData(['instruction' => 'See http://example.com for details', 'preference' => '']);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testHttpsLinkInInstructionIsInvalid(): void
+    {
+        $this->form->setData(['instruction' => 'See https://example.com for details', 'preference' => '']);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testHttpLinkInPreferenceIsInvalid(): void
+    {
+        $this->form->setData(['instruction' => '', 'preference' => 'See http://example.com for details']);
+        $this->assertFalse($this->form->isValid());
+    }
+
+    public function testHttpsLinkInPreferenceIsInvalid(): void
+    {
+        $this->form->setData(['instruction' => '', 'preference' => 'See https://example.com for details']);
+        $this->assertFalse($this->form->isValid());
+    }
 }

--- a/shared/module/MakeShared/src/DataModel/Lpa/Document/Document.php
+++ b/shared/module/MakeShared/src/DataModel/Lpa/Document/Document.php
@@ -175,12 +175,10 @@ class Document extends AbstractData
                     $context->buildViolation('must-be-less-than-or-equal:10000')->addViolation();
                 }
 
-                // use preg_split to split $value on any sequence of whitespace chars (\s+ matches one or more spaces, tabs, newlines, etc.), returning array of individual words.
-                // -1 — for the limit parameter means "no limit" — split into as many pieces as needed.
-                // PREG_SPLIT_NO_EMPTYihi is a flag that discards empty strings from the result, so multiple consecutive spaces or leading/trailing whitespace don't produce empty array entries.
-                
+                // Split on whitespace and reject if any single word exceeds 85 characters.
+                // ?: [] guards against preg_split returning false on regex failure.
                 if (is_string($value)) {
-                    foreach (preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY) as $word) {
+                    foreach (preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY) ?: [] as $word) {
                         if (strlen($word) > 85) {
                             $context->buildViolation('word-must-be-less-than-or-equal:85')->addViolation();
                             break;
@@ -200,7 +198,7 @@ class Document extends AbstractData
             })
         );
 
-        // preference should be string (not containing words over 85 chars, or http), null or boolean false.
+        // preference should be string, null or boolean false.
         $metadata->addPropertyConstraint(
             'preference',
             new CallbackConstraintSymfony(function ($value, ExecutionContextInterface $context) {
@@ -208,8 +206,10 @@ class Document extends AbstractData
                     $context->buildViolation('must-be-less-than-or-equal:10000')->addViolation();
                 }
 
+                // Split on whitespace and reject if any single word exceeds 85 characters.
+                // ?: [] guards against preg_split returning false on regex failure.
                 if (is_string($value)) {
-                    foreach (preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY) as $word) {
+                    foreach (preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY) ?: [] as $word) {
                         if (strlen($word) > 85) {
                             $context->buildViolation('word-must-be-less-than-or-equal:85')->addViolation();
                             break;

--- a/shared/module/MakeShared/src/DataModel/Lpa/Document/Document.php
+++ b/shared/module/MakeShared/src/DataModel/Lpa/Document/Document.php
@@ -167,7 +167,7 @@ class Document extends AbstractData
             new ValidConstraintSymfony(),
         ]);
 
-        // instruction should be string, null or boolean false.
+        // instruction should be string (not containing words over 85 chars, or http), null or boolean false.
         $metadata->addPropertyConstraint(
             'instruction',
             new CallbackConstraintSymfony(function ($value, ExecutionContextInterface $context) {
@@ -175,6 +175,10 @@ class Document extends AbstractData
                     $context->buildViolation('must-be-less-than-or-equal:10000')->addViolation();
                 }
 
+                // use preg_split to split $value on any sequence of whitespace chars (\s+ matches one or more spaces, tabs, newlines, etc.), returning array of individual words.
+                // -1 — for the limit parameter means "no limit" — split into as many pieces as needed.
+                // PREG_SPLIT_NO_EMPTYihi is a flag that discards empty strings from the result, so multiple consecutive spaces or leading/trailing whitespace don't produce empty array entries.
+                
                 if (is_string($value)) {
                     foreach (preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY) as $word) {
                         if (strlen($word) > 85) {
@@ -196,7 +200,7 @@ class Document extends AbstractData
             })
         );
 
-        // preference should be string, null or boolean false.
+        // preference should be string (not containing words over 85 chars, or http), null or boolean false.
         $metadata->addPropertyConstraint(
             'preference',
             new CallbackConstraintSymfony(function ($value, ExecutionContextInterface $context) {

--- a/shared/module/MakeShared/src/DataModel/Lpa/Document/Document.php
+++ b/shared/module/MakeShared/src/DataModel/Lpa/Document/Document.php
@@ -176,9 +176,9 @@ class Document extends AbstractData
                 }
 
                 // Split on whitespace and reject if any single word exceeds 85 characters.
-                // ?: [] guards against preg_split returning false on regex failure.
                 if (is_string($value)) {
-                    foreach (preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY) ?: [] as $word) {
+                    $words = preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY);
+                    foreach ($words !== false ? $words : [] as $word) {
                         if (strlen($word) > 85) {
                             $context->buildViolation('word-must-be-less-than-or-equal:85')->addViolation();
                             break;
@@ -207,9 +207,9 @@ class Document extends AbstractData
                 }
 
                 // Split on whitespace and reject if any single word exceeds 85 characters.
-                // ?: [] guards against preg_split returning false on regex failure.
                 if (is_string($value)) {
-                    foreach (preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY) ?: [] as $word) {
+                    $words = preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY);
+                    foreach ($words !== false ? $words : [] as $word) {
                         if (strlen($word) > 85) {
                             $context->buildViolation('word-must-be-less-than-or-equal:85')->addViolation();
                             break;

--- a/shared/module/MakeShared/src/DataModel/Lpa/Document/Document.php
+++ b/shared/module/MakeShared/src/DataModel/Lpa/Document/Document.php
@@ -175,6 +175,19 @@ class Document extends AbstractData
                     $context->buildViolation('must-be-less-than-or-equal:10000')->addViolation();
                 }
 
+                if (is_string($value)) {
+                    foreach (preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY) as $word) {
+                        if (strlen($word) > 85) {
+                            $context->buildViolation('word-must-be-less-than-or-equal:85')->addViolation();
+                            break;
+                        }
+                    }
+                }
+
+                if (is_string($value) && preg_match('/https?:\/\//', $value)) {
+                    $context->buildViolation('no-links-allowed')->addViolation();
+                }
+
                 if (is_null($value) || is_string($value) || $value === false) {
                     return;
                 }
@@ -189,6 +202,19 @@ class Document extends AbstractData
             new CallbackConstraintSymfony(function ($value, ExecutionContextInterface $context) {
                 if (is_string($value) && strlen($value) > 10000) {
                     $context->buildViolation('must-be-less-than-or-equal:10000')->addViolation();
+                }
+
+                if (is_string($value)) {
+                    foreach (preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY) as $word) {
+                        if (strlen($word) > 85) {
+                            $context->buildViolation('word-must-be-less-than-or-equal:85')->addViolation();
+                            break;
+                        }
+                    }
+                }
+
+                if (is_string($value) && preg_match('/https?:\/\//', $value)) {
+                    $context->buildViolation('no-links-allowed')->addViolation();
                 }
 
                 if (is_null($value) || is_string($value) || $value === false) {

--- a/shared/module/MakeShared/tests/DataModel/Lpa/Document/DocumentTest.php
+++ b/shared/module/MakeShared/tests/DataModel/Lpa/Document/DocumentTest.php
@@ -88,6 +88,100 @@ class DocumentTest extends TestCase
         $this->assertNotNull($errors['preference']);
     }
 
+    public function testValidationInstructionWordTooLongFailed()
+    {
+        $longWord = str_repeat('a', 86);
+
+        $document = new Document();
+        $document->set('instruction', "Some text {$longWord} more text");
+        $document->set('preference', 'Normal preference');
+
+        $validatorResponse = $document->validate(['instruction', 'preference']);
+        $this->assertTrue($validatorResponse->hasErrors());
+        $errors = $validatorResponse->getArrayCopy();
+        $this->assertNotNull($errors['instruction']);
+        $this->assertStringContainsString('word-must-be-less-than-or-equal:85', $errors['instruction']['messages'][0]);
+    }
+
+    public function testValidationPreferenceWordTooLongFailed()
+    {
+        $longWord = str_repeat('b', 86);
+
+        $document = new Document();
+        $document->set('instruction', 'Normal instruction');
+        $document->set('preference', "Some text {$longWord} more text");
+
+        $validatorResponse = $document->validate(['instruction', 'preference']);
+        $this->assertTrue($validatorResponse->hasErrors());
+        $errors = $validatorResponse->getArrayCopy();
+        $this->assertNotNull($errors['preference']);
+        $this->assertStringContainsString('word-must-be-less-than-or-equal:85', $errors['preference']['messages'][0]);
+    }
+
+    public function testValidationInstructionWordExactly85CharsIsValid()
+    {
+        $exactWord = str_repeat('a', 85);
+
+        $document = new Document();
+        $document->set('instruction', "Some text {$exactWord} more text");
+        $document->set('preference', 'Normal preference');
+
+        $validatorResponse = $document->validate(['instruction', 'preference']);
+        $this->assertFalse($validatorResponse->hasErrors());
+    }
+
+    public function testValidationInstructionWithHttpLinkFailed()
+    {
+        $document = new Document();
+        $document->set('instruction', 'See http://example.com for details');
+        $document->set('preference', 'Normal preference');
+
+        $validatorResponse = $document->validate(['instruction', 'preference']);
+        $this->assertTrue($validatorResponse->hasErrors());
+        $errors = $validatorResponse->getArrayCopy();
+        $this->assertNotNull($errors['instruction']);
+        $this->assertStringContainsString('no-links-allowed', $errors['instruction']['messages'][0]);
+    }
+
+    public function testValidationInstructionWithHttpsLinkFailed()
+    {
+        $document = new Document();
+        $document->set('instruction', 'See https://example.com for details');
+        $document->set('preference', 'Normal preference');
+
+        $validatorResponse = $document->validate(['instruction', 'preference']);
+        $this->assertTrue($validatorResponse->hasErrors());
+        $errors = $validatorResponse->getArrayCopy();
+        $this->assertNotNull($errors['instruction']);
+        $this->assertStringContainsString('no-links-allowed', $errors['instruction']['messages'][0]);
+    }
+
+    public function testValidationPreferenceWithHttpLinkFailed()
+    {
+        $document = new Document();
+        $document->set('instruction', 'Normal instruction');
+        $document->set('preference', 'See http://example.com for details');
+
+        $validatorResponse = $document->validate(['instruction', 'preference']);
+        $this->assertTrue($validatorResponse->hasErrors());
+        $errors = $validatorResponse->getArrayCopy();
+        $this->assertNotNull($errors['preference']);
+        $this->assertStringContainsString('no-links-allowed', $errors['preference']['messages'][0]);
+    }
+
+    public function testValidationPreferenceWithHttpsLinkFailed()
+    {
+        $document = new Document();
+        $document->set('instruction', 'Normal instruction');
+        $document->set('preference', 'See https://example.com for details');
+
+        $validatorResponse = $document->validate(['instruction', 'preference']);
+        $this->assertTrue($validatorResponse->hasErrors());
+        $errors = $validatorResponse->getArrayCopy();
+        $this->assertNotNull($errors['preference']);
+        $this->assertStringContainsString('no-links-allowed', $errors['preference']['messages'][0]);
+    }
+
     public function testValidationTypesFailed()
     {
         $document = new Document();


### PR DESCRIPTION
## Purpose

_Prevent users putting words more than 85 chars long or http in their instructions or preferences as this has caused problems_

## Approach

_Add validation and tests (unit and cypress) for - word longer than 85, http or https, in both instructions and preferences_

