### PR TITLE
LPAL-2244 - Get rid of persistent diffs on RDS parameter groups

### DIFF
--- a/terraform/region/modules/region/rds_parameter_groups.tf
+++ b/terraform/region/modules/region/rds_parameter_groups.tf
@@ -68,63 +68,63 @@ resource "aws_rds_cluster_parameter_group" "postgresql_aurora_params" {
   }
 
   # for blue/green deployments
-  parameter {
-    name         = "apg_plan_mgmt.capture_plan_baselines"
-    value        = "off"
-    apply_method = "immediate"
-  }
+  # parameter {
+  #   name         = "apg_plan_mgmt.capture_plan_baselines"
+  #   value        = "off"
+  #   apply_method = "immediate"
+  # }
 
-  parameter {
-    name         = "apg_plan_mgmt.explain_hashes"
-    value        = "0"
-    apply_method = "immediate"
-  }
+  # parameter {
+  #   name         = "apg_plan_mgmt.explain_hashes"
+  #   value        = "0"
+  #   apply_method = "immediate"
+  # }
 
-  parameter {
-    name         = "apg_plan_mgmt.log_plan_enforcement_result"
-    value        = "none"
-    apply_method = "immediate"
-  }
+  # parameter {
+  #   name         = "apg_plan_mgmt.log_plan_enforcement_result"
+  #   value        = "none"
+  #   apply_method = "immediate"
+  # }
 
-  parameter {
-    name         = "apg_plan_mgmt.max_databases"
-    value        = "10"
-    apply_method = "immediate"
-  }
+  # parameter {
+  #   name         = "apg_plan_mgmt.max_databases"
+  #   value        = "10"
+  #   apply_method = "immediate"
+  # }
 
-  parameter {
-    name         = "apg_plan_mgmt.max_plans"
-    value        = "10000"
-    apply_method = "immediate"
-  }
+  # parameter {
+  #   name         = "apg_plan_mgmt.max_plans"
+  #   value        = "10000"
+  #   apply_method = "immediate"
+  # }
 
-  parameter {
-    name         = "apg_plan_mgmt.plan_capture_threshold"
-    value        = "0"
-    apply_method = "immediate"
-  }
+  # parameter {
+  #   name         = "apg_plan_mgmt.plan_capture_threshold"
+  #   value        = "0"
+  #   apply_method = "immediate"
+  # }
 
-  parameter {
-    name         = "apg_plan_mgmt.plan_hash_version"
-    value        = "1"
-    apply_method = "immediate"
-  }
+  # parameter {
+  #   name         = "apg_plan_mgmt.plan_hash_version"
+  #   value        = "1"
+  #   apply_method = "immediate"
+  # }
 
-  parameter {
-    name         = "apg_plan_mgmt.plan_retention_period"
-    value        = "32"
-    apply_method = "immediate"
-  }
+  # parameter {
+  #   name         = "apg_plan_mgmt.plan_retention_period"
+  #   value        = "32"
+  #   apply_method = "immediate"
+  # }
 
-  parameter {
-    name         = "apg_plan_mgmt.unapproved_plan_execution_threshold"
-    value        = "0"
-    apply_method = "immediate"
-  }
+  # parameter {
+  #   name         = "apg_plan_mgmt.unapproved_plan_execution_threshold"
+  #   value        = "0"
+  #   apply_method = "immediate"
+  # }
 
-  parameter {
-    name         = "apg_plan_mgmt.use_plan_baselines"
-    value        = "false"
-    apply_method = "immediate"
-  }
+  # parameter {
+  #   name         = "apg_plan_mgmt.use_plan_baselines"
+  #   value        = "false"
+  #   apply_method = "immediate"
+  # }
 }


### PR DESCRIPTION
## Purpose

Every region configuration run wants to add parameters to the parameter group that are getting removed because they only apply to blue/green deployments. We only use blue/green deployments for PostgreSQL major version upgrades, so we'll keep the parameters commented out.

Fixes LPAL-2244

## Approach

- comment out blue/green deployment parameters, only needed for major version upgrades