### PR TITLE
LPAL-2121 | Attaching new redacted logs encryption key to s3 bucket

### DIFF
--- a/terraform/region/modules/region/data_sources.tf
+++ b/terraform/region/modules/region/data_sources.tf
@@ -22,3 +22,8 @@ data "aws_kms_alias" "sns_encryption_key" {
   name     = "alias/opg-lpa-${var.account_name}-sns-encryption-key"
   provider = aws.region
 }
+
+data "aws_kms_alias" "redacted_logs_s3_encryption_key" {
+  name     = "alias/opg-lpa-${var.account_name}-redacted-logs-s3-encryption-key"
+  provider = aws.region
+}

--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -226,3 +226,5 @@ resource "aws_s3_bucket_public_access_block" "redacted_logs" {
   restrict_public_buckets = true
   ignore_public_acls      = true
 }
+
+# adding comment to test merge conflict fix

--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -226,5 +226,3 @@ resource "aws_s3_bucket_public_access_block" "redacted_logs" {
   restrict_public_buckets = true
   ignore_public_acls      = true
 }
-
-# adding comment to test merge conflict fix

--- a/terraform/region/modules/region/s3.tf
+++ b/terraform/region/modules/region/s3.tf
@@ -213,7 +213,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "redacted_logs" {
     blocked_encryption_types = ["SSE-C"]
 
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.redacted_logs.arn
+      kms_master_key_id = data.aws_kms_alias.redacted_logs_s3_encryption_key.arn
       sse_algorithm     = "aws:kms"
     }
   }


### PR DESCRIPTION
## Purpose

Adding encryption key to redacted logs S3 bucket

Fixes LPAL-2121

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
