### PR TITLE
LPAL-2309 - remove count from dns record now its in the module

### DIFF
--- a/terraform/environment/modules/environment/modules/mock_onelogin/dns.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/dns.tf
@@ -1,5 +1,4 @@
 resource "aws_route53_record" "mock_onelogin" {
-  count    = data.aws_default_tags.current.tags.environment-name != "production" ? 1 : 0
   provider = aws.management
   zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
   name     = "${data.aws_default_tags.current.tags.environment-name}.${var.account_name}.onelogin.lpa"

--- a/terraform/environment/modules/environment/rds_proxy.tf
+++ b/terraform/environment/modules/environment/rds_proxy.tf
@@ -2,7 +2,7 @@ module "rds_proxy" {
   source                         = "./modules/rds_proxy"
   environment_name               = var.environment_name
   db_cluster_identifier          = module.api_aurora[0].cluster.id
-  api_rds_credentials_secret_arn = aws_secretsmanager_secret_version.api_rds_credentials.arn
+  api_rds_credentials_secret_arn = aws_secretsmanager_secret_version.api_rds_credentials.secret_arn
   vpc_id                         = data.aws_vpc.main.id
   vpc_subnet_ids                 = [for subnet in data.aws_subnet.data : subnet.id]
   rds_client_security_group_id   = aws_security_group.rds_client.id


### PR DESCRIPTION
## Purpose

Updating an existing environment to have the mock onelogin caused an error related to a count on the dns record resource

Fixes LPAL-2309

## Approach

- remove count from dns record (there is a count on the entire module)