### PR TITLE
LPAL- 2199 | ENV changes - updating ecs-task role permissions with pdf sqs and pdf cache s3 encryption keys

### DIFF
--- a/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
+++ b/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
@@ -101,6 +101,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
     resources = [
       data.aws_kms_key.lpa_pdf_sqs.arn,
+      data.aws_kms_alias.pdf_sqs_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
   }
@@ -343,6 +344,7 @@ data "aws_iam_policy_document" "pdf_permissions_role" {
     ]
     resources = [
       data.aws_kms_key.lpa_pdf_sqs.arn,
+      data.aws_kms_alias.pdf_sqs_encryption_key.target_key_arn,
     ]
   }
   statement {

--- a/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
+++ b/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
@@ -86,6 +86,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
       data.aws_kms_key.lpa_pdf_cache.arn,
+      data.aws_kms_alias.pdf_cache_s3_encryption_key.target_key_arn,
       data.aws_kms_alias.elasticache_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
 
@@ -235,6 +236,7 @@ data "aws_iam_policy_document" "front_permissions_role" {
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
       data.aws_kms_key.lpa_pdf_cache.arn,
+      data.aws_kms_alias.pdf_cache_s3_encryption_key.target_key_arn,
       data.aws_kms_alias.elasticache_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
@@ -327,6 +329,7 @@ data "aws_iam_policy_document" "pdf_permissions_role" {
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
       data.aws_kms_key.lpa_pdf_cache.arn,
+      data.aws_kms_alias.pdf_cache_s3_encryption_key.target_key_arn,
       data.aws_kms_alias.elasticache_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]

--- a/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
+++ b/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
@@ -99,7 +99,6 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "kms:GenerateDataKey",
     ]
     resources = [
-      data.aws_kms_key.lpa_pdf_sqs.arn,
       data.aws_kms_alias.pdf_sqs_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
@@ -340,7 +339,6 @@ data "aws_iam_policy_document" "pdf_permissions_role" {
       "kms:GenerateDataKey",
     ]
     resources = [
-      data.aws_kms_key.lpa_pdf_sqs.arn,
       data.aws_kms_alias.pdf_sqs_encryption_key.target_key_arn,
     ]
   }

--- a/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
+++ b/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
@@ -85,7 +85,6 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
-      data.aws_kms_key.lpa_pdf_cache.arn,
       data.aws_kms_alias.pdf_cache_s3_encryption_key.target_key_arn,
       data.aws_kms_alias.elasticache_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
@@ -236,7 +235,6 @@ data "aws_iam_policy_document" "front_permissions_role" {
     ]
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
-      data.aws_kms_key.lpa_pdf_cache.arn,
       data.aws_kms_alias.pdf_cache_s3_encryption_key.target_key_arn,
       data.aws_kms_alias.elasticache_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
@@ -329,7 +327,6 @@ data "aws_iam_policy_document" "pdf_permissions_role" {
     ]
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
-      data.aws_kms_key.lpa_pdf_cache.arn,
       data.aws_kms_alias.pdf_cache_s3_encryption_key.target_key_arn,
       data.aws_kms_alias.elasticache_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,

--- a/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
+++ b/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
@@ -85,6 +85,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
+      data.aws_kms_key.lpa_pdf_cache.arn,
       data.aws_kms_alias.pdf_cache_s3_encryption_key.target_key_arn,
       data.aws_kms_alias.elasticache_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
@@ -99,6 +100,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "kms:GenerateDataKey",
     ]
     resources = [
+      data.aws_kms_key.lpa_pdf_sqs.arn,
       data.aws_kms_alias.pdf_sqs_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
@@ -234,6 +236,7 @@ data "aws_iam_policy_document" "front_permissions_role" {
     ]
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
+      data.aws_kms_key.lpa_pdf_cache.arn,
       data.aws_kms_alias.pdf_cache_s3_encryption_key.target_key_arn,
       data.aws_kms_alias.elasticache_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
@@ -326,6 +329,7 @@ data "aws_iam_policy_document" "pdf_permissions_role" {
     ]
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
+      data.aws_kms_key.lpa_pdf_cache.arn,
       data.aws_kms_alias.pdf_cache_s3_encryption_key.target_key_arn,
       data.aws_kms_alias.elasticache_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
@@ -339,6 +343,7 @@ data "aws_iam_policy_document" "pdf_permissions_role" {
       "kms:GenerateDataKey",
     ]
     resources = [
+      data.aws_kms_key.lpa_pdf_sqs.arn,
       data.aws_kms_alias.pdf_sqs_encryption_key.target_key_arn,
     ]
   }

--- a/terraform/environment/modules/environment/shared_data_sources.tf
+++ b/terraform/environment/modules/environment/shared_data_sources.tf
@@ -25,10 +25,6 @@ data "aws_kms_key" "lpa_pdf_cache" {
   key_id = "alias/lpa_pdf_cache-${var.account_name}"
 }
 
-data "aws_kms_alias" "pdf_cache_s3_encryption_key" {
-  name = "alias/opg-lpa-${var.account_name}-pdf-cache-s3-encryption-key"
-}
-
 data "aws_acm_certificate" "certificate_front" {
   domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}front.lpa.opg.service.justice.gov.uk"
 }
