### PR TITLE
LPAL-2393 - recover payments Gov Pay took but never confirmed back to us  

### DIFF
--- a/cypress/e2e/CheckoutPaymentRecovery.feature
+++ b/cypress/e2e/CheckoutPaymentRecovery.feature
@@ -1,0 +1,33 @@
+Feature: Recovering a card payment that GOV.UK Pay took but never confirmed back to us
+
+  Some users pay successfully and then never return to the service, could be that they close
+  the tab as soon as the payment completes - so the redirect that records the payment is
+  never made. The payment is taken, but the LPA is left unlocked with nothing on it but a
+  gateway reference, and the user is stuck.
+
+  Returning to the LPA should repair it without the user having to do anything, and
+  without ever showing them a "pay" button they have every reason to refuse to press.
+
+  Tagged @CheckoutPaymentGateway because it needs the mock-pay container to answer the
+  GOV.UK Pay lookup; like the other gateway test it is excluded from the CI runs that
+  execute against deployed environments.
+
+  Background:
+    Given I ignore application exceptions
+    And I create PF LPA test fixture with a card payment that was never recorded
+
+  @CheckoutPaymentGateway @CleanupFixtures
+  Scenario: The stranded payment is recovered when the user opens the checkout page
+    Given I log in as appropriate test user
+    And I visit the checkout page for the test fixture lpa
+    Then I am taken to the complete page
+    And I see "Payment received" in the page text
+
+  @CheckoutPaymentGateway @CleanupFixtures
+  Scenario: The stranded payment is recovered when the user clicks Continue on the dashboard
+    Given I log in as appropriate test user
+    And I visit the dashboard
+    When I click continue on the dashboard for the test fixture lpa
+    Then I am taken to the complete page
+    And I see "Payment received" in the page text
+    And I can find link pointing to "/lp1"

