### PR TITLE
LPAL-1095| Region changes - Attaching sns encryption key to sns topics

### DIFF
--- a/terraform/region/modules/region/data_sources.tf
+++ b/terraform/region/modules/region/data_sources.tf
@@ -17,3 +17,8 @@ data "aws_kms_alias" "pdf_cache_s3_encryption_key" {
   name     = "alias/opg-lpa-${var.account_name}-pdf-cache-s3-encryption-key"
   provider = aws.region
 }
+
+data "aws_kms_alias" "sns_encryption_key" {
+  name     = "alias/opg-lpa-${var.account_name}-sns-encryption-key"
+  provider = aws.region
+}

--- a/terraform/region/modules/region/sns.tf
+++ b/terraform/region/modules/region/sns.tf
@@ -1,8 +1,7 @@
-
+#tfsec:ignore:aws-sns-enable-topic-encryption unsupported for this type of alert
 resource "aws_sns_topic" "cloudwatch_to_slack_elasticache_alerts" {
-  name              = "CloudWatch-to-PagerDuty-${local.account_name}-${local.region_name}-elasticache-alert"
-  tags              = local.front_component_tag
-  kms_master_key_id = data.aws_kms_alias.sns_encryption_key.target_key_arn
+  name = "CloudWatch-to-PagerDuty-${local.account_name}-${local.region_name}-elasticache-alert"
+  tags = local.front_component_tag
 }
 
 #tfsec:ignore:aws-sns-enable-topic-encryption unsupported for this type of alert
@@ -10,8 +9,6 @@ resource "aws_sns_topic" "cloudwatch_to_account_ops_alerts" {
   name = "CloudWatch-to-PagerDuty-${local.account_name}-${local.region_name}-ops-alert"
   tags = local.shared_component_tag
 }
-
-#tfsec:ignore:aws-sns-enable-topic-encryption - review if changed to Aurora
 resource "aws_sns_topic" "rds_events" {
   name              = "${local.account_name}-${local.region_name}-rds-events"
   tags              = local.db_component_tag
@@ -19,7 +16,6 @@ resource "aws_sns_topic" "rds_events" {
 }
 
 # All events split into different subscriptions by source type to allow filtering based on source type and event type
-
 resource "aws_db_event_subscription" "rds_events_db_cluster" {
   name      = "${local.account_name}-${local.region_name}-rds-event-db-cluster-sub"
   sns_topic = aws_sns_topic.rds_events.arn
@@ -27,7 +23,6 @@ resource "aws_db_event_subscription" "rds_events_db_cluster" {
   source_type = "db-cluster"
 }
 
-#tfsec:ignore:aws-sns-enable-topic-encryption - - review if changed to Aurora
 resource "aws_db_event_subscription" "rds_events_db_instance" {
   name      = "${local.account_name}-${local.region_name}-rds-event-db-instance-sub"
   sns_topic = aws_sns_topic.rds_events.arn
@@ -42,7 +37,6 @@ resource "aws_db_event_subscription" "rds_events_db_sg" {
   source_type = "db-security-group"
 }
 
-#tfsec:ignore:aws-sns-enable-topic-encryption - - review if changed to Aurora
 resource "aws_db_event_subscription" "rds_events_db_pg" {
   name      = "${local.account_name}-${local.region_name}-rds-event-db-pg-sub"
   sns_topic = aws_sns_topic.rds_events.arn

--- a/terraform/region/modules/region/sns.tf
+++ b/terraform/region/modules/region/sns.tf
@@ -20,7 +20,6 @@ resource "aws_sns_topic" "rds_events" {
 
 # All events split into different subscriptions by source type to allow filtering based on source type and event type
 
-#tfsec:ignore:aws-sns-enable-topic-encryption - - review if changed to Aurora
 resource "aws_db_event_subscription" "rds_events_db_cluster" {
   name      = "${local.account_name}-${local.region_name}-rds-event-db-cluster-sub"
   sns_topic = aws_sns_topic.rds_events.arn
@@ -36,7 +35,6 @@ resource "aws_db_event_subscription" "rds_events_db_instance" {
   source_type = "db-instance"
 }
 
-#tfsec:ignore:aws-sns-enable-topic-encryption - - review if changed to Aurora
 resource "aws_db_event_subscription" "rds_events_db_sg" {
   name      = "${local.account_name}-${local.region_name}-rds-event-db-sg-sub"
   sns_topic = aws_sns_topic.rds_events.arn
@@ -51,8 +49,6 @@ resource "aws_db_event_subscription" "rds_events_db_pg" {
 
   source_type = "db-parameter-group"
 }
-
-#tfsec:ignore:aws-sns-enable-topic-encryption - - review if changed to Aurora
 resource "aws_db_event_subscription" "rds_events_db_snapshot" {
   name      = "${local.account_name}-${local.region_name}-rds-event-db-snapshot-sub"
   sns_topic = aws_sns_topic.rds_events.arn
@@ -64,7 +60,6 @@ resource "aws_db_event_subscription" "rds_events_db_snapshot" {
   ]
 }
 
-#tfsec:ignore:aws-sns-enable-topic-encryption - - review if changed to Aurora
 resource "aws_db_event_subscription" "rds_events_db_cluster_snapshot" {
   name      = "${local.account_name}-${local.region_name}-rds-event-db-cluster-snapshot-sub"
   sns_topic = aws_sns_topic.rds_events.arn

--- a/terraform/region/modules/region/sns.tf
+++ b/terraform/region/modules/region/sns.tf
@@ -1,7 +1,8 @@
-#tfsec:ignore:aws-sns-enable-topic-encryption unsupported for this type of alert
+
 resource "aws_sns_topic" "cloudwatch_to_slack_elasticache_alerts" {
-  name = "CloudWatch-to-PagerDuty-${local.account_name}-${local.region_name}-elasticache-alert"
-  tags = local.front_component_tag
+  name              = "CloudWatch-to-PagerDuty-${local.account_name}-${local.region_name}-elasticache-alert"
+  tags              = local.front_component_tag
+  kms_master_key_id = data.aws_kms_alias.sns_encryption_key.target_key_arn
 }
 
 #tfsec:ignore:aws-sns-enable-topic-encryption unsupported for this type of alert
@@ -12,8 +13,9 @@ resource "aws_sns_topic" "cloudwatch_to_account_ops_alerts" {
 
 #tfsec:ignore:aws-sns-enable-topic-encryption - review if changed to Aurora
 resource "aws_sns_topic" "rds_events" {
-  name = "${local.account_name}-${local.region_name}-rds-events"
-  tags = local.db_component_tag
+  name              = "${local.account_name}-${local.region_name}-rds-events"
+  tags              = local.db_component_tag
+  kms_master_key_id = data.aws_kms_alias.sns_encryption_key.target_key_arn
 }
 
 # All events split into different subscriptions by source type to allow filtering based on source type and event type


### PR DESCRIPTION
## Purpose

Attaching SNS encryption key to sns topics for rds events
(third party apps like pagerduty and slack not supported)

Fixes LPAL-1095
## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
