### PR TITLE
Fix uv python

### DIFF
--- a/.github/workflows/locust_tests.yml
+++ b/.github/workflows/locust_tests.yml
@@ -75,7 +75,6 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           version: "0.11.21"
-          python-version: "3.14.5"
           enable-cache: true
 
       - name: Install Python

--- a/.github/workflows/workflow_merge_queue.yml
+++ b/.github/workflows/workflow_merge_queue.yml
@@ -280,6 +280,7 @@ jobs:
       - cypress_tests_Signup_StitchedHW
       - cypress_tests_SignupIncluded
       - cypress_tests_Remaining
+      - locust_tests
     environment:
       name: "preproduction"
       url: "https://${{ env.FRONT_URL }}/home"
@@ -293,7 +294,8 @@ jobs:
             ${{ contains(needs.cypress_tests_Signup_StitchedPF.result, 'success')}} &&
             ${{ contains(needs.cypress_tests_Signup_StitchedHW.result, 'success')}} &&
             ${{ contains(needs.cypress_tests_SignupIncluded.result, 'success')}} &&
-            ${{ contains(needs.cypress_tests_Remaining.result, 'success')}}; then
+            ${{ contains(needs.cypress_tests_Remaining.result, 'success')}} &&
+            ${{ contains(needs.locust_tests.result, 'success')}}; then
             echo "Preproduction environment tested, built and deployed"
             echo "Tag Deployed: integration-${SEMVER_TAG}"
             echo "URL: https://${FRONT_URL}/home"

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -234,7 +234,6 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           version: "0.11.21"
-          python-version: "3.14.5"
           enable-cache: true
 
       - name: Install Python


### PR DESCRIPTION
## Purpose

Merge queue passed when it should have failed, and path to live failed on smoke test python dep install.

## Approach

- make sure locusts tests succeed
- don't specify python versions in uv setup. Let uv toml files specify exactly which version to install.