@@ -74,3 +70,15 @@ data "aws_kms_alias" "dynamodb_encryption_key" {
 data "aws_kms_alias" "elasticache_encryption_key" {
   name = "alias/opg-lpa-${var.account_name}-elasticache-encryption-key"
 }
+
+data "aws_kms_alias" "pdf_cache_s3_encryption_key" {
+  name = "alias/opg-lpa-${var.account_name}-pdf-cache-s3-encryption-key"
+}
+
+data "aws_kms_alias" "pdf_sqs_encryption_key" {
+  name = "alias/opg-lpa-${var.account_name}-pdf-sqs-encryption-key"
+}
+
+# data "aws_kms_alias" "redacted_logs_s3_encryption_key" {
+#   name = "alias/opg-lpa-${var.account_name}-redacted-logs-s3-encryption-key"
+# }

--- a/terraform/environment/modules/environment/shared_data_sources.tf
+++ b/terraform/environment/modules/environment/shared_data_sources.tf
@@ -21,9 +21,6 @@ data "aws_s3_bucket" "lpa_pdf_cache" {
   bucket = lower("online-lpa-pdf-cache-${var.account_name}-${var.region_name}")
 }
 
-data "aws_kms_key" "lpa_pdf_cache" {
-  key_id = "alias/lpa_pdf_cache-${var.account_name}"
-}
 
 data "aws_acm_certificate" "certificate_front" {
   domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}front.lpa.opg.service.justice.gov.uk"

--- a/terraform/environment/modules/environment/shared_data_sources.tf
+++ b/terraform/environment/modules/environment/shared_data_sources.tf
@@ -25,6 +25,10 @@ data "aws_kms_key" "lpa_pdf_cache" {
   key_id = "alias/lpa_pdf_cache-${var.account_name}"
 }
 
+data "aws_kms_alias" "pdf_cache_s3_encryption_key" {
+  name = "alias/opg-lpa-${var.account_name}-pdf-cache-s3-encryption-key"
+}
+
 data "aws_acm_certificate" "certificate_front" {
   domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}front.lpa.opg.service.justice.gov.uk"
 }

--- a/terraform/environment/modules/environment/shared_data_sources.tf
+++ b/terraform/environment/modules/environment/shared_data_sources.tf
@@ -1,3 +1,7 @@
+data "aws_kms_key" "lpa_pdf_sqs" {
+  key_id = "alias/mrk_pdf_sqs_encryption_key-${var.account_name}"
+}
+
 data "aws_security_group" "new_front_cache_region" {
   filter {
     name   = "group-name"
@@ -17,6 +21,9 @@ data "aws_s3_bucket" "lpa_pdf_cache" {
   bucket = lower("online-lpa-pdf-cache-${var.account_name}-${var.region_name}")
 }
 
+data "aws_kms_key" "lpa_pdf_cache" {
+  key_id = "alias/lpa_pdf_cache-${var.account_name}"
+}
 
 data "aws_acm_certificate" "certificate_front" {
   domain = "${local.cert_prefix_internal}${local.dns_namespace_dev_prefix}front.lpa.opg.service.justice.gov.uk"

--- a/terraform/environment/modules/environment/shared_data_sources.tf
+++ b/terraform/environment/modules/environment/shared_data_sources.tf
@@ -1,7 +1,3 @@
-data "aws_kms_key" "lpa_pdf_sqs" {
-  key_id = "alias/mrk_pdf_sqs_encryption_key-${var.account_name}"
-}
-
 data "aws_security_group" "new_front_cache_region" {
   filter {
     name   = "group-name"

--- a/terraform/environment/modules/environment/shared_data_sources.tf
+++ b/terraform/environment/modules/environment/shared_data_sources.tf
@@ -78,7 +78,3 @@ data "aws_kms_alias" "pdf_cache_s3_encryption_key" {
 data "aws_kms_alias" "pdf_sqs_encryption_key" {
   name = "alias/opg-lpa-${var.account_name}-pdf-sqs-encryption-key"
 }
-
-# data "aws_kms_alias" "redacted_logs_s3_encryption_key" {
-#   name = "alias/opg-lpa-${var.account_name}-redacted-logs-s3-encryption-key"
-# }

--- a/terraform/environment/modules/environment/sqs.tf
+++ b/terraform/environment/modules/environment/sqs.tf
@@ -4,10 +4,14 @@ resource "aws_sqs_queue" "pdf_fifo_queue" {
   visibility_timeout_seconds        = "90"
   fifo_queue                        = true
   content_based_deduplication       = true
-  kms_master_key_id                 = "alias/mrk_pdf_sqs_encryption_key-${var.account_name}"
+  kms_master_key_id                 = data.aws_kms_alias.pdf_sqs_encryption_key.name
   kms_data_key_reuse_period_seconds = "300"
   max_message_size                  = "262144"
   tags                              = local.pdf_component_tag
+
+  lifecycle {
+    ignore_changes = [kms_master_key_id]
+  }
 
   depends_on = [aws_ecs_service.api]
 }

--- a/terraform/environment/modules/environment/sqs.tf
+++ b/terraform/environment/modules/environment/sqs.tf
@@ -9,10 +9,6 @@ resource "aws_sqs_queue" "pdf_fifo_queue" {
   max_message_size                  = "262144"
   tags                              = local.pdf_component_tag
 
-  lifecycle {
-    ignore_changes = [kms_master_key_id]
-  }
-
   depends_on = [aws_ecs_service.api]
 }
 


### PR DESCRIPTION


## Purpose

- Replacing references to old KMS keys in ecs-task-role permissions with the following:
```
 - PDF SQS encryption key
 - PDF cache S3 bucket encryption key
```
 
 - Attaching new kms key to sqs.tf
 
Both keys are also being attached to the resources in region in this [PR ](https://github.com/ministryofjustice/opg-lpa/pull/3689)

Fixes LPAL-2119

## Approach

https://medium.com/@roshanpoudel.me/avoiding-unnecessary-terraform-replacements-understanding-lifecycle-ignore-changes-e8cabdada7b6
## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
