### PR TITLE
LPAL-2366 - restrict what s3 resources can accessed via the s3 vpc endpoint

### DIFF
--- a/terraform/region/modules/region/firewalled_network.tf
+++ b/terraform/region/modules/region/firewalled_network.tf
@@ -73,25 +73,13 @@ module "vpc_endpoints" {
   data_lpa_api_account_id        = var.account.data_lpa_api_account_id
   allowed_s3_resource_arns = [
     # allowed buckets
-    "arn:aws:s3:::config-${data.aws_region.current.region}-${var.account_name}-opg-lpa-opg",
-    "arn:aws:s3:::config.${data.aws_region.current.region}.${var.account_name}.opg-lpa.opg.justice.gov.uk", # deprecated config bucket
-    "arn:aws:s3:::config.${var.account_name}.opg-lpa.opg.service.justice.gov.uk",                           # deprecated config bucket
-    "arn:aws:s3:::online-lpa-cloudtrail-${var.account_name}",
     "arn:aws:s3:::online-lpa-pdf-cache-${var.account_name}-${data.aws_region.current.region}",
     "arn:aws:s3:::online-lpa-${var.account_name}-${data.aws_region.current.region}-lb-access-logs",
     "arn:aws:s3:::online-lpa-${var.account_name}-lb-access-logs",
-    "arn:aws:s3:::redacted-logs.${var.account_name}.${data.aws_region.current.region}.lpa.opg.justice.gov.uk",
-    "arn:aws:s3:::s3-access-logs-opg-opg-lpa-${var.account_name}-${data.aws_region.current.region}",
     # allowed objects
-    "arn:aws:s3:::config-${data.aws_region.current.region}-${var.account_name}-opg-lpa-opg/*",
-    "arn:aws:s3:::config.${data.aws_region.current.region}.${var.account_name}.opg-lpa.opg.justice.gov.uk/*", # deprecated config bucket
-    "arn:aws:s3:::config.${var.account_name}.opg-lpa.opg.service.justice.gov.uk/*",                           # deprecated config bucket
-    "arn:aws:s3:::online-lpa-cloudtrail-${var.account_name}/*",
     "arn:aws:s3:::online-lpa-pdf-cache-${var.account_name}-${data.aws_region.current.region}/*",
     "arn:aws:s3:::online-lpa-${var.account_name}-${data.aws_region.current.region}-lb-access-logs/*",
     "arn:aws:s3:::online-lpa-${var.account_name}-lb-access-logs/*",
-    "arn:aws:s3:::redacted-logs.${var.account_name}.${data.aws_region.current.region}.lpa.opg.justice.gov.uk/*",
-    "arn:aws:s3:::s3-access-logs-opg-opg-lpa-${var.account_name}-${data.aws_region.current.region}/*",
   ]
   providers = {
     aws.region = aws

--- a/terraform/region/modules/region/firewalled_network.tf
+++ b/terraform/region/modules/region/firewalled_network.tf
@@ -71,6 +71,28 @@ module "vpc_endpoints" {
   codecatalyst_endpoints_enabled = local.account.regions[data.aws_region.current.region].codecatalyst_endpoints_enabled
   management_account_id          = data.aws_caller_identity.management.account_id
   data_lpa_api_account_id        = var.account.data_lpa_api_account_id
+  allowed_s3_bucket_arns = [
+    # allowed buckets
+    "arn:aws:s3:::config-${data.aws_region.current.region}-${var.account_name}-opg-lpa-opg",
+    "arn:aws:s3:::config.${data.aws_region.current.region}.${var.account_name}.opg-lpa.opg.justice.gov.uk", # deprecated config bucket
+    "arn:aws:s3:::config.${var.account_name}.opg-lpa.opg.service.justice.gov.uk",                           # deprecated config bucket
+    "arn:aws:s3:::online-lpa-cloudtrail-${var.account_name}",
+    "arn:aws:s3:::online-lpa-pdf-cache-${var.account_name}-${data.aws_region.current.region}",
+    "arn:aws:s3:::online-lpa-${var.account_name}-${data.aws_region.current.region}-lb-access-logs",
+    "arn:aws:s3:::online-lpa-${var.account_name}-lb-access-logs",
+    "arn:aws:s3:::redacted-logs.${var.account_name}.${data.aws_region.current.region}.lpa.opg.justice.gov.uk",
+    "arn:aws:s3:::s3-access-logs-opg-opg-lpa-${var.account_name}-${data.aws_region.current.region}",
+    # allowed objects
+    "arn:aws:s3:::config-${data.aws_region.current.region}-${var.account_name}-opg-lpa-opg/*",
+    "arn:aws:s3:::config.${data.aws_region.current.region}.${var.account_name}.opg-lpa.opg.justice.gov.uk/*", # deprecated config bucket
+    "arn:aws:s3:::config.${var.account_name}.opg-lpa.opg.service.justice.gov.uk/*",                           # deprecated config bucket
+    "arn:aws:s3:::online-lpa-cloudtrail-${var.account_name}/*",
+    "arn:aws:s3:::online-lpa-pdf-cache-${var.account_name}-${data.aws_region.current.region}/*",
+    "arn:aws:s3:::online-lpa-${var.account_name}-${data.aws_region.current.region}-lb-access-logs/*",
+    "arn:aws:s3:::online-lpa-${var.account_name}-lb-access-logs/*",
+    "arn:aws:s3:::redacted-logs.${var.account_name}.${data.aws_region.current.region}.lpa.opg.justice.gov.uk/*",
+    "arn:aws:s3:::s3-access-logs-opg-opg-lpa-${var.account_name}-${data.aws_region.current.region}/*",
+  ]
   providers = {
     aws.region = aws
   }

--- a/terraform/region/modules/region/firewalled_network.tf
+++ b/terraform/region/modules/region/firewalled_network.tf
@@ -75,11 +75,9 @@ module "vpc_endpoints" {
     # allowed buckets
     "arn:aws:s3:::online-lpa-pdf-cache-${var.account_name}-${data.aws_region.current.region}",
     "arn:aws:s3:::online-lpa-${var.account_name}-${data.aws_region.current.region}-lb-access-logs",
-    "arn:aws:s3:::online-lpa-${var.account_name}-lb-access-logs",
     # allowed objects
     "arn:aws:s3:::online-lpa-pdf-cache-${var.account_name}-${data.aws_region.current.region}/*",
     "arn:aws:s3:::online-lpa-${var.account_name}-${data.aws_region.current.region}-lb-access-logs/*",
-    "arn:aws:s3:::online-lpa-${var.account_name}-lb-access-logs/*",
   ]
   providers = {
     aws.region = aws

--- a/terraform/region/modules/region/firewalled_network.tf
+++ b/terraform/region/modules/region/firewalled_network.tf
@@ -60,6 +60,17 @@ data "aws_route_tables" "firewalled_network_application" {
   }
 }
 
+locals {
+  allowed_s3_resource_arns = [
+    # allowed buckets
+    "arn:aws:s3:::online-lpa-pdf-cache-${var.account_name}-${data.aws_region.current.region}",
+    "arn:aws:s3:::online-lpa-${var.account_name}-${data.aws_region.current.region}-lb-access-logs",
+    # allowed objects
+    "arn:aws:s3:::online-lpa-pdf-cache-${var.account_name}-${data.aws_region.current.region}/*",
+    "arn:aws:s3:::online-lpa-${var.account_name}-${data.aws_region.current.region}-lb-access-logs/*",
+  ]
+}
+
 module "vpc_endpoints" {
   source                          = "./modules/vpc_endpoints"
   vpc_id                          = module.network.vpc.id
@@ -71,14 +82,7 @@ module "vpc_endpoints" {
   codecatalyst_endpoints_enabled = local.account.regions[data.aws_region.current.region].codecatalyst_endpoints_enabled
   management_account_id          = data.aws_caller_identity.management.account_id
   data_lpa_api_account_id        = var.account.data_lpa_api_account_id
-  allowed_s3_resource_arns = [
-    # allowed buckets
-    "arn:aws:s3:::online-lpa-pdf-cache-${var.account_name}-${data.aws_region.current.region}",
-    "arn:aws:s3:::online-lpa-${var.account_name}-${data.aws_region.current.region}-lb-access-logs",
-    # allowed objects
-    "arn:aws:s3:::online-lpa-pdf-cache-${var.account_name}-${data.aws_region.current.region}/*",
-    "arn:aws:s3:::online-lpa-${var.account_name}-${data.aws_region.current.region}-lb-access-logs/*",
-  ]
+  allowed_s3_resource_arns       = var.account_name != "production" ? local.allowed_s3_resource_arns : ["*"]
   providers = {
     aws.region = aws
   }

--- a/terraform/region/modules/region/firewalled_network.tf
+++ b/terraform/region/modules/region/firewalled_network.tf
@@ -71,7 +71,7 @@ module "vpc_endpoints" {
   codecatalyst_endpoints_enabled = local.account.regions[data.aws_region.current.region].codecatalyst_endpoints_enabled
   management_account_id          = data.aws_caller_identity.management.account_id
   data_lpa_api_account_id        = var.account.data_lpa_api_account_id
-  allowed_s3_bucket_arns = [
+  allowed_s3_resource_arns = [
     # allowed buckets
     "arn:aws:s3:::config-${data.aws_region.current.region}-${var.account_name}-opg-lpa-opg",
     "arn:aws:s3:::config.${data.aws_region.current.region}.${var.account_name}.opg-lpa.opg.justice.gov.uk", # deprecated config bucket

--- a/terraform/region/modules/region/modules/vpc_endpoints/variables.tf
+++ b/terraform/region/modules/region/modules/vpc_endpoints/variables.tf
@@ -47,3 +47,7 @@ variable "management_account_id" {
 variable "data_lpa_api_account_id" {
   type = string
 }
+
+variable "allowed_s3_resource_arns" {
+  type = list(string)
+}

--- a/terraform/region/modules/region/modules/vpc_endpoints/vpce_s3.tf
+++ b/terraform/region/modules/region/modules/vpc_endpoints/vpce_s3.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "s3_gateway_endpoint_allow_account_access" {
     sid       = "Allow-callers-from-specific-account"
     effect    = "Allow"
     actions   = ["*"]
-    resources = ["*"]
+    resources = var.allowed_s3_resource_arns
     principals {
       type        = "AWS"
       identifiers = ["*"]


### PR DESCRIPTION
## Purpose

Apply good policies to VPC endpoints to prevent egress to unauthorised locations

Fixes LPAL-2366

## Approach

- define the s3 resources that can be accessed
- use allowed resources in the S3 gateway endpoint policy

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
