### PR TITLE
LPAL-2217 | ECS Task Definitions - specify non root user

### DIFF
--- a/terraform/environment/modules/environment/ecs_admin.tf
+++ b/terraform/environment/modules/environment/ecs_admin.tf
@@ -158,6 +158,8 @@ locals {
         }
       ],
       volumesFrom = [],
+      privileged  = false,
+      user        = "appuser",
       logConfiguration = {
         logDriver = "awslogs",
         options = {
@@ -206,7 +208,7 @@ locals {
       },
       volumesFrom = [],
       privileged  = false,
-      user        = "app-user",
+      user        = "appuser",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_admin.tf
+++ b/terraform/environment/modules/environment/ecs_admin.tf
@@ -205,6 +205,8 @@ locals {
         retries     = 3
       },
       volumesFrom = [],
+      privileged  = false,
+      user        = "app-user",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_admin.tf
+++ b/terraform/environment/modules/environment/ecs_admin.tf
@@ -159,7 +159,7 @@ locals {
       ],
       volumesFrom = [],
       privileged  = false,
-      user        = "appuser",
+      user        = "nginx",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -215,6 +215,8 @@ locals {
         condition     = "HEALTHY"
       }],
       volumesFrom = [],
+      privileged  = false,
+      user        = "appuser",
       logConfiguration = {
         logDriver = "awslogs",
         options = {
@@ -265,7 +267,7 @@ locals {
       command     = ["php-fpm"]
       volumesFrom = [],
       privileged  = false,
-      user        = "app-user",
+      user        = "appuser",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -216,7 +216,7 @@ locals {
       }],
       volumesFrom = [],
       privileged  = false,
-      user        = "appuser",
+      user        = "nginx",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -264,6 +264,8 @@ locals {
       },
       command     = ["php-fpm"]
       volumesFrom = [],
+      privileged  = false,
+      user        = "app-user",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_api_migrations.tf
+++ b/terraform/environment/modules/environment/ecs_api_migrations.tf
@@ -78,6 +78,8 @@ locals {
       },
       command     = ["/bin/sh", "-c", "/usr/local/bin/db-migrations.sh"]
       volumesFrom = [],
+      privileged  = false,
+      user        = "aoc",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_api_migrations.tf
+++ b/terraform/environment/modules/environment/ecs_api_migrations.tf
@@ -79,7 +79,6 @@ locals {
       command     = ["/bin/sh", "-c", "/usr/local/bin/db-migrations.sh"]
       volumesFrom = [],
       privileged  = false,
-      user        = "aoc",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -276,3 +276,6 @@ locals {
     }
   )
 }
+
+
+# testing with new changes rebased from main - non root user dockerfile changes

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -276,6 +276,3 @@ locals {
     }
   )
 }
-
-
-# testing with new changes rebased from main - non root user dockerfile changes

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -220,6 +220,8 @@ locals {
         retries     = 3
       },
       volumesFrom = [],
+      privileged  = false,
+      user        = "app-user",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -171,6 +171,8 @@ locals {
       }
     ]
     volumesFrom = [],
+    privileged  = false,
+    user        = "appuser",
     logConfiguration = {
       logDriver = "awslogs",
       options = {
@@ -221,7 +223,7 @@ locals {
       },
       volumesFrom = [],
       privileged  = false,
-      user        = "app-user",
+      user        = "appuser",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -172,7 +172,7 @@ locals {
     ]
     volumesFrom = [],
     privileged  = false,
-    user        = "appuser",
+    user        = "nginx",
     logConfiguration = {
       logDriver = "awslogs",
       options = {

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -120,6 +120,8 @@ locals {
         }
       ],
       volumesFrom = [],
+      privileged  = false,
+      user        = "app-user",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_pdf.tf
+++ b/terraform/environment/modules/environment/ecs_pdf.tf
@@ -121,7 +121,7 @@ locals {
       ],
       volumesFrom = [],
       privileged  = false,
-      user        = "app-user",
+      user        = "appuser",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_seeding.tf
+++ b/terraform/environment/modules/environment/ecs_seeding.tf
@@ -70,6 +70,8 @@ locals {
         }
       ],
       volumesFrom = [],
+      privileged  = false,
+      user        = "aoc",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_seeding.tf
+++ b/terraform/environment/modules/environment/ecs_seeding.tf
@@ -71,7 +71,6 @@ locals {
       ],
       volumesFrom = [],
       privileged  = false,
-      user        = "aoc",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/locals.tf
+++ b/terraform/environment/modules/environment/locals.tf
@@ -63,8 +63,6 @@ locals {
         retries     = 3
       },
       volumesFrom = [],
-      privileged  = false,
-      user        = "aoc",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/locals.tf
+++ b/terraform/environment/modules/environment/locals.tf
@@ -63,6 +63,8 @@ locals {
         retries     = 3
       },
       volumesFrom = [],
+      privileged  = false,
+      user        = "aoc",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
@@ -176,6 +176,8 @@ locals {
       ],
       volumesFrom    = [],
       systemControls = [],
+      privileged     = false,
+      user           = "aoc",
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
@@ -177,7 +177,7 @@ locals {
       volumesFrom    = [],
       systemControls = [],
       privileged     = false,
-      user           = "aoc",
+      user           = "app",
       logConfiguration = {
         logDriver = "awslogs",
         options = {


### PR DESCRIPTION
Set privileged = false and user = app to all task definitions to stop them running as root users


Fixes LPAL-2217

## Approach

```
privileged  = false,
user        = "appuser",
  
```

```
privileged  = false,
user        = "nginx",
```

```
privileged  = false,
user        = "app",
```


This can also be set in docker-compose files

## Learning

https://medium.com/@mughal.asim/kubernetes-security-contexts-series-part-3-running-containers-as-non-root-0b7ebd54636c

https://github.com/ministryofjustice/opg-mock-onelogin/blob/260df45440bd0d2a6f3a7d405a968d7991e109a0/Dockerfile#L25