### PR TITLE
LPAL-2247 specify symfony/yaml explicitly in require-dev

### DIFF
--- a/service-front/composer.json
+++ b/service-front/composer.json
@@ -85,6 +85,7 @@
         "phpunit/phpunit": "^11.5.42",
         "psalm/plugin-phpunit": "^0.19.5",
         "roave/security-advisories": "dev-master",
+        "symfony/yaml": "^8.0",
         "vimeo/psalm": "^6.13.1"
     },
     "conflict": {

--- a/service-front/docker/app/.snyk
+++ b/service-front/docker/app/.snyk
@@ -2,14 +2,4 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-PHP-SYMFONYYAML-16797942:
-    - '*':
-        reason: >
-          symfony/yaml vulnerability exists only in the nested tools/behat/composer.lock
-          inside the psalm/plugin-phpunit vendor package. This is dev tooling used by the
-          psalm plugin maintainers, not a runtime or test dependency of this project.
-          psalm/plugin-phpunit 0.20.x (which ships the fix) requires vimeo/psalm ^7,
-          incompatible with our current vimeo/psalm ^6. Will be resolved when upgrading psalm.
-        expires: 2026-08-11T00:00:00.000Z
-        created: 2026-06-11T00:00:00.000Z
 patch: {}

--- a/service-front/docker/app/.snyk
+++ b/service-front/docker/app/.snyk
@@ -2,4 +2,14 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+  SNYK-PHP-SYMFONYYAML-16797942:
+    - '*':
+        reason: >
+          symfony/yaml vulnerability exists only in the nested tools/behat/composer.lock
+          inside the psalm/plugin-phpunit vendor package. This is dev tooling used by the
+          psalm plugin maintainers, not a runtime or test dependency of this project.
+          psalm/plugin-phpunit 0.20.x (which ships the fix) requires vimeo/psalm ^7,
+          incompatible with our current vimeo/psalm ^6. Will be resolved when upgrading psalm.
+        expires: 2026-08-11T00:00:00.000Z
+        created: 2026-06-11T00:00:00.000Z
 patch: {}


### PR DESCRIPTION
## Purpose

_Dissuade snyk from flagging vulnerability that would never actually get pulled in_

## Approach

Snyk flagged a vuln from symfony/yaml potentially being pulled in at an old, unsafe version via:

1. service-front/composer.json requires aws/aws-sdk-php: ^3.xxx.x (recent version)
2. aws/aws-sdk-php lists behat/behat: ~3.0 in its own require-dev
3. behat/behat v3.0.x requires symfony/yaml: ~2.1 (i.e. `>=2.1 <3.0`) — range containing known vulnerabilities

Snyk analysis includes require-dev, so it thinks a vulnerable 2.x version of symfony/yaml could get pulled in

behat/behat is not actually installed in service-front — Composer does not install the dev dependencies of dependencies. The installed version  of symfony/yaml is already safe (v8.1.1), enforced by the existing symfony/yaml: ^8.0 constraint in require. However, Snyk analyses dev and non-dev separately and was not satisfied by the require constraint alone.

Fixed by adding symfony/yaml: "^8.0" to the require-dev section of service-front/composer.json. This makes the safe version constraint visible in both the dev and non-dev that Snyk analyses, so it doesn't resolve to a vulnerable version in either.

Unfortunately we can't yet remove the snyk ignore as psalm has a similar issue, and no version of psalm fixes this yet