--- a/cypress/e2e/common/fixtures.js
+++ b/cypress/e2e/common/fixtures.js
@@ -422,6 +422,23 @@ Then(
 );
 
 Then(
+  `I create PF LPA test fixture with a card payment that was never recorded`,
+  () => {
+    cy.runPythonApiCommand(
+      'createLpa.py -d -a -r -cp -pn -i -w donor -co donor -y -ra false -pa card-started-not-recorded',
+    )
+      .its('stdout')
+      .as('lpaId')
+      .then((lpaId) => {
+        cy.log(
+          'Created PF LPA test fixture with an unrecorded card payment through the API with id ' +
+          lpaId,
+        );
+      });
+  },
+);
+
+Then(
   `I create PF LPA test fixture with donor, attorneys, replacement attorneys, cert provider, people to notify, instructions, preferences, applicant, correspondent, who are you, repeat application, fee reduction`,
   () => {
     cy.runPythonApiCommand(

--- a/cypress/e2e/common/i_click.js
+++ b/cypress/e2e/common/i_click.js
@@ -63,6 +63,12 @@ Then(`If I am on dashboard I click to create lpa`, () => {
   });
 });
 
+Then('I click continue on the dashboard for the test fixture lpa', () => {
+  cy.get('@lpaId').then((lpaId) => {
+    cy.get('[data-cy="view-or-continue-lpa-' + lpaId + '"]').click();
+  });
+});
+
 Then('I click the "Reuse LPA details" link for the test fixture lpa', () => {
   cy.get('@lpaId').then((lpaId) => {
     const selector = 'a[href*="/user/dashboard/create/' + lpaId + '"]';

--- a/mock-pay/get-payment.js
+++ b/mock-pay/get-payment.js
@@ -7,7 +7,7 @@ var paymentId = context.request.pathParams.paymentId;
 
 var paymentsStore = stores.open('payments');
 var returnUrl  = paymentsStore.load('return_url_' + paymentId) || '';
-var reference  = paymentsStore.load('reference_' + paymentId) || '';
+var reference  = paymentsStore.load('reference_' + paymentId) || paymentId;
 var email      = paymentsStore.load('email_' + paymentId) || 'payer@example.org';
 
 var baseUrl = 'http://mock-pay:8080';

--- a/service-front/src/App/src/Handler/Lpa/CheckoutIndexHandler.php
+++ b/service-front/src/App/src/Handler/Lpa/CheckoutIndexHandler.php
@@ -9,6 +9,7 @@ use App\Handler\Traits\CommonTemplateVariablesTrait;
 use App\Middleware\RequestAttribute;
 use App\Service\Lpa\Application as LpaApplicationService;
 use App\Service\Lpa\Communication;
+use App\Service\Payment\CardPayments;
 use Fig\Http\Message\RequestMethodInterface;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Laminas\Form\FormElementManager;
@@ -31,6 +32,7 @@ class CheckoutIndexHandler implements RequestHandlerInterface
         LpaApplicationService $lpaApplicationService,
         Communication $communicationService,
         UrlHelper $urlHelper,
+        private readonly CardPayments $cardPayments,
     ) {
         $this->lpaApplicationService = $lpaApplicationService;
         $this->communicationService = $communicationService;
@@ -41,6 +43,10 @@ class CheckoutIndexHandler implements RequestHandlerInterface
     {
         /** @var Lpa $lpa */
         $lpa = $request->getAttribute(RequestAttribute::LPA);
+
+        if ($this->cardPayments->recoverCompletedPayment($lpa)) {
+            return $this->finishCheckout($lpa, $request);
+        }
 
         $isPost = strtoupper($request->getMethod()) === RequestMethodInterface::METHOD_POST;
 

--- a/service-front/src/App/src/Handler/Lpa/CheckoutPayHandler.php
+++ b/service-front/src/App/src/Handler/Lpa/CheckoutPayHandler.php
@@ -11,19 +11,17 @@ use App\Middleware\RequestAttribute;
 use App\Model\FormFlowChecker;
 use App\Service\Lpa\Application as LpaApplicationService;
 use App\Service\Lpa\Communication;
+use App\Service\Payment\CardPayments;
 use App\Service\Payment\Helper\LpaIdHelper;
 use Fig\Http\Message\RequestMethodInterface;
 use GuzzleHttp\Psr7\Uri;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Laminas\Form\FormElementManager;
-use MakeShared\DataModel\Common\EmailAddress;
 use MakeShared\DataModel\Lpa\Lpa;
-use MakeShared\DataModel\Lpa\Payment\Payment;
 use Mezzio\Helper\UrlHelper;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
@@ -42,7 +40,7 @@ class CheckoutPayHandler implements RequestHandlerInterface
         Communication $communicationService,
         private readonly GovPayClient $paymentClient,
         UrlHelper $urlHelper,
-        private readonly LoggerInterface $logger,
+        private readonly CardPayments $cardPayments,
     ) {
         $this->lpaApplicationService = $lpaApplicationService;
         $this->communicationService  = $communicationService;
@@ -102,24 +100,7 @@ class CheckoutPayHandler implements RequestHandlerInterface
 
             if ($payment->isSuccess()) {
                 // Payment already completed — record it and finish.
-                $lpa->payment->method    = Payment::PAYMENT_TYPE_CARD;
-                $lpa->payment->reference = $payment->reference;
-                $lpa->payment->date      = new \DateTime();
-
-                $govPayEmail         = $payment->email ?? null;
-                $lpa->payment->email = is_string($govPayEmail) && trim($govPayEmail) !== ''
-                    ? new EmailAddress(['address' => strtolower(trim($govPayEmail))])
-                    : null;
-
-                $result = $this->lpaApplicationService->updateApplication($lpa->id, ['payment' => $lpa->payment->toArray()]);
-
-                if ($result === false) {
-                    $this->logger->critical('PAYMENT RECORDING FAILED — payment taken but LPA not updated', [
-                        'lpaId'            => $lpa->id,
-                        'gatewayReference' => $gatewayReference,
-                        'has_email'        => $lpa->payment->email !== null,
-                    ]);
-                }
+                $this->cardPayments->recordSuccessfulPayment($lpa, $payment);
 
                 return $this->finishCheckout($lpa, $request);
             }

--- a/service-front/src/App/src/Handler/Lpa/CheckoutPayResponseHandler.php
+++ b/service-front/src/App/src/Handler/Lpa/CheckoutPayResponseHandler.php
@@ -10,12 +10,11 @@ use App\Handler\Traits\CommonTemplateVariablesTrait;
 use App\Middleware\RequestAttribute;
 use App\Service\Lpa\Application as LpaApplicationService;
 use App\Service\Lpa\Communication;
+use App\Service\Payment\CardPayments;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Laminas\Form\FormElementManager;
-use MakeShared\DataModel\Common\EmailAddress;
 use MakeShared\DataModel\Lpa\Lpa;
-use MakeShared\DataModel\Lpa\Payment\Payment;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -42,6 +41,7 @@ class CheckoutPayResponseHandler implements RequestHandlerInterface
         UrlHelper $urlHelper,
         private readonly TemplateRendererInterface $renderer,
         private readonly LoggerInterface $logger,
+        private readonly CardPayments $cardPayments,
     ) {
         $this->lpaApplicationService = $lpaApplicationService;
         $this->communicationService  = $communicationService;
@@ -122,31 +122,12 @@ class CheckoutPayResponseHandler implements RequestHandlerInterface
         ]);
 
         // Payment succeeded at GovPay — record it on the LPA.
-        $lpa->payment->method    = Payment::PAYMENT_TYPE_CARD;
-        $lpa->payment->reference = $paymentResponse->reference;
-        $lpa->payment->date      = new \DateTime();
-
-        $govPayEmail = $paymentResponse->email ?? null;
-
-        $lpa->payment->email = is_string($govPayEmail) && trim($govPayEmail) !== ''
-            ? new EmailAddress(['address' => strtolower(trim($govPayEmail))])
-            : null;
-
-        $result = $this->lpaApplicationService->updateApplication($lpa->id, ['payment' => $lpa->payment->toArray()]);
+        $recorded = $this->cardPayments->recordSuccessfulPayment($lpa, $paymentResponse);
 
         $this->logger->info('PayResponse: updateApplication result', [
             'lpaId'   => $lpa->id,
-            'success' => $result !== false,
+            'success' => $recorded,
         ]);
-
-        if ($result === false) {
-            $this->logger->critical('PAYMENT RECORDING FAILED — payment taken but LPA not updated', [
-                'lpaId'            => $lpa->id,
-                'gatewayReference' => $gatewayReference,
-                'govpay_status'    => $paymentResponse->state->status ?? 'unknown',
-                'has_email'        => $lpa->payment->email !== null,
-            ]);
-        }
 
         return $this->finishCheckout($lpa, $request);
     }

--- a/service-front/src/App/src/Service/Payment/CardPayments.php
+++ b/service-front/src/App/src/Service/Payment/CardPayments.php
@@ -38,7 +38,7 @@ class CardPayments
     {
         $payment = $lpa->payment;
 
-        rreturn $payment instanceof Payment
+        return $payment instanceof Payment
             && is_string($payment->gatewayReference) && trim($payment->gatewayReference) !== ''
             && $payment->date === null && $payment->method === null
             && $lpa->locked !== true && $lpa->completedAt === null

--- a/service-front/src/App/src/Service/Payment/CardPayments.php
+++ b/service-front/src/App/src/Service/Payment/CardPayments.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Payment;
+
+use App\Service\Lpa\Application as LpaApplicationService;
+use App\Service\Payment\GovPay\Client as GovPayClient;
+use App\Service\Payment\GovPay\Response\Payment as GovPayPayment;
+use DateTime;
+use MakeShared\DataModel\Common\EmailAddress;
+use MakeShared\DataModel\Lpa\Lpa;
+use MakeShared\DataModel\Lpa\Payment\Payment;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Records confirmed GOV Pay card payments against an LPA, and recovers payments that
+ * succeeded at GOV.UK Pay but were never recorded.
+ *
+ * The normal flow records the payment when GOV Pay redirects the user back to
+ * /checkout/pay/response. If the user never comes back — they close the tab as soon as
+ * the payment completes, or the browser drops the redirect — the payment is taken but the
+ * LPA is left unlocked and the user cannot proceed.
+ *
+ * @psalm-suppress UndefinedPropertyFetch  Lpa/Payment expose their fields via AbstractData
+ */
+class CardPayments
+{
+    public function __construct(
+        private readonly GovPayClient $paymentClient,
+        private readonly LpaApplicationService $lpaApplicationService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function isAwaitingConfirmation(Lpa $lpa): bool
+    {
+        $payment = $lpa->payment;
+
+        if (!$payment instanceof Payment) {
+            return false;
+        }
+
+        if (!is_string($payment->gatewayReference) || trim($payment->gatewayReference) === '') {
+            return false;
+        }
+
+        if ($payment->date !== null || $payment->method !== null) {
+            return false;
+        }
+
+        if ($lpa->locked === true || $lpa->completedAt !== null) {
+            return false;
+        }
+
+        return $lpa->hasFinishedCreation();
+    }
+
+    public function recoverCompletedPayment(Lpa $lpa): bool
+    {
+        if (!$this->isAwaitingConfirmation($lpa)) {
+            return false;
+        }
+
+        $gatewayReference = $lpa->payment->gatewayReference;
+
+        try {
+            $govPayPayment = $this->paymentClient->getPayment($gatewayReference);
+
+            if ($govPayPayment === null) {
+                $this->logger->info('Payment recovery: GOV.UK Pay has no record of this payment', [
+                    'lpaId'            => $lpa->id,
+                    'gatewayReference' => $gatewayReference,
+                ]);
+
+                return false;
+            }
+
+            if (!$govPayPayment->isSuccess()) {
+                $this->logger->info('Payment recovery: outstanding payment did not succeed', [
+                    'lpaId'            => $lpa->id,
+                    'gatewayReference' => $gatewayReference,
+                    'status'           => $govPayPayment->state->status ?? null,
+                    'finished'         => $govPayPayment->state->finished ?? null,
+                ]);
+
+                return false;
+            }
+
+            $reference = $govPayPayment->reference ?? null;
+
+            if (!is_string($reference) || trim($reference) === '') {
+                $this->logger->warning('Payment recovery: successful payment carries no reference, not recording', [
+                    'lpaId'            => $lpa->id,
+                    'gatewayReference' => $gatewayReference,
+                ]);
+
+                return false;
+            }
+
+            if (!$this->recordSuccessfulPayment($lpa, $govPayPayment)) {
+                return false;
+            }
+        } catch (Throwable $e) {
+            $this->logger->warning('Payment recovery: could not check or record the outstanding payment', [
+                'lpaId'            => $lpa->id,
+                'gatewayReference' => $gatewayReference,
+                'exception'        => $e,
+            ]);
+
+            return false;
+        }
+
+        $this->logger->warning('Payment recovery: recorded a completed GOV.UK Pay payment that was never saved', [
+            'lpaId'            => $lpa->id,
+            'gatewayReference' => $gatewayReference,
+            'paymentReference' => $lpa->payment->reference,
+        ]);
+
+        return true;
+    }
+
+    public function recordSuccessfulPayment(Lpa $lpa, GovPayPayment $govPayPayment): bool
+    {
+        $lpa->payment->method    = Payment::PAYMENT_TYPE_CARD;
+        $lpa->payment->reference = $govPayPayment->reference;
+        $lpa->payment->date      = new DateTime();
+
+        $govPayEmail = $govPayPayment->email ?? null;
+
+        $lpa->payment->email = is_string($govPayEmail) && trim($govPayEmail) !== ''
+            ? new EmailAddress(['address' => strtolower(trim($govPayEmail))])
+            : null;
+
+        $result = $this->lpaApplicationService->updateApplication($lpa->id, ['payment' => $lpa->payment->toArray()]);
+
+        if ($result === false) {
+            $this->logger->critical('PAYMENT RECORDING FAILED — payment taken but LPA not updated', [
+                'lpaId'            => $lpa->id,
+                'gatewayReference' => $lpa->payment->gatewayReference,
+                'govpay_status'    => $govPayPayment->state->status ?? 'unknown',
+                'has_email'        => $lpa->payment->email !== null,
+            ]);
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/service-front/src/App/src/Service/Payment/CardPayments.php
+++ b/service-front/src/App/src/Service/Payment/CardPayments.php
@@ -38,23 +38,11 @@ class CardPayments
     {
         $payment = $lpa->payment;
 
-        if (!$payment instanceof Payment) {
-            return false;
-        }
-
-        if (!is_string($payment->gatewayReference) || trim($payment->gatewayReference) === '') {
-            return false;
-        }
-
-        if ($payment->date !== null || $payment->method !== null) {
-            return false;
-        }
-
-        if ($lpa->locked === true || $lpa->completedAt !== null) {
-            return false;
-        }
-
-        return $lpa->hasFinishedCreation();
+        rreturn $payment instanceof Payment
+            && is_string($payment->gatewayReference) && trim($payment->gatewayReference) !== ''
+            && $payment->date === null && $payment->method === null
+            && $lpa->locked !== true && $lpa->completedAt === null
+            && $lpa->hasFinishedCreation();
     }
 
     public function recoverCompletedPayment(Lpa $lpa): bool

--- a/service-front/test/AppTest/Handler/Lpa/CheckoutIndexHandlerTest.php
+++ b/service-front/test/AppTest/Handler/Lpa/CheckoutIndexHandlerTest.php
@@ -9,6 +9,10 @@ use App\Middleware\RequestAttribute;
 use App\Model\FormFlowChecker;
 use App\Service\Lpa\Application as LpaApplicationService;
 use App\Service\Lpa\Communication;
+use App\Service\Payment\CardPayments;
+use App\Service\Payment\GovPay\Client as GovPayClient;
+use App\Service\Payment\GovPay\Exception\PayException;
+use App\Service\Payment\GovPay\Response\Payment as GovPayPayment;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Laminas\Diactoros\ServerRequest;
@@ -23,6 +27,7 @@ use Mezzio\Helper\UrlHelper;
 use Mezzio\Template\TemplateRendererInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class CheckoutIndexHandlerTest extends TestCase
 {
@@ -31,6 +36,8 @@ class CheckoutIndexHandlerTest extends TestCase
     private LpaApplicationService&MockObject $lpaApplicationService;
     private Communication&MockObject $communicationService;
     private UrlHelper&MockObject $urlHelper;
+    private GovPayClient&MockObject $paymentClient;
+    private LoggerInterface&MockObject $logger;
     private CheckoutIndexHandler $handler;
 
     protected function setUp(): void
@@ -41,12 +48,20 @@ class CheckoutIndexHandlerTest extends TestCase
         $this->communicationService = $this->createMock(Communication::class);
         $this->urlHelper = $this->createMock(UrlHelper::class);
 
+        $this->paymentClient = $this->createMock(GovPayClient::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
         $this->handler = new CheckoutIndexHandler(
             $this->renderer,
             $this->formElementManager,
             $this->lpaApplicationService,
             $this->communicationService,
             $this->urlHelper,
+            new CardPayments(
+                $this->paymentClient,
+                $this->lpaApplicationService,
+                $this->logger,
+            ),
         );
     }
 
@@ -55,6 +70,18 @@ class CheckoutIndexHandlerTest extends TestCase
         $lpa = FixturesData::getPfLpa();
         $lpa->payment = new Payment();
         Calculator::calculate($lpa);
+
+        return $lpa;
+    }
+
+    private function createStrandedPaymentLpa(): Lpa
+    {
+        $lpa = $this->createCompleteLpa();
+
+        $lpa->payment->gatewayReference = 'pay-ref-123';
+        $lpa->locked      = false;
+        $lpa->lockedAt    = null;
+        $lpa->completedAt = null;
 
         return $lpa;
     }
@@ -161,5 +188,94 @@ class CheckoutIndexHandlerTest extends TestCase
         $response = $this->handler->handle($this->createRequest('POST', $lpa));
 
         $this->assertInstanceOf(HtmlResponse::class, $response);
+    }
+
+    public function testGovPayIsNotContactedForAnLpaWithNoPaymentInFlight(): void
+    {
+        $lpa = $this->createCompleteLpa();
+        $this->mockBlankForm();
+
+        $this->paymentClient->expects($this->never())->method('getPayment');
+
+        $this->urlHelper->method('generate')->willReturn('/lpa/91333263035/checkout/pay');
+        $this->renderer->method('render')->willReturn('html');
+
+        $this->assertInstanceOf(HtmlResponse::class, $this->handler->handle($this->createRequest('GET', $lpa)));
+    }
+
+    public function testAStrandedPaymentIsRecoveredAndTheUserIsSentToTheCompletedLpa(): void
+    {
+        $lpa = $this->createStrandedPaymentLpa();
+
+        $this->paymentClient->expects($this->once())
+            ->method('getPayment')
+            ->with('pay-ref-123')
+            ->willReturn(new GovPayPayment((array) json_decode((string) json_encode([
+                'payment_id' => 'pay-ref-123',
+                'reference'  => 'A12345678901', // pragma: allowlist secret
+                'email'      => 'payer@example.org',
+                'state'      => ['status' => 'success', 'finished' => true],
+            ]))));
+
+        $this->lpaApplicationService->expects($this->once())
+            ->method('updateApplication')
+            ->willReturn($lpa);
+
+        $this->lpaApplicationService->expects($this->once())
+            ->method('lockLpa')
+            ->with($lpa)
+            ->willReturn(true);
+
+        $this->communicationService->expects($this->once())
+            ->method('sendRegistrationCompleteEmail')
+            ->with($lpa)
+            ->willReturn(true);
+
+        $this->urlHelper->expects($this->once())
+            ->method('generate')
+            ->with('lpa/complete', ['lpa-id' => $lpa->id])
+            ->willReturn('/lpa/' . $lpa->id . '/complete');
+
+        $this->renderer->expects($this->never())->method('render');
+
+        $response = $this->handler->handle($this->createRequest('GET', $lpa));
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('/lpa/' . $lpa->id . '/complete', $response->getHeaderLine('location'));
+    }
+
+    public function testAnUnpaidGatewayReferenceStillShowsTheCheckoutPage(): void
+    {
+        $lpa = $this->createStrandedPaymentLpa();
+        $this->mockBlankForm();
+
+        $this->paymentClient->expects($this->once())
+            ->method('getPayment')
+            ->willReturn(new GovPayPayment((array) json_decode((string) json_encode([
+                'payment_id' => 'pay-ref-123',
+                'state'      => ['status' => 'created', 'finished' => false],
+            ]))));
+
+        $this->lpaApplicationService->expects($this->never())->method('updateApplication');
+        $this->lpaApplicationService->expects($this->never())->method('lockLpa');
+
+        $this->urlHelper->method('generate')->willReturn('/lpa/91333263035/checkout/pay');
+        $this->renderer->expects($this->once())->method('render')->willReturn('html');
+
+        $this->assertInstanceOf(HtmlResponse::class, $this->handler->handle($this->createRequest('GET', $lpa)));
+    }
+
+    public function testAnUnreachableGovPayStillShowsTheCheckoutPage(): void
+    {
+        $lpa = $this->createStrandedPaymentLpa();
+        $this->mockBlankForm();
+
+        $this->paymentClient->method('getPayment')
+            ->willThrowException(new PayException('GOV.UK Pay unreachable', 503));
+
+        $this->urlHelper->method('generate')->willReturn('/lpa/91333263035/checkout/pay');
+        $this->renderer->expects($this->once())->method('render')->willReturn('html');
+
+        $this->assertInstanceOf(HtmlResponse::class, $this->handler->handle($this->createRequest('GET', $lpa)));
     }
 }

--- a/service-front/test/AppTest/Handler/Lpa/CheckoutPayHandlerTest.php
+++ b/service-front/test/AppTest/Handler/Lpa/CheckoutPayHandlerTest.php
@@ -11,6 +11,7 @@ use App\Middleware\RequestAttribute;
 use App\Model\FormFlowChecker;
 use App\Service\Lpa\Application as LpaApplicationService;
 use App\Service\Lpa\Communication;
+use App\Service\Payment\CardPayments;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Laminas\Diactoros\ServerRequest;
 use Laminas\Form\Element\Submit;
@@ -46,13 +47,19 @@ class CheckoutPayHandlerTest extends TestCase
         $this->urlHelper = $this->createMock(UrlHelper::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
+        $cardPayments = new CardPayments(
+            $this->paymentClient,
+            $this->lpaApplicationService,
+            $this->logger,
+        );
+
         $this->handler = new CheckoutPayHandler(
             $this->formElementManager,
             $this->lpaApplicationService,
             $this->communicationService,
             $this->paymentClient,
             $this->urlHelper,
-            $this->logger,
+            $cardPayments,
         );
     }
 

--- a/service-front/test/AppTest/Handler/Lpa/CheckoutPayResponseHandlerTest.php
+++ b/service-front/test/AppTest/Handler/Lpa/CheckoutPayResponseHandlerTest.php
@@ -11,6 +11,7 @@ use App\Middleware\RequestAttribute;
 use App\Model\FormFlowChecker;
 use App\Service\Lpa\Application as LpaApplicationService;
 use App\Service\Lpa\Communication;
+use App\Service\Payment\CardPayments;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Laminas\Diactoros\ServerRequest;
@@ -49,6 +50,12 @@ class CheckoutPayResponseHandlerTest extends TestCase
         $this->renderer = $this->createMock(TemplateRendererInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
+        $cardPayments = new CardPayments(
+            $this->paymentClient,
+            $this->lpaApplicationService,
+            $this->logger,
+        );
+
         $this->handler = new CheckoutPayResponseHandler(
             $this->formElementManager,
             $this->lpaApplicationService,
@@ -57,6 +64,7 @@ class CheckoutPayResponseHandlerTest extends TestCase
             $this->urlHelper,
             $this->renderer,
             $this->logger,
+            $cardPayments,
         );
     }
 

--- a/service-front/test/AppTest/Service/Payment/CardPaymentsTest.php
+++ b/service-front/test/AppTest/Service/Payment/CardPaymentsTest.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Service\Payment;
+
+use App\Service\Lpa\Application as LpaApplicationService;
+use App\Service\Payment\CardPayments;
+use App\Service\Payment\GovPay\Client as GovPayClient;
+use App\Service\Payment\GovPay\Exception\PayException as GovPayException;
+use App\Service\Payment\GovPay\Response\Payment as GovPayPayment;
+use DateTime;
+use MakeShared\DataModel\Lpa\Document\Document;
+use MakeShared\DataModel\Lpa\Lpa;
+use MakeShared\DataModel\Lpa\Payment\Payment;
+use MakeSharedTest\DataModel\FixturesData;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+class CardPaymentsTest extends TestCase
+{
+    private const string GATEWAY_REFERENCE = '9aphnjaet2k20e31ue3272m28i';
+
+    private GovPayClient&MockObject $paymentClient;
+    private LpaApplicationService&MockObject $lpaApplicationService;
+    private LoggerInterface&MockObject $logger;
+    private CardPayments $cardPayments;
+
+    protected function setUp(): void
+    {
+        $this->paymentClient         = $this->createMock(GovPayClient::class);
+        $this->lpaApplicationService = $this->createMock(LpaApplicationService::class);
+        $this->logger                = $this->createMock(LoggerInterface::class);
+
+        $this->cardPayments = new CardPayments(
+            $this->paymentClient,
+            $this->lpaApplicationService,
+            $this->logger,
+        );
+    }
+
+    private function makeStrandedLpa(): Lpa
+    {
+        $lpa = FixturesData::getPfLpa();
+
+        $lpa->payment                   = new Payment();
+        $lpa->payment->amount           = 92;
+        $lpa->payment->gatewayReference = self::GATEWAY_REFERENCE;
+
+        $lpa->locked      = false;
+        $lpa->lockedAt    = null;
+        $lpa->completedAt = null;
+
+        return $lpa;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function makeGovPayPayment(array $data): GovPayPayment
+    {
+        return new GovPayPayment((array) json_decode((string) json_encode($data)));
+    }
+
+    private function makeSuccessfulGovPayPayment(string $email = 'payer@example.org'): GovPayPayment
+    {
+        return $this->makeGovPayPayment([
+            'payment_id' => self::GATEWAY_REFERENCE,
+            'reference'  => 'A12345678901', // pragma: allowlist secret
+            'email'      => $email,
+            'state'      => ['status' => 'success', 'finished' => true],
+        ]);
+    }
+
+    public function testStrandedLpaIsAwaitingConfirmation(): void
+    {
+        $this->assertTrue($this->cardPayments->isAwaitingConfirmation($this->makeStrandedLpa()));
+    }
+
+    public function testLpaWithNoPaymentObjectIsNotAwaitingConfirmation(): void
+    {
+        $lpa = $this->makeStrandedLpa();
+        $lpa->payment = null;
+
+        $this->assertFalse($this->cardPayments->isAwaitingConfirmation($lpa));
+    }
+
+    /**
+     * @return array<string, array{string|null}>
+     */
+    public static function emptyGatewayReferenceProvider(): array
+    {
+        return [
+            'null'       => [null],
+            'empty'      => [''],
+            'whitespace' => ['   '],
+        ];
+    }
+
+    #[DataProvider('emptyGatewayReferenceProvider')]
+    public function testLpaWithNoUsableGatewayReferenceIsNotAwaitingConfirmation(?string $reference): void
+    {
+        $lpa = $this->makeStrandedLpa();
+        $lpa->payment->gatewayReference = $reference;
+
+        $this->assertFalse($this->cardPayments->isAwaitingConfirmation($lpa));
+    }
+
+    public function testLpaWithAPaymentDateIsNotAwaitingConfirmation(): void
+    {
+        $lpa = $this->makeStrandedLpa();
+        $lpa->payment->date = new DateTime();
+
+        $this->assertFalse($this->cardPayments->isAwaitingConfirmation($lpa));
+    }
+
+    public function testLpaPaidByChequeIsNotAwaitingConfirmation(): void
+    {
+        $lpa = $this->makeStrandedLpa();
+        $lpa->payment->method = Payment::PAYMENT_TYPE_CHEQUE;
+
+        $this->assertFalse($this->cardPayments->isAwaitingConfirmation($lpa));
+    }
+
+    public function testLockedLpaIsNotAwaitingConfirmation(): void
+    {
+        $lpa = $this->makeStrandedLpa();
+        $lpa->locked = true;
+
+        $this->assertFalse($this->cardPayments->isAwaitingConfirmation($lpa));
+    }
+
+    public function testCompletedLpaIsNotAwaitingConfirmation(): void
+    {
+        $lpa = $this->makeStrandedLpa();
+        $lpa->completedAt = new DateTime();
+
+        $this->assertFalse($this->cardPayments->isAwaitingConfirmation($lpa));
+    }
+
+    public function testUnfinishedInstrumentIsNotAwaitingConfirmation(): void
+    {
+        $lpa = new Lpa();
+        $lpa->id       = 91333263035;
+        $lpa->document = new Document();
+        $lpa->payment  = new Payment();
+        $lpa->payment->gatewayReference = self::GATEWAY_REFERENCE;
+
+        $this->assertFalse($lpa->hasFinishedCreation(), 'guard precondition');
+        $this->assertFalse($this->cardPayments->isAwaitingConfirmation($lpa));
+    }
+
+    public function testNoGovPayCallIsMadeWhenTheLpaIsNotStranded(): void
+    {
+        $lpa = $this->makeStrandedLpa();
+        $lpa->payment->date = new DateTime();
+
+        $this->paymentClient->expects($this->never())->method('getPayment');
+        $this->lpaApplicationService->expects($this->never())->method('updateApplication');
+
+        $this->assertFalse($this->cardPayments->recoverCompletedPayment($lpa));
+    }
+
+    public function testSuccessfulPaymentIsRecordedAndReported(): void
+    {
+        $lpa = $this->makeStrandedLpa();
+
+        $this->paymentClient->expects($this->once())
+            ->method('getPayment')
+            ->with(self::GATEWAY_REFERENCE)
+            ->willReturn($this->makeSuccessfulGovPayPayment());
+
+        $recorded = null;
+
+        $this->lpaApplicationService->expects($this->once())
+            ->method('updateApplication')
+            ->with(
+                $lpa->id,
+                $this->callback(function (array $data) use (&$recorded): bool {
+                    $recorded = $data['payment'] ?? null;
+                    return is_array($recorded);
+                })
+            )
+            ->willReturn($lpa);
+
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('recorded a completed GOV.UK Pay payment'));
+
+        $this->assertTrue($this->cardPayments->recoverCompletedPayment($lpa));
+
+        $this->assertSame(Payment::PAYMENT_TYPE_CARD, $recorded['method']);
+        $this->assertSame('A12345678901', $recorded['reference']); // pragma: allowlist secret
+        $this->assertNotNull($recorded['date']);
+        $this->assertSame(self::GATEWAY_REFERENCE, $recorded['gatewayReference']);
+
+        $this->assertSame(Payment::PAYMENT_TYPE_CARD, $lpa->payment->method);
+        $this->assertInstanceOf(DateTime::class, $lpa->payment->date);
+    }
+
+    public function testNothingIsRecordedWhenGovPayHasNoRecordOfThePayment(): void
+    {
+        $lpa = $this->makeStrandedLpa();
+
+        $this->paymentClient->method('getPayment')->willReturn(null);
+
+        $this->lpaApplicationService->expects($this->never())->method('updateApplication');
+        $this->logger->expects($this->never())->method('warning');
+
+        $this->assertFalse($this->cardPayments->recoverCompletedPayment($lpa));
+        $this->assertNull($lpa->payment->date);
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public static function unsuccessfulStatusProvider(): array
+    {
+        return [
+            'created'   => ['created', false],
+            'started'   => ['started', false],
+            'failed'    => ['failed', true],
+            'cancelled' => ['cancelled', true],
+            'error'     => ['error', true],
+        ];
+    }
+
+    #[DataProvider('unsuccessfulStatusProvider')]
+    public function testNothingIsRecordedWhenThePaymentDidNotSucceed(string $status, bool $finished): void
+    {
+        $lpa = $this->makeStrandedLpa();
+
+        $this->paymentClient->method('getPayment')->willReturn($this->makeGovPayPayment([
+            'payment_id' => self::GATEWAY_REFERENCE,
+            'state'      => ['status' => $status, 'finished' => $finished],
+        ]));
+
+        $this->lpaApplicationService->expects($this->never())->method('updateApplication');
+        $this->logger->expects($this->never())->method('warning');
+
+        $this->assertFalse($this->cardPayments->recoverCompletedPayment($lpa));
+        $this->assertNull($lpa->payment->method);
+        $this->assertNull($lpa->payment->date);
+    }
+
+    public function testAPaymentWithNoReferenceIsNotRecorded(): void
+    {
+        $lpa = $this->makeStrandedLpa();
+
+        $this->paymentClient->method('getPayment')->willReturn($this->makeGovPayPayment([
+            'payment_id' => self::GATEWAY_REFERENCE,
+            'email'      => 'payer@example.org',
+            'state'      => ['status' => 'success', 'finished' => true],
+        ]));
+
+        $this->lpaApplicationService->expects($this->never())->method('updateApplication');
+
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('carries no reference'));
+
+        $this->assertFalse($this->cardPayments->recoverCompletedPayment($lpa));
+        $this->assertNull($lpa->payment->method);
+        $this->assertNull($lpa->payment->date);
+    }
+
+    /**
+     * @return array<string, array{\Throwable}>
+     */
+    public static function govPayFailureProvider(): array
+    {
+        return [
+            "pay transport error" => [new GovPayException("GOV.UK Pay unreachable", 503)],
+            'unexpected'    => [new RuntimeException('connection reset')],
+        ];
+    }
+
+    #[DataProvider('govPayFailureProvider')]
+    public function testAGovPayFailureLeavesTheLpaUntouched(\Throwable $thrown): void
+    {
+        $lpa = $this->makeStrandedLpa();
+
+        $this->paymentClient->method('getPayment')->willThrowException($thrown);
+
+        $this->lpaApplicationService->expects($this->never())->method('updateApplication');
+
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('Payment recovery'));
+
+        $this->assertFalse($this->cardPayments->recoverCompletedPayment($lpa));
+        $this->assertNull($lpa->payment->date);
+    }
+
+    public function testAFailedApiUpdateIsReportedAsCriticalAndDoesNotCompleteCheckout(): void
+    {
+        $lpa = $this->makeStrandedLpa();
+
+        $this->paymentClient->method('getPayment')->willReturn($this->makeSuccessfulGovPayPayment());
+        $this->lpaApplicationService->method('updateApplication')->willReturn(false);
+
+        $this->logger->expects($this->once())
+            ->method('critical')
+            ->with($this->stringContains('PAYMENT RECORDING FAILED'));
+
+        $this->logger->expects($this->never())->method('warning');
+
+        $this->assertFalse($this->cardPayments->recoverCompletedPayment($lpa));
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function emailNormalisationProvider(): array
+    {
+        return [
+            'mixed case'            => ['Payer@Example.ORG', 'payer@example.org'],
+            'surrounding space'     => ['  payer@example.org ', 'payer@example.org'],
+        ];
+    }
+
+    #[DataProvider('emailNormalisationProvider')]
+    public function testGovPayEmailIsNormalisedBeforeItIsStored(string $given, string $expected): void
+    {
+        $lpa = $this->makeStrandedLpa();
+
+        $this->lpaApplicationService->method('updateApplication')->willReturn($lpa);
+
+        $this->assertTrue($this->cardPayments->recordSuccessfulPayment(
+            $lpa,
+            $this->makeSuccessfulGovPayPayment($given)
+        ));
+
+        $this->assertSame($expected, (string) $lpa->payment->email);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function unusableEmailProvider(): array
+    {
+        return [
+            'empty'      => [''],
+            'whitespace' => ['   '],
+        ];
+    }
+
+    #[DataProvider('unusableEmailProvider')]
+    public function testAnUnusableGovPayEmailIsStoredAsNull(string $given): void
+    {
+        $lpa = $this->makeStrandedLpa();
+
+        $this->lpaApplicationService->method('updateApplication')->willReturn($lpa);
+
+        $this->cardPayments->recordSuccessfulPayment($lpa, $this->makeSuccessfulGovPayPayment($given));
+
+        $this->assertNull($lpa->payment->email);
+    }
+
+    public function testAMissingGovPayEmailIsStoredAsNull(): void
+    {
+        $lpa = $this->makeStrandedLpa();
+
+        $this->lpaApplicationService->method('updateApplication')->willReturn($lpa);
+
+        $this->cardPayments->recordSuccessfulPayment($lpa, $this->makeGovPayPayment([
+            'payment_id' => self::GATEWAY_REFERENCE,
+            'reference'  => 'A12345678901', // pragma: allowlist secret
+            'state'      => ['status' => 'success', 'finished' => true],
+        ]));
+
+        $this->assertNull($lpa->payment->email);
+    }
+}

--- a/shared/module/MakeShared/src/DataModel/Lpa/Payment/Payment.php
+++ b/shared/module/MakeShared/src/DataModel/Lpa/Payment/Payment.php
@@ -21,7 +21,7 @@ class Payment extends AbstractData
     public const PAYMENT_TYPE_CHEQUE = 'cheque';
 
     /**
-     * @var string The payment method used (or that will be used).
+     * @var string|null The payment method used (or that will be used).
      */
     protected $method;
 
@@ -49,7 +49,7 @@ class Payment extends AbstractData
     protected $gatewayReference;
 
     /**
-     * @var DateTime Date the payment was made.
+     * @var DateTime|null Date the payment was made.
      */
     protected $date;
 
@@ -154,7 +154,7 @@ class Payment extends AbstractData
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getMethod()
     {
@@ -249,7 +249,7 @@ class Payment extends AbstractData
     }
 
     /**
-     * @return DateTime
+     * @return DateTime|null
      */
     public function getDate()
     {

--- a/tests/python-api-client/createLpa.py
+++ b/tests/python-api-client/createLpa.py
@@ -45,6 +45,7 @@ payment_choices = [
     "on-benefits",
     "normal-pay-by-cheque",
     "low-income-claiming-reduction",
+    "card-started-not-recorded",
 ]
 parser.add_argument("-pa", type=str, choices=payment_choices, help="Set Payment")
 
@@ -109,4 +110,6 @@ if args.pa:
         setPaymentLowIncomeClaimingReduction(lpaId)
     elif args.pa == "on-benefits":
         setPaymentOnBenefits(lpaId)
+    elif args.pa == "card-started-not-recorded":
+        setPaymentCardStartedButNotRecorded(lpaId)
 print(lpaId)

--- a/tests/python-api-client/lpaapi.py
+++ b/tests/python-api-client/lpaapi.py
@@ -480,6 +480,7 @@ def setPayment(
     reducedFeeReceivesBenefits=None,
     reducedFeeLowIncome=None,
     reducedFeeUniversalCredit=None,
+    gatewayReference=None,
 ):
     # default is normal fee, without cheque, used by HW test
     payment = {
@@ -487,7 +488,7 @@ def setPayment(
         "email": None,
         "amount": amount,
         "reference": None,
-        "gatewayReference": None,
+        "gatewayReference": gatewayReference,
         "date": None,
         "reducedFeeReceivesBenefits": reducedFeeReceivesBenefits,
         "reducedFeeAwardedDamages": None,
@@ -513,6 +514,10 @@ def setPaymentLowIncomeClaimingReduction(lpaId):
 
 def setPaymentLowIncomeNotClaimingReduction(lpaId):
     setPayment(lpaId, amount=41)
+
+
+def setPaymentCardStartedButNotRecorded(lpaId, gatewayReference="mockpaystrandedref"):
+    setPayment(lpaId, amount=92, gatewayReference=gatewayReference)
 
 
 def setInstruction(lpaId, instruction="Some instructions"):


### PR DESCRIPTION
LPAL-2393

If a user completes payment and never returns to the service (maybe closing the tab as soon as Pay finishes), the redirect that records the payment never happens. The payment is taken but the LPA keeps only a gatewayReference - no payment record, unlocked, and the user can't proceed.

Added payment recovery which now happens on the checkout page itself, so the user only has to open their LPA. Clicking "Continue" from the dashboard routes through /lpa/{id} > lpa/checkout, so both entry paths are covered by one handler.  

Added card payment service which also has re-usable functions
Added Cypress test which uses @CheckoutPaymentGateway and used mock-pay.  Not in dc-up so needs to be re-built 
Added logging for both paths