### PR TITLE
LPAL-2199 | region changes - Attaching PDF cache S3 bucket encryption key to S3 resources

### DIFF
--- a/terraform/region/modules/region/data_sources.tf
+++ b/terraform/region/modules/region/data_sources.tf
@@ -12,3 +12,8 @@ data "aws_kms_alias" "elasticache_encryption_key" {
   name     = "alias/opg-lpa-${var.account_name}-elasticache-encryption-key"
   provider = aws.region
 }
+
+data "aws_kms_alias" "pdf_cache_s3_encryption_key" {
+  name     = "alias/opg-lpa-${var.account_name}-pdf-cache-s3-encryption-key"
+  provider = aws.region
+}

--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -126,7 +126,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "lpa_pdf_cache" {
     blocked_encryption_types = ["SSE-C"]
 
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.lpa_pdf_cache.arn
+      kms_master_key_id = data.aws_kms_alias.pdf_cache_s3_encryption_key.arn
       sse_algorithm     = "aws:kms"
     }
   }


### PR DESCRIPTION
## Purpose

Attaching `PDF cache S3 bucket encryption key` to S3 resources
Fixes LPAL-2199

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
