### PR TITLE
LPAL-2357 - Update default tags in environment to include service area

### DIFF
--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -8,7 +8,7 @@ locals {
   mandatory_moj_tags = {
     business-unit = "OPG"
     application   = "Online LPA Service"
-    owner         = "Amy Wilson: amy.wilson@digital.justice.gov.uk"
+    owner         = "OPG LPA Product Team: opgteam+online-lpa@digital.justice.gov.uk"
     is-production = local.environment.is_production
     service-area  = "POAS"
   }

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -10,6 +10,7 @@ locals {
     application   = "Online LPA Service"
     owner         = "Amy Wilson: amy.wilson@digital.justice.gov.uk"
     is-production = local.environment.is_production
+    service-area  = "POAS"
   }
 
   optional_tags = {

--- a/terraform/environment/main.tf
+++ b/terraform/environment/main.tf
@@ -23,6 +23,7 @@ module "eu-west-1" {
     cloudwatch_events = aws_iam_role.cloudwatch_events_ecs_role
   }
   rds_proxy_iam_role = aws_iam_role.rds_proxy
+  tags               = local.default_tags
   providers = {
     aws            = aws.eu_west_1
     aws.management = aws.management
@@ -55,7 +56,7 @@ module "eu-west-2" {
     cloudwatch_events = aws_iam_role.cloudwatch_events_ecs_role
   }
   rds_proxy_iam_role = aws_iam_role.rds_proxy
-
+  tags               = local.default_tags
   providers = {
     aws            = aws.eu_west_2
     aws.management = aws.management

--- a/terraform/environment/modules/environment/mock_onelogin.tf
+++ b/terraform/environment/modules/environment/mock_onelogin.tf
@@ -41,6 +41,7 @@ module "mock_onelogin" {
     name = aws_service_discovery_private_dns_namespace.internal.name
   }
   front_app_ecs_service_security_group_id = aws_security_group.front_ecs_service.id
+  tags                                    = var.tags
   providers = {
     aws.region     = aws
     aws.management = aws.management

--- a/terraform/environment/modules/environment/modules/mock_onelogin/alb.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/alb.tf
@@ -1,5 +1,5 @@
 resource "aws_lb_target_group" "mock_onelogin" {
-  name                 = "${data.aws_default_tags.current.tags.environment-name}-mock-onelogin"
+  name                 = "${var.tags.environment-name}-mock-onelogin"
   port                 = 80
   protocol             = "HTTP"
   target_type          = "ip"
@@ -16,7 +16,7 @@ resource "aws_lb_target_group" "mock_onelogin" {
 }
 
 resource "aws_lb" "mock_onelogin" {
-  name                       = "${data.aws_default_tags.current.tags.environment-name}-mock-onelogin"
+  name                       = "${var.tags.environment-name}-mock-onelogin"
   internal                   = false #tfsec:ignore:AWS005 - public alb
   load_balancer_type         = "application"
   drop_invalid_header_fields = true
@@ -26,7 +26,7 @@ resource "aws_lb" "mock_onelogin" {
 
   access_logs {
     bucket  = data.aws_s3_bucket.access_log.bucket
-    prefix  = "mock-onelogin-${data.aws_default_tags.current.tags.environment-name}"
+    prefix  = "mock-onelogin-${var.tags.environment-name}"
     enabled = true
   }
   provider = aws.region
@@ -75,7 +75,7 @@ resource "aws_lb_listener_certificate" "mock_onelogin_loadbalancer_live_service_
 }
 
 resource "aws_security_group" "mock_onelogin_loadbalancer" {
-  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-mock-onelogin-loadbalancer"
+  name_prefix = "${var.tags.environment-name}-mock-onelogin-loadbalancer"
   description = "mock-onelogin service application load balancer"
   vpc_id      = var.network.vpc_id
   lifecycle {

--- a/terraform/environment/modules/environment/modules/mock_onelogin/data_sources.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/data_sources.tf
@@ -2,10 +2,6 @@ data "aws_region" "current" {
   provider = aws.region
 }
 
-data "aws_default_tags" "current" {
-  provider = aws.region
-}
-
 data "aws_route53_zone" "opg_service_justice_gov_uk" {
   provider = aws.management
   name     = "opg.service.justice.gov.uk"

--- a/terraform/environment/modules/environment/modules/mock_onelogin/dns.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/dns.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_record" "mock_onelogin" {
   provider = aws.management
   zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  name     = "${data.aws_default_tags.current.tags.environment-name}.${var.account_name}.onelogin.lpa"
+  name     = "${var.tags.environment-name}.${var.account_name}.onelogin.lpa"
   type     = "A"
 
   alias {

--- a/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/ecs.tf
@@ -61,7 +61,7 @@ locals {
 }
 
 resource "aws_security_group" "mock_onelogin_ecs_service" {
-  name_prefix = "${data.aws_default_tags.current.tags.environment-name}-ecs-service"
+  name_prefix = "${var.tags.environment-name}-ecs-service"
   description = "mock-onelogin service security group"
   vpc_id      = var.network.vpc_id
   lifecycle {
@@ -115,7 +115,7 @@ resource "aws_security_group_rule" "mock_onelogin_ecs_service_egress" {
 }
 
 resource "aws_ecs_task_definition" "mock_onelogin" {
-  family                   = "${data.aws_default_tags.current.tags.environment-name}-mock-onelogin"
+  family                   = "${var.tags.environment-name}-mock-onelogin"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 256
@@ -127,7 +127,7 @@ resource "aws_ecs_task_definition" "mock_onelogin" {
 }
 
 resource "aws_iam_role_policy" "mock_onelogin_task_role" {
-  name     = "${data.aws_default_tags.current.tags.environment-name}-${data.aws_region.current.region}-mock-onelogin-task-role"
+  name     = "${var.tags.environment-name}-${data.aws_region.current.region}-mock-onelogin-task-role"
   policy   = data.aws_iam_policy_document.task_role_access_policy.json
   role     = var.ecs_task_role.name
   provider = aws.region
@@ -157,7 +157,7 @@ data "aws_iam_policy_document" "task_role_access_policy" {
 
 locals {
   # TODO: fix this url
-  mock_onelogin_url = "https://${data.aws_default_tags.current.tags.environment-name}.${var.account_name}.onelogin.lpa.opg.service.justice.gov.uk"
+  mock_onelogin_url = "https://${var.tags.environment-name}.${var.account_name}.onelogin.lpa.opg.service.justice.gov.uk"
 
   mock_onelogin = jsonencode(
     {
@@ -181,7 +181,7 @@ locals {
         options = {
           awslogs-group         = var.ecs_application_log_group_name,
           awslogs-region        = data.aws_region.current.region,
-          awslogs-stream-prefix = data.aws_default_tags.current.tags.environment-name
+          awslogs-stream-prefix = var.tags.environment-name
           mode                  = "non-blocking"
           max-buffer-size       = "25m"
         }

--- a/terraform/environment/modules/environment/modules/mock_onelogin/variables.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/variables.tf
@@ -107,3 +107,7 @@ variable "template_sub" {
 variable "account_name" {
   type = string
 }
+
+variable "tags" {
+  type = any
+}

--- a/terraform/environment/modules/environment/modules/mock_onelogin/variables.tf
+++ b/terraform/environment/modules/environment/modules/mock_onelogin/variables.tf
@@ -109,5 +109,16 @@ variable "account_name" {
 }
 
 variable "tags" {
-  type = any
+  type = object({
+    business-unit          = string
+    application            = string
+    owner                  = string
+    is-production          = string
+    service-area           = string
+    environment-name       = string
+    infrastructure-support = string
+    runbook                = string
+    source-code            = string
+    Name                   = string
+  })
 }

--- a/terraform/environment/modules/environment/variables.tf
+++ b/terraform/environment/modules/environment/variables.tf
@@ -147,3 +147,7 @@ variable "admin_cognito" {
   })
   sensitive = true
 }
+
+variable "tags" {
+  type = any
+}

--- a/terraform/environment/modules/environment/variables.tf
+++ b/terraform/environment/modules/environment/variables.tf
@@ -149,5 +149,16 @@ variable "admin_cognito" {
 }
 
 variable "tags" {
-  type = any
+  type = object({
+    business-unit          = string
+    application            = string
+    owner                  = string
+    is-production          = string
+    service-area           = string
+    environment-name       = string
+    infrastructure-support = string
+    runbook                = string
+    source-code            = string
+    Name                   = string
+  })
 }


### PR DESCRIPTION
## Purpose

comply with the mandatory tagging standard in terraform/environment

Fixes LPAL-2357

## Approach

- Add service-area tag witha value of `POAS`
- replace use of the default_tags data source with a tags variable (the data source forces resources to be replaced when the tagging structure changes, the variable does not)

I've checked this update against production and and preproduction, there are no destructive changes
<img width="437" height="49" alt="image" src="https://github.com/user-attachments/assets/f9a9a13b-0660-4f7a-be7b-82a5618f5e84" />
