### PR TITLE
LPAL-2309 - deploy mock onelogin in non prod envs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -218,28 +218,28 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "e04e85b6c64a463fd4f449b7d7164cdf2e4da35d",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 66
       },
       {
         "type": "Secret Keyword",
         "filename": "docker-compose.yml",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 268
+        "line_number": 281
       },
       {
         "type": "Secret Keyword",
         "filename": "docker-compose.yml",
         "hashed_secret": "d758128216d96d049e531602d7fb04f62158cfd0",
         "is_verified": false,
-        "line_number": 269
+        "line_number": 282
       },
       {
         "type": "Secret Keyword",
         "filename": "docker-compose.yml",
         "hashed_secret": "9f75b3e3dc93390c18a538f001b0f6f4e2d1f46b",
         "is_verified": false,
-        "line_number": 364
+        "line_number": 377
       }
     ],
     "docs/runbooks/seeding_non_live_environments/seeding_non-live_environments.md": [
@@ -865,5 +865,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-15T12:19:42Z"
+  "generated_at": "2026-07-17T09:01:39Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ dc-up: all-composer-install ecrlogin
 	docker compose run --rm npm-front run watch
 
 .PHONY: dc-up-debug
-dc-up-debug: all-composer-install
+dc-up-debug: all-composer-install ecrlogin
 	$(info ${YELLOW}exporting secrets from aws secrets manager. you will be prompted for a password${RESET})
 	@export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_API_NOTIFY_API_KEY=${NOTIFY}; \

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ RESET  := $(shell tput -Txterm sgr0)
 all:
 	@${MAKE} dc-up
 
+.PHONY: ecrlogin
+ecrlogin:
+	aws-vault exec management -- aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin 311462405659.dkr.ecr.eu-west-1.amazonaws.com
+
 .PHONY: reset
 reset:
 	@${MAKE} dc-build-clean
@@ -107,7 +111,7 @@ api-composer-why:
 	@docker run --rm -v `pwd`/service-api/:/app/ composer:${COMPOSER_VERSION} composer why $(PACKAGE)
 
 .PHONY: dc-up
-dc-up: all-composer-install
+dc-up: all-composer-install ecrlogin
 	$(info ${YELLOW}exporting secrets from aws secrets manager. you will be prompted for a password${RESET})
 	@export OPG_LPA_FRONT_GOV_PAY_KEY=${GOVPAY}; \
 	export OPG_LPA_API_NOTIFY_API_KEY=${NOTIFY}; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,19 @@ services:
   #    ports:
   #      - 8000:8000
 
+  mock-onelogin:
+    image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/mock-onelogin:latest
+    container_name: mock-onelogin
+    ports:
+      - "7012:8080"
+    environment:
+      - PUBLIC_URL=http://localhost:7012
+      - CLIENT_ID=client-id-value
+      - REDIRECT_URL=http://localhost:5050/auth/redirect
+      - TEMPLATE_SUB=1
+      - TEMPLATE_SUB_DEFAULT=random
+      - TEMPLATE_RETURN_CODES=1
+
   mock-pay:
     container_name: lpa-mock-pay
     build:

--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -2,38 +2,26 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "6.28.0"
-  constraints = "6.28.0"
+  version     = "6.52.0"
+  constraints = ">= 6.28.0, 6.52.0"
   hashes = [
-    "h1:0aLYWoSJohXeijeD/nB/8wh++Ge2nI/BfsxdZZJf8LI=",
-    "h1:2bDndcCvti7hgXw4MkMo37cyAAu1gk+JvsU9/UbRJNQ=",
-    "h1:4xwnb3NQWg9A3SGIYjvhd5WmFbBP++9fLhvcokAKzKc=",
-    "h1:HYhZgZXKnPKQfV8EFrlKXi4M9YW/RVZ30PpJPKt6Tes=",
-    "h1:RwoFuX1yGMVaKJaUmXDKklEaQ/yUCEdt5k2kz+/g08c=",
-    "h1:XOuWba4Jt7rm+TLlLUhIp8m9i5jbA1K9Ab1FUL1PEjE=",
-    "h1:aGqTvbGcexw1rDeneRME44suXtkM6QKHXEmfEiM8gjc=",
-    "h1:bMiTeecRXGBmx/btqJX57X0KuJ3j9BmM/ph3KZ3FGj0=",
-    "h1:dVGoEW/F1Xb7k2bm+O3IG2eCoe/Dxid4p81yy3lbwqs=",
-    "h1:pAg//+BvaDrvVtw5xgijtsKXAYQGLn2mKl0LBUf6aO8=",
-    "h1:tsoMkB0xujvKt6jQuRlOGVI++eLTLCYqnVAOAeiNoQQ=",
-    "h1:we7AZ0oyoO4dyZtYSoAE5nbbGyDrwyc9+99LbnCrb7I=",
-    "h1:wzZdGs0FFmNqIgPyo9tKnGKJ37BGNSgwRrEXayL29+0=",
-    "h1:xBJIpfIyvY8aCtkbZM/Om23s7bfNqkpe4pTnBlLiAws=",
-    "zh:0ba0d5eb6e0c6a933eb2befe3cdbf22b58fbc0337bf138f95bf0e8bb6e6df93e",
-    "zh:23eacdd4e6db32cf0ff2ce189461bdbb62e46513978d33c5de4decc4670870ec",
-    "zh:307b06a15fc00a8e6fd243abde2cbe5112e9d40371542665b91bec1018dd6e3c",
-    "zh:37a02d5b45a9d050b9642c9e2e268297254192280df72f6e46641daca52e40ec",
-    "zh:3da866639f07d92e734557d673092719c33ede80f4276c835bf7f231a669aa33",
-    "zh:480060b0ba310d0f6b6a14d60b276698cb103c48fd2f7e2802ae47c963995ec6",
-    "zh:57796453455c20db80d9168edbf125bf6180e1aae869de1546a2be58e4e405ec",
-    "zh:69139cba772d4df8de87598d8d8a2b1b4b254866db046c061dccc79edb14e6b9",
-    "zh:7312763259b859ff911c5452ca8bdf7d0be6231c5ea0de2df8f09d51770900ac",
-    "zh:8d2d6f4015d3c155d7eb53e36f019a729aefb46ebfe13f3a637327d3a1402ecc",
-    "zh:94ce589275c77308e6253f607de96919b840c2dd36c44aa798f693c9dd81af42",
+    "h1:lpXqosKH8yAahK3SA1P5Pdy1ziXJcY+blUidY0q9yGk=",
+    "zh:1ab1d78f2336fed42b4e13fa0077a0be9d86a7899897cda5b9f1a60051ec2e93",
+    "zh:1df11f5f252030803939a1c778931dbdcee1b1070b38b98d9a8cbfc26c2aeb8e",
+    "zh:20ec9af03c0c1f2f8582a8805d43a4cd1a0a65082308e00f025d87605715a88f",
+    "zh:2d5562ed0e7cb0892fb537c7989d25fdde1d0ac1f3a768ba15fa087985f2a0f5",
+    "zh:40d64f668961a172355c3d11d258e19172ffafb421c40d89266b129ed8f92a5d",
+    "zh:497792bccc33001247473bc32a148c067982cb3d245b8f3610afb920635d2235",
+    "zh:8011f9167082af74ed9257582a83d54e889388656597721b2691797f1dd6fb58",
+    "zh:8b10d1bbca51b0da1e1be0967ce75b039f2d5d86f2ca7339994a92d35cdf47a8",
+    "zh:9549647dbf7c913512c26fed6badd7bf24a29a36c2bd308536849303a85427da",
+    "zh:97c4b726cdbe48166f4b9e6a1230312a7933dc19dd139d941ca6aca86706eb33",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:adaceec6a1bf4f5df1e12bd72cf52b72087c72efed078aef636f8988325b1a8b",
-    "zh:d37be1ce187d94fd9df7b13a717c219964cd835c946243f096c6b230cdfd7e92",
-    "zh:fe6205b5ca2ff36e68395cb8d3ae10a3728f405cdbcd46b206a515e1ebcf17a1",
+    "zh:a484bc8166278b546bfe53698fa9e0a919dffe3bfda3c8bf8a0fc6811b5b9e66",
+    "zh:aa96e76bd9f93e5395a553fccec485554a74acae46b3834b1296374eba4f010f",
+    "zh:cf290ee3d0dfe91b596445f860440d9f18826f7395ff785f83f70d36cedadd1c",
+    "zh:d56b6a79207663673f66d9ed378d705c1bd1b4d117eeb5e2be3938cf1b75b7be",
+    "zh:febef068317f8e49bd438ccdf2f54345fc3bc4b80a2699d9ab3c449d7e521d8e",
   ]
 }
 
