### PR TITLE
LPAL-2088 use data-cy lozenge status instead of direct access to class from cypress

### DIFF
--- a/cypress/e2e/common/statuses.js
+++ b/cypress/e2e/common/statuses.js
@@ -8,10 +8,10 @@ Then(
     // of the statuses for LPAs happening in client-side JS.
     expectedStatus = expectedStatus.toLowerCase();
     const selector =
-      '.opg-lozenge-status--' +
-      expectedStatus +
-      '[data-cy=lpa-status-lozenge-' +
+      'li[data-cy=lpa-' +
       lpaId +
+      '] [data-cy=opg-lozenge-status-' +
+      expectedStatus +
       '][data-refreshed=true]';
 
     cy.get(selector).then((elt) => {

--- a/service-front/assets/js/opg/dashboard-statuses.js
+++ b/service-front/assets/js/opg/dashboard-statuses.js
@@ -33,6 +33,7 @@ $(document).ready(function () {
 
             statusIndicator.removeClass('opg-lozenge-status--' + currentStatus);
             statusIndicator.addClass('opg-lozenge-status--' + newStatus);
+            statusIndicator.attr('data-cy', 'opg-lozenge-status-' + newStatus);
 
             // Update style on status container
             li.removeClass('status-container--' + currentStatus);

--- a/service-front/src/App/templates/application/authenticated/dashboard/macros.twig
+++ b/service-front/src/App/templates/application/authenticated/dashboard/macros.twig
@@ -27,7 +27,7 @@
 
                     <div class="list-item_status">
                         <p class="opg-application-status-text govuk-visually-hidden">Application status for A{{ lpa.id }} - {{status}}</p>
-                        <div data-cy="lpa-status-lozenge-{{ lpa.id }}" class="opg-status opg-lozenge-status--{{ status }}">{{ lpa.progress }}</div>
+                        <div data-cy="opg-lozenge-status-{{ status }}" class="opg-status opg-lozenge-status--{{ status }}">{{ lpa.progress }}</div>
                         <br/>
 
                         {{ macros.showStatusDescriptionLinksIfEnabled(trackingEnabled, status, lpa.id) }}


### PR DESCRIPTION
cypress

## Purpose

_Tidy up of cypress tests that was earlier indentified as needing doing_

## Approach

_Where the class is set, also set data-cy tags in the same way. Access from cypress with these tags_
