### PR TITLE
LPAL-2207 - update prod smoke test script to test internal facing url

### DIFF
--- a/scripts/pipeline/healthcheck_test/healthcheck_test.py
+++ b/scripts/pipeline/healthcheck_test/healthcheck_test.py
@@ -17,9 +17,7 @@ class HealthcheckTester:
     def read_parameters_from_file(self, config_file):
         with open(config_file) as json_file:
             parameters = json.load(json_file)
-            self.front_url = "https://{}/ping/json".format(
-                parameters["front_fqdn"]
-            )
+            self.front_url = "https://{}/ping/json".format(parameters["front_fqdn"])
             self.expected_tag = parameters["tag"]
 
     def read_healthcheck(self):

--- a/scripts/pipeline/healthcheck_test/healthcheck_test.py
+++ b/scripts/pipeline/healthcheck_test/healthcheck_test.py
@@ -18,7 +18,7 @@ class HealthcheckTester:
         with open(config_file) as json_file:
             parameters = json.load(json_file)
             self.front_url = "https://{}/ping/json".format(
-                parameters["public_facing_fqdn"]
+                parameters["front_fqdn"]
             )
             self.expected_tag = parameters["tag"]
 


### PR DESCRIPTION
## Purpose

Allow smoke test to pass when maintenance mode is enabled

Fixes LPAL-2207

## Approach

- use the front fully qualified domain name (fqdn) for smoke test instead of the public facing fqdn