@@ -41,10 +29,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version     = "2.6.1"
   constraints = "2.6.1"
   hashes = [
-    "h1:3xsXDTrMyw3QAktU4aGAja2wE0/6DQV8NaAJL3GeTeU=",
     "h1:DbiR/D2CPigzCGweYIyJH0N0x04oyI5xiZ9wSW/s3kQ=",
-    "h1:LMoX85QLTgCCqRuy2aXoz47P7gZ4WRPSA00fUPC/Rho=",
-    "h1:ixzpZFfRJjW6G1hxQDQ66Lx3gfvVxB8+g5FzwDYO0xA=",
     "zh:10050d08f416de42a857e4b6f76809aae63ea4ec6f5c852a126a915dede814b4",
     "zh:2df2a3ebe9830d4759c59b51702e209fe053f47453cb4688f43c063bac8746b7",
     "zh:2e759568bcc38c86ca0e43701d34cf29945736fdc8e429c5b287ddc2703c7b18",
@@ -64,19 +49,7 @@ provider "registry.terraform.io/pagerduty/pagerduty" {
   version     = "3.30.9"
   constraints = "~> 3.0, 3.30.9"
   hashes = [
-    "h1:+Mj6CdRgIZjw81PkBTFOnBafdhjpQBnazzl9dFyG9w4=",
-    "h1:0DmU/Syyvtf0bu5kkAp8FBh2xP0p+/RaWrs7qZixRDQ=",
     "h1:1BDIoKLH4Ta1m+bddYvLbjnrnA+DaP5pnbd92JGwdFg=",
-    "h1:I9t2cdxXK187LewOqNcmVS87KY6OszotP96huzsHzno=",
-    "h1:QHa8cxauMnMfTuQZKhf6E+mMfYR2Tib6Y3AEonpIy/k=",
-    "h1:UGaxdM7NwR4R5nmOHDRlSL0lOjQ49C5FmsNQrZPEwNc=",
-    "h1:W2QB2M8hwbkSZUJbNz44s/zTZMxLRSgOVqSzGXcjD98=",
-    "h1:bvcIj+l+Ok1KksUAYr7eyhkfWJvolZTOBDFbyaxyslE=",
-    "h1:i02vpsiWrimpQ7SHe6ZNNDYgjuMwyQUN/VT2pCVGyLI=",
-    "h1:kSWSX3l4O4NB+DClZiGbGoaqpF9pI1WywAOr4v7A/ew=",
-    "h1:nm9lvRDNFEj9qMqoPhrdW9bGHyiy+/0aKnp8WGtnj2E=",
-    "h1:uEe3RhggOPCgI5bQbuB9vQLVNKpln4HanF72jzbCXM0=",
-    "h1:wn8lfnUbErDDxEPg3P3u3gqkZPH/h9KwQxumMmPzVR0=",
     "zh:045ccead16193b91eef257f9fc14621ccfab87a6c9073d73e47ed0989b644d8b",
     "zh:0795ff87aea77e27924658c01f09c403c46df201f000877b1814abe1fc570d2f",
     "zh:21b2671fee3ee4eaab6c0191f46b4cca30ea827cf14e46ad1c55c89015b9ed1e",

--- a/terraform/environment/iam_ecs_task_roles.tf
+++ b/terraform/environment/iam_ecs_task_roles.tf
@@ -47,6 +47,14 @@ resource "aws_iam_role" "seeding_task_role" {
   tags               = local.seeding_component_tag
 }
 
+//----------------
+// Mock ECS task role
+resource "aws_iam_role" "mock_onelogin" {
+  name               = "${local.environment_name}-mock-onelogin-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
+  tags               = local.seeding_component_tag
+}
+
 //------------------------------------------------
 // ECS API Cron task role
 

--- a/terraform/environment/main.tf
+++ b/terraform/environment/main.tf
@@ -69,14 +69,12 @@ module "environment_dns" {
     aws.us_east_1  = aws.us_east_1
     aws.management = aws.management
   }
-  account_name           = local.account_name
-  environment_name       = local.environment_name
-  front_dns_name         = !local.dr_enabled ? module.eu-west-1.front_load_balancer_dns_name : module.eu-west-2[0].front_load_balancer_dns_name
-  front_zone_id          = !local.dr_enabled ? module.eu-west-1.front_load_balancer_zone_id : module.eu-west-2[0].front_load_balancer_zone_id
-  admin_dns_name         = !local.dr_enabled ? module.eu-west-1.admin_load_balancer_dns_name : module.eu-west-2[0].admin_load_balancer_dns_name
-  admin_zone_id          = !local.dr_enabled ? module.eu-west-1.admin_load_balancer_zone_id : module.eu-west-2[0].admin_load_balancer_zone_id
-  mock_onelogin_dns_name = !local.dr_enabled ? module.eu-west-1.mock_onelogin_loadbalancer.dns_name : module.eu-west-2[0].mock_onelogin_loadbalancer.dns_name
-  mock_onelogin_zone_id  = !local.dr_enabled ? module.eu-west-1.mock_onelogin_loadbalancer.zone_id : module.eu-west-2[0].mock_onelogin_loadbalancer.zone_id
+  account_name     = local.account_name
+  environment_name = local.environment_name
+  front_dns_name   = !local.dr_enabled ? module.eu-west-1.front_load_balancer_dns_name : module.eu-west-2[0].front_load_balancer_dns_name
+  front_zone_id    = !local.dr_enabled ? module.eu-west-1.front_load_balancer_zone_id : module.eu-west-2[0].front_load_balancer_zone_id
+  admin_dns_name   = !local.dr_enabled ? module.eu-west-1.admin_load_balancer_dns_name : module.eu-west-2[0].admin_load_balancer_dns_name
+  admin_zone_id    = !local.dr_enabled ? module.eu-west-1.admin_load_balancer_zone_id : module.eu-west-2[0].admin_load_balancer_zone_id
 }
 
 module "cross_region_backup" {

--- a/terraform/environment/main.tf
+++ b/terraform/environment/main.tf
@@ -69,12 +69,14 @@ module "environment_dns" {
     aws.us_east_1  = aws.us_east_1
     aws.management = aws.management
   }
-  account_name     = local.account_name
-  environment_name = local.environment_name
-  front_dns_name   = !local.dr_enabled ? module.eu-west-1.front_load_balancer_dns_name : module.eu-west-2[0].front_load_balancer_dns_name
-  front_zone_id    = !local.dr_enabled ? module.eu-west-1.front_load_balancer_zone_id : module.eu-west-2[0].front_load_balancer_zone_id
-  admin_dns_name   = !local.dr_enabled ? module.eu-west-1.admin_load_balancer_dns_name : module.eu-west-2[0].admin_load_balancer_dns_name
-  admin_zone_id    = !local.dr_enabled ? module.eu-west-1.admin_load_balancer_zone_id : module.eu-west-2[0].admin_load_balancer_zone_id
+  account_name           = local.account_name
+  environment_name       = local.environment_name
+  front_dns_name         = !local.dr_enabled ? module.eu-west-1.front_load_balancer_dns_name : module.eu-west-2[0].front_load_balancer_dns_name
+  front_zone_id          = !local.dr_enabled ? module.eu-west-1.front_load_balancer_zone_id : module.eu-west-2[0].front_load_balancer_zone_id
+  admin_dns_name         = !local.dr_enabled ? module.eu-west-1.admin_load_balancer_dns_name : module.eu-west-2[0].admin_load_balancer_dns_name
+  admin_zone_id          = !local.dr_enabled ? module.eu-west-1.admin_load_balancer_zone_id : module.eu-west-2[0].admin_load_balancer_zone_id
+  mock_onelogin_dns_name = !local.dr_enabled ? module.eu-west-1.mock_onelogin_loadbalancer.dns_name : module.eu-west-2[0].mock_onelogin_loadbalancer.dns_name
+  mock_onelogin_zone_id  = !local.dr_enabled ? module.eu-west-1.mock_onelogin_loadbalancer.zone_id : module.eu-west-2[0].mock_onelogin_loadbalancer.zone_id
 }
 
 module "cross_region_backup" {

--- a/terraform/environment/main.tf
+++ b/terraform/environment/main.tf
@@ -19,6 +19,7 @@ module "eu-west-1" {
     admin             = aws_iam_role.admin_task_role
     pdf               = aws_iam_role.pdf_task_role
     seeding           = aws_iam_role.seeding_task_role
+    mock_onelogin     = aws_iam_role.mock_onelogin
     cloudwatch_events = aws_iam_role.cloudwatch_events_ecs_role
   }
   rds_proxy_iam_role = aws_iam_role.rds_proxy
@@ -50,6 +51,7 @@ module "eu-west-2" {
     admin             = aws_iam_role.admin_task_role
     pdf               = aws_iam_role.pdf_task_role
     seeding           = aws_iam_role.seeding_task_role
+    mock_onelogin     = aws_iam_role.mock_onelogin
     cloudwatch_events = aws_iam_role.cloudwatch_events_ecs_role
   }
   rds_proxy_iam_role = aws_iam_role.rds_proxy

--- a/terraform/environment/modules/dns/locals.tf
+++ b/terraform/environment/modules/dns/locals.tf
@@ -5,5 +5,4 @@ locals {
   dns_namespace_dev_prefix = var.account_name == "development" ? "development." : ""
   front_dns                = "front.lpa"
   admin_dns                = "admin.lpa"
-  mock_onelogin_dns        = "onelogin.lpa"
 }

--- a/terraform/environment/modules/dns/locals.tf
+++ b/terraform/environment/modules/dns/locals.tf
@@ -5,4 +5,5 @@ locals {
   dns_namespace_dev_prefix = var.account_name == "development" ? "development." : ""
   front_dns                = "front.lpa"
   admin_dns                = "admin.lpa"
+  mock_onelogin_dns        = "onelogin.lpa"
 }

--- a/terraform/environment/modules/dns/main.tf
+++ b/terraform/environment/modules/dns/main.tf
@@ -164,23 +164,3 @@ resource "aws_cloudwatch_metric_alarm" "public_facing_lastingpowerofattorney" {
 
   provider = aws.us_east_1
 }
-
-
-# mock onelogin
-resource "aws_route53_record" "mock_onelogin" {
-  count    = var.environment_name != "production" ? 1 : 0
-  provider = aws.management
-  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  name     = "${local.dns_namespace_env}${local.dns_namespace_dev_prefix}${local.mock_onelogin_dns}"
-  type     = "A"
-
-  alias {
-    evaluate_target_health = false
-    name                   = var.mock_onelogin_dns_name
-    zone_id                = var.mock_onelogin_zone_id
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}

--- a/terraform/environment/modules/dns/main.tf
+++ b/terraform/environment/modules/dns/main.tf
@@ -164,3 +164,23 @@ resource "aws_cloudwatch_metric_alarm" "public_facing_lastingpowerofattorney" {
 
   provider = aws.us_east_1
 }
+
+
+# mock onelogin
+resource "aws_route53_record" "mock_onelogin" {
+  count    = var.environment_name != "production" ? 1 : 0
+  provider = aws.management
+  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  name     = "${local.dns_namespace_env}${local.dns_namespace_dev_prefix}${local.mock_onelogin_dns}"
+  type     = "A"
+
+  alias {
+    evaluate_target_health = false
+    name                   = var.mock_onelogin_dns_name
+    zone_id                = var.mock_onelogin_zone_id
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/terraform/environment/modules/dns/variables.tf
+++ b/terraform/environment/modules/dns/variables.tf
@@ -18,6 +18,16 @@ variable "admin_zone_id" {
   description = "admin route 53 zone id"
 }
 
+variable "mock_onelogin_dns_name" {
+  type        = string
+  description = "mock onelogin service dns name"
+}
+
+variable "mock_onelogin_zone_id" {
+  type        = string
+  description = "mock onelogin route 53 zone id"
+}
+
 variable "account_name" {
   type        = string
   description = "aws account name"

--- a/terraform/environment/modules/dns/variables.tf
+++ b/terraform/environment/modules/dns/variables.tf
@@ -18,16 +18,6 @@ variable "admin_zone_id" {
   description = "admin route 53 zone id"
 }
 
-variable "mock_onelogin_dns_name" {
-  type        = string
-  description = "mock onelogin service dns name"
-}
-
-variable "mock_onelogin_zone_id" {
-  type        = string
-  description = "mock onelogin route 53 zone id"
-}
-
 variable "account_name" {
   type        = string
   description = "aws account name"

--- a/terraform/environment/modules/dns/versions.tf
+++ b/terraform/environment/modules/dns/versions.tf
@@ -6,7 +6,7 @@ terraform {
         aws.management,
         aws.us_east_1
       ]
-      version = "6.28.0"
+      version = ">= 6.28.0"
     }
     pagerduty = {
       source  = "PagerDuty/pagerduty"

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -238,7 +238,7 @@ locals {
         { name = "OPG_LPA_COMMON_ADMIN_ACCOUNTS", valueFrom = "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_common_admin_accounts.name}" },
         { name = "OPG_LPA_FRONT_OS_PLACES_HUB_LICENSE_KEY", valueFrom = "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_front_os_places_hub_license_key.name}" },
         { name = "OPG_LPA_COMMON_REDIS_AUTH_TOKEN", valueFrom = data.aws_secretsmanager_secret.elasticache_auth_token.arn },
-        { name = "CLIENT_ID", valueFrom = data.aws_secretsmanager_secret.gov_one_login_mrlpa_client_id.arn }
+        { name = "CLIENT_ID", valueFrom = data.aws_secretsmanager_secret.mock_onelogin_client_id.arn }
 
       ],
       environment = [

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -237,7 +237,8 @@ locals {
         { name = "OPG_LPA_COMMON_ACCOUNT_CLEANUP_NOTIFICATION_RECIPIENTS", valueFrom = "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_common_account_cleanup_notification_recipients.name}" },
         { name = "OPG_LPA_COMMON_ADMIN_ACCOUNTS", valueFrom = "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_common_admin_accounts.name}" },
         { name = "OPG_LPA_FRONT_OS_PLACES_HUB_LICENSE_KEY", valueFrom = "/aws/reference/secretsmanager/${data.aws_secretsmanager_secret.opg_lpa_front_os_places_hub_license_key.name}" },
-        { name = "OPG_LPA_COMMON_REDIS_AUTH_TOKEN", valueFrom = data.aws_secretsmanager_secret.elasticache_auth_token.arn }
+        { name = "OPG_LPA_COMMON_REDIS_AUTH_TOKEN", valueFrom = data.aws_secretsmanager_secret.elasticache_auth_token.arn },
+        { name = "CLIENT_ID", valueFrom = data.aws_secretsmanager_secret.gov_one_login_mrlpa_client_id.arn }
 
       ],
       environment = [

--- a/terraform/environment/modules/environment/iam_ecs_permissions.tf
+++ b/terraform/environment/modules/environment/iam_ecs_permissions.tf
@@ -91,7 +91,7 @@ data "aws_iam_policy_document" "execution_role" {
       data.aws_secretsmanager_secret.opg_lpa_api_auth_log_salt.arn,
       data.aws_secretsmanager_secret.elasticache_auth_token.arn,
       data.aws_secretsmanager_secret.opg_lpa_admin_service_secret.arn,
-      data.aws_secretsmanager_secret.gov_one_login_mrlpa_client_id.arn,
+      data.aws_secretsmanager_secret.mock_onelogin_client_id.arn,
     ]
   }
 

--- a/terraform/environment/modules/environment/iam_ecs_permissions.tf
+++ b/terraform/environment/modules/environment/iam_ecs_permissions.tf
@@ -91,6 +91,7 @@ data "aws_iam_policy_document" "execution_role" {
       data.aws_secretsmanager_secret.opg_lpa_api_auth_log_salt.arn,
       data.aws_secretsmanager_secret.elasticache_auth_token.arn,
       data.aws_secretsmanager_secret.opg_lpa_admin_service_secret.arn,
+      data.aws_secretsmanager_secret.gov_one_login_mrlpa_client_id.arn,
     ]
   }
 

--- a/terraform/environment/modules/environment/mock_onelogin.tf
+++ b/terraform/environment/modules/environment/mock_onelogin.tf
@@ -1,19 +1,22 @@
-data "aws_ecr_repository" "mock_pay" {
-  name     = "modernising-lpa/mock-pay"
-  provider = aws.management_eu_west_1
+data "aws_ecr_repository" "mock_onelogin" {
+  name     = "modernising-lpa/mock-onelogin"
+  provider = aws.management
 }
 
 data "aws_ecr_image" "mock_onelogin" {
   repository_name = data.aws_ecr_repository.mock_onelogin.name
   image_tag       = "latest"
-  provider        = aws.management_eu_west_1
+  provider        = aws.management
 }
 
 module "mock_onelogin" {
-  count                           = data.aws_default_tags.current.tags.environment-name != "production" && var.mock_onelogin.enabled ? 1 : 0
-  source                          = "./modules/mock_onelogin"
-  ecs_cluster                     = aws_ecs_cluster.online-lpa.id
-  ecs_execution_role              = var.iam_roles.ecs_execution_role
+  count       = data.aws_default_tags.current.tags.environment-name != "production" && var.environment.feature_flags.onelogin_enabled ? 1 : 0
+  source      = "./modules/mock_onelogin"
+  ecs_cluster = aws_ecs_cluster.online-lpa.id
+  ecs_execution_role = {
+    id  = var.ecs_execution_role.id
+    arn = var.ecs_execution_role.arn
+  }
   ecs_task_role                   = var.ecs_iam_task_roles.mock_onelogin.arn
   ecs_service_desired_count       = 1
   ecs_application_log_group_name  = aws_cloudwatch_log_group.application_logs.name
@@ -25,19 +28,19 @@ module "mock_onelogin" {
   waf_alb_association_enabled     = true
   container_port                  = 8080
   public_access_enabled           = false
-  redirect_base_url               = var.app_env_vars.auth_redirect_base_url
-  template_sub                    = var.mock_onelogin.template_sub
+  redirect_base_url               = "https://${data.aws_default_tags.current.tags.environment-name}.${var.account_name}.front.lpa.opg.service.justice.gov.uk/"
+  template_sub                    = "1"
   network = {
     vpc_id              = data.aws_vpc.main.id
     application_subnets = data.aws_subnet.application[*].id
-    public_subnets      = data.aws_subnet.public[*].id
+    public_subnets      = data.aws_subnet.lb[*].id
   }
   aws_service_discovery_private_dns_namespace = {
     id   = aws_service_discovery_private_dns_namespace.internal.id
     name = aws_service_discovery_private_dns_namespace.internal.name
   }
-  app_ecs_service_security_group_id = module.app.ecs_service_security_group.id
+  front_app_ecs_service_security_group_id = aws_security_group.front_ecs_service.id
   providers = {
-    aws.region = aws.region
+    aws.region = aws
   }
 }

--- a/terraform/environment/modules/environment/mock_onelogin.tf
+++ b/terraform/environment/modules/environment/mock_onelogin.tf
@@ -10,9 +10,10 @@ data "aws_ecr_image" "mock_onelogin" {
 }
 
 module "mock_onelogin" {
-  count       = data.aws_default_tags.current.tags.environment-name != "production" && var.environment.feature_flags.onelogin_enabled ? 1 : 0
-  source      = "./modules/mock_onelogin"
-  ecs_cluster = aws_ecs_cluster.online-lpa.id
+  count        = data.aws_default_tags.current.tags.environment-name != "production" && var.environment.feature_flags.onelogin_enabled ? 1 : 0
+  source       = "./modules/mock_onelogin"
+  account_name = var.account_name
+  ecs_cluster  = aws_ecs_cluster.online-lpa.id
   ecs_execution_role = {
     id  = var.ecs_execution_role.id
     arn = var.ecs_execution_role.arn

--- a/terraform/environment/modules/environment/mock_onelogin.tf
+++ b/terraform/environment/modules/environment/mock_onelogin.tf
@@ -42,7 +42,8 @@ module "mock_onelogin" {
   }
   front_app_ecs_service_security_group_id = aws_security_group.front_ecs_service.id
   providers = {
-    aws.region = aws
+    aws.region     = aws
+    aws.management = aws.management
   }
 
   depends_on = [

--- a/terraform/environment/modules/environment/mock_onelogin.tf
+++ b/terraform/environment/modules/environment/mock_onelogin.tf
@@ -1,5 +1,5 @@
 data "aws_ecr_repository" "mock_onelogin" {
-  name     = "modernising-lpa/mock-onelogin"
+  name     = "mock-onelogin"
   provider = aws.management
 }
 
@@ -18,7 +18,7 @@ module "mock_onelogin" {
     id  = var.ecs_execution_role.id
     arn = var.ecs_execution_role.arn
   }
-  ecs_task_role                   = var.ecs_iam_task_roles.mock_onelogin.arn
+  ecs_task_role                   = var.ecs_iam_task_roles.mock_onelogin
   ecs_service_desired_count       = 1
   ecs_application_log_group_name  = aws_cloudwatch_log_group.application_logs.name
   ecs_capacity_provider           = "FARGATE_SPOT"
@@ -44,4 +44,8 @@ module "mock_onelogin" {
   providers = {
     aws.region = aws
   }
+
+  depends_on = [
+    aws_iam_role_policy.api_permissions_role
+  ]
 }

--- a/terraform/environment/modules/environment/mock_onelogin.tf
+++ b/terraform/environment/modules/environment/mock_onelogin.tf
@@ -1,0 +1,43 @@
+data "aws_ecr_repository" "mock_pay" {
+  name     = "modernising-lpa/mock-pay"
+  provider = aws.management_eu_west_1
+}
+
+data "aws_ecr_image" "mock_onelogin" {
+  repository_name = data.aws_ecr_repository.mock_onelogin.name
+  image_tag       = "latest"
+  provider        = aws.management_eu_west_1
+}
+
+module "mock_onelogin" {
+  count                           = data.aws_default_tags.current.tags.environment-name != "production" && var.mock_onelogin.enabled ? 1 : 0
+  source                          = "./modules/mock_onelogin"
+  ecs_cluster                     = aws_ecs_cluster.online-lpa.id
+  ecs_execution_role              = var.iam_roles.ecs_execution_role
+  ecs_task_role                   = var.ecs_iam_task_roles.mock_onelogin.arn
+  ecs_service_desired_count       = 1
+  ecs_application_log_group_name  = aws_cloudwatch_log_group.application_logs.name
+  ecs_capacity_provider           = "FARGATE_SPOT"
+  ingress_allow_list_cidr         = module.allowed_ip_list.moj_sites
+  repository_url                  = data.aws_ecr_repository.mock_onelogin.repository_url
+  image_digest                    = data.aws_ecr_image.mock_onelogin.id
+  alb_deletion_protection_enabled = false
+  waf_alb_association_enabled     = true
+  container_port                  = 8080
+  public_access_enabled           = false
+  redirect_base_url               = var.app_env_vars.auth_redirect_base_url
+  template_sub                    = var.mock_onelogin.template_sub
+  network = {
+    vpc_id              = data.aws_vpc.main.id
+    application_subnets = data.aws_subnet.application[*].id
+    public_subnets      = data.aws_subnet.public[*].id
+  }
+  aws_service_discovery_private_dns_namespace = {
+    id   = aws_service_discovery_private_dns_namespace.internal.id
+    name = aws_service_discovery_private_dns_namespace.internal.name
+  }
+  app_ecs_service_security_group_id = module.app.ecs_service_security_group.id
+  providers = {
+    aws.region = aws.region
+  }
+}

--- a/terraform/environment/modules/environment/modules/ecs_autoscaling/versions.tf
+++ b/terraform/environment/modules/environment/modules/ecs_autoscaling/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.28.0"
+      version = ">= 6.28.0"
     }
   }
   required_version = "1.14.3"

--- a/terraform/environment/modules/environment/modules/ecs_scheduled_scaling/versions.tf
+++ b/terraform/environment/modules/environment/modules/ecs_scheduled_scaling/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.28.0"
+      version = ">= 6.28.0"
     }
   }
   required_version = "1.14.3"

--- a/terraform/environment/modules/environment/modules/mock_onelogin/README.md
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/README.md
@@ -1,0 +1,79 @@
+# Mock One Login Module
+
+This module creates the resources required to mock One Login.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.42.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws.region"></a> [aws.region](#provider\_aws.region) | ~> 5.42.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecs_service.mock_onelogin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.mock_onelogin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_lb.mock_onelogin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.mock_onelogin_loadbalancer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.mock_onelogin_loadbalancer_http_redirect](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener_certificate.mock_onelogin_loadbalancer_live_service_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate) | resource |
+| [aws_lb_target_group.mock_onelogin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_security_group.mock_onelogin_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.mock_onelogin_loadbalancer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.loadbalancer_ingress_route53_healthchecks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.mock_one_login_service_app_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.mock_onelogin_ecs_service_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.mock_onelogin_ecs_service_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.mock_onelogin_loadbalancer_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.mock_onelogin_loadbalancer_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.mock_onelogin_loadbalancer_port_80_redirect_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.mock_onelogin_loadbalancer_public_access_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_service_discovery_service.mock_onelogin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_service) | resource |
+| [aws_acm_certificate.certificate_mock_onelogin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
+| [aws_default_tags.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
+| [aws_ip_ranges.route53_healthchecks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ip_ranges) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_s3_bucket.access_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_alb_deletion_protection_enabled"></a> [alb\_deletion\_protection\_enabled](#input\_alb\_deletion\_protection\_enabled) | If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false. | `bool` | n/a | yes |
+| <a name="input_app_ecs_service_security_group_id"></a> [app\_ecs\_service\_security\_group\_id](#input\_app\_ecs\_service\_security\_group\_id) | ID of the security group for the app ECS service | `string` | n/a | yes |
+| <a name="input_aws_service_discovery_private_dns_namespace"></a> [aws\_service\_discovery\_private\_dns\_namespace](#input\_aws\_service\_discovery\_private\_dns\_namespace) | ID and name of the AWS Service Discovery private DNS namespace | <pre>object({<br>    id   = string<br>    name = string<br>  })</pre> | n/a | yes |
+| <a name="input_container_port"></a> [container\_port](#input\_container\_port) | Port on the container to associate with. | `number` | n/a | yes |
+| <a name="input_container_version"></a> [container\_version](#input\_container\_version) | Version of the container to use | `string` | n/a | yes |
+| <a name="input_ecs_application_log_group_name"></a> [ecs\_application\_log\_group\_name](#input\_ecs\_application\_log\_group\_name) | The AWS Cloudwatch Log Group resource for application logging | `string` | n/a | yes |
+| <a name="input_ecs_capacity_provider"></a> [ecs\_capacity\_provider](#input\_ecs\_capacity\_provider) | Name of the capacity provider to use. Valid values are FARGATE\_SPOT and FARGATE | `string` | n/a | yes |
+| <a name="input_ecs_cluster"></a> [ecs\_cluster](#input\_ecs\_cluster) | ARN of an ECS cluster. | `string` | n/a | yes |
+| <a name="input_ecs_execution_role"></a> [ecs\_execution\_role](#input\_ecs\_execution\_role) | ID and ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. | <pre>object({<br>    id  = string<br>    arn = string<br>  })</pre> | n/a | yes |
+| <a name="input_ecs_service_desired_count"></a> [ecs\_service\_desired\_count](#input\_ecs\_service\_desired\_count) | Number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the DAEMON scheduling strategy. | `number` | `0` | no |
+| <a name="input_ecs_task_role"></a> [ecs\_task\_role](#input\_ecs\_task\_role) | ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services. | `any` | n/a | yes |
+| <a name="input_ingress_allow_list_cidr"></a> [ingress\_allow\_list\_cidr](#input\_ingress\_allow\_list\_cidr) | List of CIDR ranges permitted to access the service | `list(string)` | n/a | yes |
+| <a name="input_network"></a> [network](#input\_network) | VPC ID, a list of application subnets, and a list of private subnets required to provision the ECS service | <pre>object({<br>    vpc_id              = string<br>    application_subnets = list(string)<br>    public_subnets      = list(string)<br>  })</pre> | n/a | yes |
+| <a name="input_public_access_enabled"></a> [public\_access\_enabled](#input\_public\_access\_enabled) | Enable access to the Modernising LPA service from the public internet | `bool` | n/a | yes |
+| <a name="input_redirect_base_url"></a> [redirect\_base\_url](#input\_redirect\_base\_url) | Base URL expected for redirect\_url | `string` | n/a | yes |
+| <a name="input_repository_url"></a> [repository\_url](#input\_repository\_url) | URL of the repository for the container to use | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_ecs_service"></a> [ecs\_service](#output\_ecs\_service) | n/a |
+| <a name="output_load_balancer"></a> [load\_balancer](#output\_load\_balancer) | n/a |
+| <a name="output_load_balancer_security_group"></a> [load\_balancer\_security\_group](#output\_load\_balancer\_security\_group) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/environment/modules/environment/modules/mock_onelogin/access_logging_bucket.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/access_logging_bucket.tf
@@ -1,0 +1,4 @@
+data "aws_s3_bucket" "access_log" {
+  bucket   = "${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-lb-access-logs-${data.aws_region.current.region}"
+  provider = aws.region
+}

--- a/terraform/environment/modules/environment/modules/mock_onelogin/access_logging_bucket.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/access_logging_bucket.tf
@@ -1,4 +1,4 @@
 data "aws_s3_bucket" "access_log" {
-  bucket   = "${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-lb-access-logs-${data.aws_region.current.region}"
+  bucket   = "online-lpa-${var.account_name}-${data.aws_region.current.region}-lb-access-logs"
   provider = aws.region
 }

--- a/terraform/environment/modules/environment/modules/mock_onelogin/alb.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/alb.tf
@@ -1,0 +1,178 @@
+resource "aws_lb_target_group" "mock_onelogin" {
+  name                 = "${data.aws_default_tags.current.tags.environment-name}-mock-onelogin"
+  port                 = 80
+  protocol             = "HTTP"
+  target_type          = "ip"
+  vpc_id               = var.network.vpc_id
+  deregistration_delay = 300
+  depends_on           = [aws_lb.mock_onelogin]
+
+  health_check {
+    enabled = true
+    path    = "/.well-known/openid-configuration"
+  }
+
+  provider = aws.region
+}
+
+resource "aws_lb" "mock_onelogin" {
+  name                       = "${data.aws_default_tags.current.tags.environment-name}-mock-onelogin"
+  internal                   = false #tfsec:ignore:AWS005 - public alb
+  load_balancer_type         = "application"
+  drop_invalid_header_fields = true
+  subnets                    = var.network.public_subnets
+  enable_deletion_protection = var.alb_deletion_protection_enabled
+  security_groups            = [aws_security_group.mock_onelogin_loadbalancer.id]
+
+  access_logs {
+    bucket  = data.aws_s3_bucket.access_log.bucket
+    prefix  = "mock-onelogin-${data.aws_default_tags.current.tags.environment-name}"
+    enabled = true
+  }
+  provider = aws.region
+}
+
+resource "aws_lb_listener" "mock_onelogin_loadbalancer_http_redirect" {
+  load_balancer_arn = aws_lb.mock_onelogin.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = 443
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+  provider = aws.region
+}
+
+data "aws_acm_certificate" "certificate_mock_onelogin" {
+  domain   = "*.app.modernising.opg.service.justice.gov.uk"
+  provider = aws.region
+}
+
+resource "aws_lb_listener" "mock_onelogin_loadbalancer" {
+  load_balancer_arn = aws_lb.mock_onelogin.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-2019-08"
+  certificate_arn   = data.aws_acm_certificate.certificate_mock_onelogin.arn
+
+  default_action {
+    target_group_arn = aws_lb_target_group.mock_onelogin.arn
+    type             = "forward"
+  }
+  provider = aws.region
+}
+
+resource "aws_lb_listener_certificate" "mock_onelogin_loadbalancer_live_service_certificate" {
+  listener_arn    = aws_lb_listener.mock_onelogin_loadbalancer.arn
+  certificate_arn = data.aws_acm_certificate.certificate_mock_onelogin.arn
+  provider        = aws.region
+}
+
+resource "aws_security_group" "mock_onelogin_loadbalancer" {
+  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-mock-onelogin-loadbalancer"
+  description = "mock-onelogin service application load balancer"
+  vpc_id      = var.network.vpc_id
+  lifecycle {
+    create_before_destroy = true
+  }
+  provider = aws.region
+}
+
+data "aws_ip_ranges" "route53_healthchecks" {
+  services = ["route53_healthchecks"]
+  regions  = ["GLOBAL", "us-east-1", "eu-west-1", "us-west-2"]
+  provider = aws.region
+}
+
+resource "terraform_data" "route53_healthchecks_cidr_blocks" {
+  input = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
+}
+
+resource "terraform_data" "route53_healthchecks_ipv6_cidr_blocks" {
+  input = data.aws_ip_ranges.route53_healthchecks.ipv6_cidr_blocks
+}
+
+resource "terraform_data" "ingress_allow_list_cidr" {
+  input = var.ingress_allow_list_cidr
+}
+
+resource "aws_security_group_rule" "mock_onelogin_loadbalancer_port_80_redirect_ingress" {
+  count             = var.public_access_enabled ? 0 : 1
+  description       = "Port 80 ingress for redirection to port 443"
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = var.ingress_allow_list_cidr #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+  security_group_id = aws_security_group.mock_onelogin_loadbalancer.id
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.ingress_allow_list_cidr
+    ]
+  }
+  provider = aws.region
+}
+
+resource "aws_security_group_rule" "mock_onelogin_loadbalancer_ingress" {
+  count             = var.public_access_enabled ? 0 : 1
+  description       = "Port 443 ingress from the allow list to the application load balancer"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = var.ingress_allow_list_cidr #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+  security_group_id = aws_security_group.mock_onelogin_loadbalancer.id
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.ingress_allow_list_cidr
+    ]
+  }
+  provider = aws.region
+}
+
+resource "aws_security_group_rule" "loadbalancer_ingress_route53_healthchecks" {
+  description       = "Loadbalancer ingresss from Route53 healthchecks"
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = "443"
+  to_port           = "443"
+  cidr_blocks       = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
+  ipv6_cidr_blocks  = data.aws_ip_ranges.route53_healthchecks.ipv6_cidr_blocks
+  security_group_id = aws_security_group.mock_onelogin_loadbalancer.id
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.route53_healthchecks_cidr_blocks,
+      terraform_data.route53_healthchecks_ipv6_cidr_blocks
+    ]
+  }
+  provider = aws.region
+}
+
+resource "aws_security_group_rule" "mock_onelogin_loadbalancer_public_access_ingress" {
+  count             = var.public_access_enabled ? 1 : 0
+  description       = "Port 443 production public ingress to the application load balancer"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-ingress-sgr - open ingress for production
+  security_group_id = aws_security_group.mock_onelogin_loadbalancer.id
+  provider          = aws.region
+}
+
+resource "aws_security_group_rule" "mock_onelogin_loadbalancer_egress" {
+  description       = "Allow any egress from service load balancer"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:aws-ec2-no-public-egress-sgr - open egress for load balancers
+  security_group_id = aws_security_group.mock_onelogin_loadbalancer.id
+  provider          = aws.region
+}

--- a/terraform/environment/modules/environment/modules/mock_onelogin/alb.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/alb.tf
@@ -50,7 +50,7 @@ resource "aws_lb_listener" "mock_onelogin_loadbalancer_http_redirect" {
 }
 
 data "aws_acm_certificate" "certificate_mock_onelogin" {
-  domain   = "*.app.modernising.opg.service.justice.gov.uk"
+  domain   = "*.${var.account_name}.front.lpa.opg.service.justice.gov.uk"
   provider = aws.region
 }
 

--- a/terraform/environment/modules/environment/modules/mock_onelogin/data_sources.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/data_sources.tf
@@ -1,0 +1,7 @@
+data "aws_region" "current" {
+  provider = aws.region
+}
+
+data "aws_default_tags" "current" {
+  provider = aws.region
+}

--- a/terraform/environment/modules/environment/modules/mock_onelogin/data_sources.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/data_sources.tf
@@ -5,3 +5,8 @@ data "aws_region" "current" {
 data "aws_default_tags" "current" {
   provider = aws.region
 }
+
+data "aws_route53_zone" "opg_service_justice_gov_uk" {
+  provider = aws.management
+  name     = "opg.service.justice.gov.uk"
+}

--- a/terraform/environment/modules/environment/modules/mock_onelogin/dns.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/dns.tf
@@ -2,7 +2,7 @@ resource "aws_route53_record" "mock_onelogin" {
   count    = data.aws_default_tags.current.tags.environment-name != "production" ? 1 : 0
   provider = aws.management
   zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  name     = "${data.aws_default_tags.current.tags.environment-name}${var.account_name}.onelogin.lpa"
+  name     = "${data.aws_default_tags.current.tags.environment-name}.${var.account_name}.onelogin.lpa"
   type     = "A"
 
   alias {

--- a/terraform/environment/modules/environment/modules/mock_onelogin/dns.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/dns.tf
@@ -1,0 +1,17 @@
+resource "aws_route53_record" "mock_onelogin" {
+  count    = data.aws_default_tags.current.tags.environment-name != "production" ? 1 : 0
+  provider = aws.management
+  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  name     = "${data.aws_default_tags.current.tags.environment-name}${var.account_name}.onelogin.lpa"
+  type     = "A"
+
+  alias {
+    evaluate_target_health = false
+    name                   = aws_lb.mock_onelogin.dns_name
+    zone_id                = aws_lb.mock_onelogin.zone_id
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
@@ -92,7 +92,7 @@ resource "aws_security_group_rule" "mock_one_login_service_app_ingress" {
   to_port                  = var.container_port
   protocol                 = "tcp"
   security_group_id        = aws_security_group.mock_onelogin_ecs_service.id
-  source_security_group_id = var.app_ecs_service_security_group_id
+  source_security_group_id = var.front_app_ecs_service_security_group_id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
@@ -1,0 +1,227 @@
+resource "aws_ecs_service" "mock_onelogin" {
+  name                  = "mock_onelogin"
+  cluster               = var.ecs_cluster
+  task_definition       = aws_ecs_task_definition.mock_onelogin.arn
+  desired_count         = var.ecs_service_desired_count
+  platform_version      = "1.4.0"
+  wait_for_steady_state = true
+  propagate_tags        = "SERVICE"
+
+  capacity_provider_strategy {
+    capacity_provider = var.ecs_capacity_provider
+    weight            = 100
+  }
+
+  network_configuration {
+    security_groups  = [aws_security_group.mock_onelogin_ecs_service.id]
+    subnets          = var.network.application_subnets
+    assign_public_ip = false
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.mock_onelogin.arn
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.mock_onelogin.arn
+    container_name   = "mock_onelogin"
+    container_port   = var.container_port
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  timeouts {
+    create = "7m"
+    update = "4m"
+  }
+  provider = aws.region
+}
+
+resource "aws_service_discovery_service" "mock_onelogin" {
+  name = "mock-onelogin"
+
+  dns_config {
+    namespace_id = var.aws_service_discovery_private_dns_namespace.id
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  provider = aws.region
+}
+
+locals {
+  mock_onelogin_service_discovery_fqdn = "${aws_service_discovery_service.mock_onelogin.name}.${var.aws_service_discovery_private_dns_namespace.name}"
+}
+
+resource "aws_security_group" "mock_onelogin_ecs_service" {
+  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-ecs-service"
+  description = "mock-onelogin service security group"
+  vpc_id      = var.network.vpc_id
+  lifecycle {
+    create_before_destroy = true
+  }
+  provider = aws.region
+}
+
+resource "aws_security_group_rule" "mock_onelogin_ecs_service_ingress" {
+  description              = "Allow Port 80 ingress from the mock-onelogin load balancer"
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = var.container_port
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.mock_onelogin_ecs_service.id
+  source_security_group_id = aws_security_group.mock_onelogin_loadbalancer.id
+  lifecycle {
+    create_before_destroy = true
+  }
+  provider = aws.region
+}
+
+
+resource "aws_security_group_rule" "mock_one_login_service_app_ingress" {
+  description              = "Allow Port 8080 ingress from the app ecs service"
+  type                     = "ingress"
+  from_port                = var.container_port
+  to_port                  = var.container_port
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.mock_onelogin_ecs_service.id
+  source_security_group_id = var.app_ecs_service_security_group_id
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  provider = aws.region
+}
+
+resource "aws_security_group_rule" "mock_onelogin_ecs_service_egress" {
+  description       = "Allow any egress from service"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:aws-ec2-no-public-egress-sgr - open egress for ECR access
+  security_group_id = aws_security_group.mock_onelogin_ecs_service.id
+  lifecycle {
+    create_before_destroy = true
+  }
+  provider = aws.region
+}
+
+resource "aws_ecs_task_definition" "mock_onelogin" {
+  family                   = "${data.aws_default_tags.current.tags.environment-name}-mock-onelogin"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  container_definitions    = "[${local.mock_onelogin}]"
+  task_role_arn            = var.ecs_task_role.arn
+  execution_role_arn       = var.ecs_execution_role.arn
+  provider                 = aws.region
+}
+
+resource "aws_iam_role_policy" "mock_onelogin_task_role" {
+  name     = "${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.region}-mock-onelogin-task-role"
+  policy   = data.aws_iam_policy_document.task_role_access_policy.json
+  role     = var.ecs_task_role.name
+  provider = aws.region
+}
+
+data "aws_secretsmanager_secret" "gov_one_login_mrlpa_client_id" {
+  name     = "gov-one-login-mrlpa-client-id"
+  provider = aws.region
+}
+
+data "aws_iam_policy_document" "task_role_access_policy" {
+  policy_id = "${local.policy_region_prefix}task_role_access_policy"
+  statement {
+    sid    = "${local.policy_region_prefix}EcsSecretAccess"
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+    ]
+
+    resources = [
+      data.aws_secretsmanager_secret.gov_one_login_mrlpa_client_id.arn,
+    ]
+  }
+}
+
+locals {
+  # TODO: fix this url
+  mock_onelogin_url = "https://${data.aws_default_tags.current.tags.environment-name}-mock-onelogin.app.modernising.opg.service.justice.gov.uk"
+
+  mock_onelogin = jsonencode(
+    {
+      cpu                    = 1,
+      essential              = true,
+      image                  = "${var.repository_url}@${var.image_digest}",
+      mountPoints            = [],
+      readonlyRootFilesystem = true
+      name                   = "mock_onelogin",
+      portMappings = [
+        {
+          containerPort = var.container_port,
+          hostPort      = var.container_port,
+          protocol      = "tcp"
+        }
+      ],
+      volumesFrom    = [],
+      systemControls = [],
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          awslogs-group         = var.ecs_application_log_group_name,
+          awslogs-region        = data.aws_region.current.region,
+          awslogs-stream-prefix = data.aws_default_tags.current.tags.environment-name
+          mode                  = "non-blocking"
+          max-buffer-size       = "25m"
+        }
+      },
+      secrets = [
+        {
+          name      = "CLIENT_ID",
+          valueFrom = data.aws_secretsmanager_secret.gov_one_login_mrlpa_client_id.arn
+        }
+      ],
+      environment = [
+        {
+          name  = "PORT",
+          value = tostring(var.container_port)
+        },
+        {
+          name  = "PUBLIC_URL",
+          value = local.mock_onelogin_url
+        },
+        {
+          name  = "INTERNAL_URL",
+          value = "http://${local.mock_onelogin_service_discovery_fqdn}:${var.container_port}"
+        },
+        {
+          name  = "REDIRECT_URL",
+          value = "${var.redirect_base_url}/auth/redirect"
+        },
+        {
+          name  = "TEMPLATE_SUB",
+          value = var.template_sub
+        },
+        {
+          name  = "TEMPLATE_RETURN_CODES",
+          value = "1"
+        },
+        {
+          name  = "TEMPLATE_SUB_DEFAULT",
+          value = "random"
+        }
+      ]
+    }
+  )
+}

--- a/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
@@ -134,7 +134,7 @@ resource "aws_iam_role_policy" "mock_onelogin_task_role" {
 }
 
 data "aws_secretsmanager_secret" "gov_one_login_mrlpa_client_id" {
-  name     = "gov-one-login-mrlpa-client-id"
+  name     = "${var.account_name}/mock-onelogin-client-id"
   provider = aws.region
 }
 

--- a/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
@@ -157,7 +157,7 @@ data "aws_iam_policy_document" "task_role_access_policy" {
 
 locals {
   # TODO: fix this url
-  mock_onelogin_url = "https://${data.aws_default_tags.current.tags.environment-name}-mock-onelogin.app.modernising.opg.service.justice.gov.uk"
+  mock_onelogin_url = "https://${data.aws_default_tags.current.tags.environment-name}.${var.account_name}.onelogin.lpa.opg.service.justice.gov.uk"
 
   mock_onelogin = jsonencode(
     {

--- a/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
@@ -133,7 +133,7 @@ resource "aws_iam_role_policy" "mock_onelogin_task_role" {
   provider = aws.region
 }
 
-data "aws_secretsmanager_secret" "gov_one_login_mrlpa_client_id" {
+data "aws_secretsmanager_secret" "mock_onelogin_client_id" {
   name     = "${var.account_name}/mock-onelogin-client-id"
   provider = aws.region
 }
@@ -150,7 +150,7 @@ data "aws_iam_policy_document" "task_role_access_policy" {
     ]
 
     resources = [
-      data.aws_secretsmanager_secret.gov_one_login_mrlpa_client_id.arn,
+      data.aws_secretsmanager_secret.mock_onelogin_client_id.arn,
     ]
   }
 }
@@ -189,7 +189,7 @@ locals {
       secrets = [
         {
           name      = "CLIENT_ID",
-          valueFrom = data.aws_secretsmanager_secret.gov_one_login_mrlpa_client_id.arn
+          valueFrom = data.aws_secretsmanager_secret.mock_onelogin_client_id.arn
         }
       ],
       environment = [

--- a/terraform/environment/modules/environment/modules/mock_onelogin/outputs.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/outputs.tf
@@ -1,0 +1,11 @@
+output "load_balancer" {
+  value = aws_lb.mock_onelogin
+}
+
+output "load_balancer_security_group" {
+  value = aws_security_group.mock_onelogin_loadbalancer
+}
+
+output "ecs_service" {
+  value = aws_ecs_service.mock_onelogin
+}

--- a/terraform/environment/modules/environment/modules/mock_onelogin/variables.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/variables.tf
@@ -88,7 +88,7 @@ variable "aws_service_discovery_private_dns_namespace" {
   description = "ID and name of the AWS Service Discovery private DNS namespace"
 }
 
-variable "app_ecs_service_security_group_id" {
+variable "front_app_ecs_service_security_group_id" {
   type        = string
   description = "ID of the security group for the app ECS service"
 }

--- a/terraform/environment/modules/environment/modules/mock_onelogin/variables.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/variables.tf
@@ -1,0 +1,105 @@
+locals {
+  policy_region_prefix = lower(replace(data.aws_region.current.region, "-", ""))
+}
+
+variable "ecs_execution_role" {
+  type = object({
+    id  = string
+    arn = string
+  })
+  description = "ID and ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume."
+}
+
+variable "ecs_task_role" {
+  type        = any
+  description = "ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services."
+}
+
+variable "ecs_cluster" {
+  type        = string
+  description = "ARN of an ECS cluster."
+}
+
+variable "ecs_service_desired_count" {
+  type        = number
+  default     = 0
+  description = "Number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the DAEMON scheduling strategy."
+}
+
+variable "network" {
+  type = object({
+    vpc_id              = string
+    application_subnets = list(string)
+    public_subnets      = list(string)
+  })
+  description = "VPC ID, a list of application subnets, and a list of private subnets required to provision the ECS service"
+}
+
+variable "ecs_capacity_provider" {
+  type        = string
+  description = "Name of the capacity provider to use. Valid values are FARGATE_SPOT and FARGATE"
+}
+
+variable "ecs_application_log_group_name" {
+  type        = string
+  description = "The AWS Cloudwatch Log Group resource for application logging"
+}
+
+variable "repository_url" {
+  type        = string
+  description = "URL of the repository for the container to use"
+}
+
+variable "image_digest" {
+  type        = string
+  description = "Digest of the container to use"
+}
+
+variable "ingress_allow_list_cidr" {
+  type        = list(string)
+  description = "List of CIDR ranges permitted to access the service"
+}
+
+variable "alb_deletion_protection_enabled" {
+  type        = bool
+  description = "If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false."
+}
+
+variable "container_port" {
+  type        = number
+  description = "Port on the container to associate with."
+}
+
+variable "public_access_enabled" {
+  type        = bool
+  description = "Enable access to the Modernising LPA service from the public internet"
+}
+
+variable "redirect_base_url" {
+  type        = string
+  description = "Base URL expected for redirect_url"
+}
+
+variable "aws_service_discovery_private_dns_namespace" {
+  type = object({
+    id   = string
+    name = string
+  })
+  description = "ID and name of the AWS Service Discovery private DNS namespace"
+}
+
+variable "app_ecs_service_security_group_id" {
+  type        = string
+  description = "ID of the security group for the app ECS service"
+}
+
+variable "waf_alb_association_enabled" {
+  type        = bool
+  description = "Enable WAF association with the ALB"
+  default     = true
+}
+
+variable "template_sub" {
+  type        = string
+  description = "Value for TEMPLATE_SUB"
+}

--- a/terraform/environment/modules/environment/modules/mock_onelogin/variables.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/variables.tf
@@ -103,3 +103,7 @@ variable "template_sub" {
   type        = string
   description = "Value for TEMPLATE_SUB"
 }
+
+variable "account_name" {
+  type = string
+}

--- a/terraform/environment/modules/environment/modules/mock_onelogin/versions.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/versions.tf
@@ -1,9 +1,13 @@
 terraform {
+  required_version = ">= 1.5.2"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 6.28.0"
+      configuration_aliases = [
+        aws.region,
+      ]
     }
   }
-  required_version = "1.14.3"
 }

--- a/terraform/environment/modules/environment/modules/mock_onelogin/versions.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/versions.tf
@@ -7,6 +7,7 @@ terraform {
       version = ">= 6.28.0"
       configuration_aliases = [
         aws.region,
+        aws.management,
       ]
     }
   }

--- a/terraform/environment/modules/environment/modules/mock_onelogin/waf.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/waf.tf
@@ -1,6 +1,6 @@
 data "aws_wafv2_web_acl" "main" {
   provider = aws.region
-  name     = "${data.aws_default_tags.current.tags.account-name}-web-acl"
+  name     = "${var.account_name}-${data.aws_region.current.region}-web-acl"
   scope    = "REGIONAL"
 }
 

--- a/terraform/environment/modules/environment/modules/mock_onelogin/waf.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/waf.tf
@@ -1,0 +1,12 @@
+data "aws_wafv2_web_acl" "main" {
+  provider = aws.region
+  name     = "${data.aws_default_tags.current.tags.account-name}-web-acl"
+  scope    = "REGIONAL"
+}
+
+resource "aws_wafv2_web_acl_association" "app" {
+  count        = var.waf_alb_association_enabled ? 1 : 0
+  provider     = aws.region
+  resource_arn = aws_lb.mock_onelogin.arn
+  web_acl_arn  = data.aws_wafv2_web_acl.main.arn
+}

--- a/terraform/environment/modules/environment/modules/rds_proxy/versions.tf
+++ b/terraform/environment/modules/environment/modules/rds_proxy/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.28.0"
+      version = ">= 6.28.0"
     }
   }
   required_version = "1.14.3"

--- a/terraform/environment/modules/environment/outputs.tf
+++ b/terraform/environment/modules/environment/outputs.tf
@@ -50,3 +50,7 @@ output "vpc_id" {
 output "app_subnet_ids" {
   value = [for subnet in data.aws_subnet.application : subnet.id]
 }
+
+output "mock_onelogin_loadbalancer" {
+  value = module.mock_onelogin[0].load_balancer
+}

--- a/terraform/environment/modules/environment/outputs.tf
+++ b/terraform/environment/modules/environment/outputs.tf
@@ -52,5 +52,5 @@ output "app_subnet_ids" {
 }
 
 output "mock_onelogin_loadbalancer" {
-  value = module.mock_onelogin[0].load_balancer
+  value = var.environment.feature_flags.onelogin_enabled ? module.mock_onelogin[0].load_balancer : null
 }

--- a/terraform/environment/modules/environment/secrets.tf
+++ b/terraform/environment/modules/environment/secrets.tf
@@ -92,6 +92,6 @@ data "aws_secretsmanager_secret" "elasticache_auth_token" {
   name = "${var.account_name}/elasticache_auth_token"
 }
 
-data "aws_secretsmanager_secret" "gov_one_login_mrlpa_client_id" {
+data "aws_secretsmanager_secret" "mock_onelogin_client_id" {
   name = "${var.account_name}/mock-onelogin-client-id"
 }

--- a/terraform/environment/modules/environment/secrets.tf
+++ b/terraform/environment/modules/environment/secrets.tf
@@ -91,3 +91,7 @@ resource "aws_secretsmanager_secret_version" "api_rds_credentials" {
 data "aws_secretsmanager_secret" "elasticache_auth_token" {
   name = "${var.account_name}/elasticache_auth_token"
 }
+
+data "aws_secretsmanager_secret" "gov_one_login_mrlpa_client_id" {
+  name = "${var.account_name}/mock-onelogin-client-id"
+}

--- a/terraform/environment/modules/environment/variables.tf
+++ b/terraform/environment/modules/environment/variables.tf
@@ -104,6 +104,11 @@ variable "ecs_iam_task_roles" {
       arn  = string
       id   = string
     })
+    mock_onelogin = object({
+      name = string
+      arn  = string
+      id   = string
+    })
     cloudwatch_events = object({
       name = string
       arn  = string
@@ -117,6 +122,7 @@ variable "ecs_execution_role" {
   type = object({
     name = string
     arn  = string
+    id   = string
   })
   description = "The ARN of the ECS execution role"
 }

--- a/terraform/environment/modules/environment/versions.tf
+++ b/terraform/environment/modules/environment/versions.tf
@@ -5,7 +5,7 @@ terraform {
       configuration_aliases = [
         aws.management
       ]
-      version = "6.28.0"
+      version = ">= 6.28.0"
     }
     pagerduty = {
       source  = "PagerDuty/pagerduty"

--- a/terraform/environment/modules/rds_cross_region_backup/versions.tf
+++ b/terraform/environment/modules/rds_cross_region_backup/versions.tf
@@ -7,7 +7,7 @@ terraform {
         aws.backup,
         aws.destination,
       ]
-      version = "6.28.0"
+      version = "6.52.0"
     }
     pagerduty = {
       source  = "PagerDuty/pagerduty"

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -25,7 +25,7 @@
         ]
       },
       "feature_flags": {
-        "onelogin_enabled": false,
+        "onelogin_enabled": true,
         "organisations_enabled": false
       },
       "shared_secret_enabled": true,

--- a/terraform/environment/versions.tf
+++ b/terraform/environment/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.28.0"
+      version = "6.52.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/terraform/region/secrets.tf
+++ b/terraform/region/secrets.tf
@@ -188,7 +188,6 @@ resource "aws_secretsmanager_secret" "elasticache_auth_token" {
 }
 
 resource "aws_secretsmanager_secret" "mock_onelogin_client_id" {
-  count                          = local.account_name != "production" ? 1 : 0
   name                           = "${local.account_name}/mock-onelogin-client-id"
   tags                           = local.front_component_tag
   kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn

--- a/terraform/region/secrets.tf
+++ b/terraform/region/secrets.tf
@@ -188,6 +188,7 @@ resource "aws_secretsmanager_secret" "elasticache_auth_token" {
 }
 
 resource "aws_secretsmanager_secret" "mock_onelogin_client_id" {
+  count                          = local.account_name != "production" ? 1 : 0
   name                           = "${local.account_name}/mock-onelogin-client-id"
   tags                           = local.front_component_tag
   kms_key_id                     = module.secrets_manager_encryption_key.primary_key.arn


### PR DESCRIPTION
## Purpose

Provide a mock onelogin service to develop and test against

Fixes LPAL-2309

## Approach

- update module version constraints to specify minimum version 
- add a module for a mock gov.uk onelogin service
- provide front_app with a mock client id secret environment variable
- add a mock-onelogin service to docker compose for local development

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
