### PR TITLE
LPAL-2242 - add a cognito user pool for test users in non-production environments

### DIFF
--- a/terraform/environment/cognito_client.tf
+++ b/terraform/environment/cognito_client.tf
@@ -1,11 +1,11 @@
 data "aws_cognito_user_pools" "make_a_lasting_power_of_attorney_admin" {
   provider = aws.identity
-  name     = "make-a-lasting-power-of-attorney-admin"
+  name     = local.environment.cognito.admin_cognito_user_pool_name
 }
 
 data "aws_ssm_parameter" "make_a_lasting_power_of_attorney_admin_domain" {
   provider = aws.identity
-  name     = "make_a_lasting_power_of_attorney_admin_domain"
+  name     = local.environment.cognito.admin_cognito_user_pool_domain_name
 }
 
 locals {
@@ -19,7 +19,7 @@ resource "aws_cognito_user_pool_client" "make_a_lasting_power_of_attorney_admin"
   user_pool_id                         = local.admin_cognito_user_pool_id
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_scopes                 = ["openid"]
-  supported_identity_providers         = ["EntraID"]
+  supported_identity_providers         = local.environment.cognito.admin_cognito_client_supported_identity_providers
   allowed_oauth_flows_user_pool_client = true
   explicit_auth_flows = [
     "ALLOW_CUSTOM_AUTH",

--- a/terraform/environment/modules/environment/load_balancer_admin.tf
+++ b/terraform/environment/modules/environment/load_balancer_admin.tf
@@ -44,7 +44,7 @@ resource "aws_lb_listener" "admin_loadbalancer" {
   certificate_arn   = data.aws_acm_certificate.certificate_admin.arn
 
   dynamic "default_action" {
-    for_each = var.environment.admin_cognito_auth_enabled ? [1] : []
+    for_each = var.environment.cognito.admin_cognito_auth_enabled ? [1] : []
     content {
       type = "authenticate-oidc"
       authenticate_oidc {

--- a/terraform/environment/modules/environment/variables.tf
+++ b/terraform/environment/modules/environment/variables.tf
@@ -14,7 +14,9 @@ variable "environment" {
     log_retention_in_days                  = number
     account_name_short                     = string
     associate_alb_with_waf_web_acl_enabled = bool
-    admin_cognito_auth_enabled             = bool
+    cognito = object({
+      admin_cognito_auth_enabled = bool
+    })
     database = object({
       cluster_identifier                 = string
       aurora_cross_region_backup_enabled = bool

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -17,7 +17,7 @@
       "account_name_short": "dev",
       "associate_alb_with_waf_web_acl_enabled": true,
       "cognito": {
-        "admin_cognito_auth_enabled": false,
+        "admin_cognito_auth_enabled": true,
         "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-non-production-admin",
         "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_non_production_admin_domain",
         "admin_cognito_client_supported_identity_providers": [
@@ -239,7 +239,7 @@
       "account_name_short": "prod",
       "associate_alb_with_waf_web_acl_enabled": true,
       "cognito": {
-        "admin_cognito_auth_enabled": false,
+        "admin_cognito_auth_enabled": true,
         "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-admin",
         "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_admin_domain",
         "admin_cognito_client_supported_identity_providers": [

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -18,10 +18,10 @@
       "associate_alb_with_waf_web_acl_enabled": true,
       "cognito": {
         "admin_cognito_auth_enabled": false,
-        "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-admin",
-        "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_admin_domain",
+        "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-non-production-admin",
+        "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_non_production_admin_domain",
         "admin_cognito_client_supported_identity_providers": [
-          "EntraID"
+          "COGNITO"
         ]
       },
       "database": {
@@ -92,10 +92,10 @@
       "associate_alb_with_waf_web_acl_enabled": true,
       "cognito": {
         "admin_cognito_auth_enabled": false,
-        "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-admin",
-        "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_admin_domain",
+        "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-non-production-admin",
+        "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_non_production_admin_domain",
         "admin_cognito_client_supported_identity_providers": [
-          "EntraID"
+          "COGNITO"
         ]
       },
       "database": {
@@ -166,10 +166,10 @@
       "associate_alb_with_waf_web_acl_enabled": true,
       "cognito": {
         "admin_cognito_auth_enabled": false,
-        "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-admin",
-        "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_admin_domain",
+        "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-non-production-admin",
+        "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_non_production_admin_domain",
         "admin_cognito_client_supported_identity_providers": [
-          "EntraID"
+          "COGNITO"
         ]
       },
       "database": {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -239,7 +239,7 @@
       "account_name_short": "prod",
       "associate_alb_with_waf_web_acl_enabled": true,
       "cognito": {
-        "admin_cognito_auth_enabled": true,
+        "admin_cognito_auth_enabled": false,
         "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-admin",
         "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_admin_domain",
         "admin_cognito_client_supported_identity_providers": [

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -17,7 +17,7 @@
       "account_name_short": "dev",
       "associate_alb_with_waf_web_acl_enabled": true,
       "cognito": {
-        "admin_cognito_auth_enabled": true,
+        "admin_cognito_auth_enabled": false,
         "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-non-production-admin",
         "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_non_production_admin_domain",
         "admin_cognito_client_supported_identity_providers": [
@@ -239,7 +239,7 @@
       "account_name_short": "prod",
       "associate_alb_with_waf_web_acl_enabled": true,
       "cognito": {
-        "admin_cognito_auth_enabled": false,
+        "admin_cognito_auth_enabled": true,
         "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-admin",
         "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_admin_domain",
         "admin_cognito_client_supported_identity_providers": [

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -16,7 +16,14 @@
       "log_retention_in_days": 7,
       "account_name_short": "dev",
       "associate_alb_with_waf_web_acl_enabled": true,
-      "admin_cognito_auth_enabled": false,
+      "cognito": {
+        "admin_cognito_auth_enabled": false,
+        "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-admin",
+        "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_admin_domain",
+        "admin_cognito_client_supported_identity_providers": [
+          "EntraID"
+        ]
+      },
       "database": {
         "cluster_identifier": "api2",
         "aurora_cross_region_backup_enabled": false,
@@ -83,7 +90,14 @@
       "log_retention_in_days": 7,
       "account_name_short": "dev",
       "associate_alb_with_waf_web_acl_enabled": true,
-      "admin_cognito_auth_enabled": false,
+      "cognito": {
+        "admin_cognito_auth_enabled": false,
+        "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-admin",
+        "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_admin_domain",
+        "admin_cognito_client_supported_identity_providers": [
+          "EntraID"
+        ]
+      },
       "database": {
         "cluster_identifier": "api2",
         "aurora_cross_region_backup_enabled": false,
@@ -150,7 +164,14 @@
       "log_retention_in_days": 7,
       "account_name_short": "pre",
       "associate_alb_with_waf_web_acl_enabled": true,
-      "admin_cognito_auth_enabled": false,
+      "cognito": {
+        "admin_cognito_auth_enabled": false,
+        "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-admin",
+        "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_admin_domain",
+        "admin_cognito_client_supported_identity_providers": [
+          "EntraID"
+        ]
+      },
       "database": {
         "cluster_identifier": "api2-20260414",
         "aurora_cross_region_backup_enabled": true,
@@ -217,7 +238,14 @@
       "log_retention_in_days": 120,
       "account_name_short": "prod",
       "associate_alb_with_waf_web_acl_enabled": true,
-      "admin_cognito_auth_enabled": true,
+      "cognito": {
+        "admin_cognito_auth_enabled": false,
+        "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-admin",
+        "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_admin_domain",
+        "admin_cognito_client_supported_identity_providers": [
+          "EntraID"
+        ]
+      },
       "database": {
         "cluster_identifier": "api2-20260415",
         "aurora_cross_region_backup_enabled": true,

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -33,7 +33,6 @@ variable "environments" {
       log_retention_in_days                  = number
       account_name_short                     = string
       associate_alb_with_waf_web_acl_enabled = bool
-      admin_cognito_auth_enabled             = bool
       cognito = object({
         admin_cognito_auth_enabled                        = bool
         admin_cognito_user_pool_name                      = string

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -34,6 +34,12 @@ variable "environments" {
       account_name_short                     = string
       associate_alb_with_waf_web_acl_enabled = bool
       admin_cognito_auth_enabled             = bool
+      cognito = object({
+        admin_cognito_auth_enabled                        = bool
+        admin_cognito_user_pool_name                      = string
+        admin_cognito_user_pool_domain_name               = string
+        admin_cognito_client_supported_identity_providers = list(string)
+      })
       database = object({
         cluster_identifier                 = string
         aurora_cross_region_backup_enabled = bool


### PR DESCRIPTION
## Purpose

Allow for a test user in non-production environments to test admin features using Cypress

Fixes LPAL-2242

## Approach

- use tfvars to define cognito identity providers for each environment