### PR TITLE
Add Telemetry back in to frontend container

### DIFF
--- a/service-front/config/autoload/dependencies.global.php
+++ b/service-front/config/autoload/dependencies.global.php
@@ -53,6 +53,8 @@ use Laminas\Stratigility\Middleware\ErrorHandler;
 use MakeShared\Logging\LoggerFactory;
 use MakeShared\Logging\RequestLoggingMiddleware;
 use MakeShared\Logging\RequestLoggingMiddlewareFactory;
+use MakeShared\Telemetry\Exporter\ExporterFactory;
+use MakeShared\Telemetry\Tracer;
 use Mezzio\Container\ErrorHandlerFactory;
 use Mezzio\Csrf\CsrfGuardFactoryInterface;
 use Mezzio\Csrf\CsrfMiddleware;
@@ -220,6 +222,12 @@ return [
             AuthenticationService::class                => AuthenticationServiceFactory::class,
             LoggerInterface::class                      => LoggerFactory::class,
             RequestLoggingMiddleware::class             => RequestLoggingMiddlewareFactory::class,
+            Tracer::class => function ($sm) {
+                $telemetryConfig = $sm->get('config')['telemetry'];
+                $exporterFactory = new ExporterFactory($sm);
+
+                return Tracer::create($exporterFactory, $telemetryConfig);
+            },
         ],
     ],
     'api_client'        => [
@@ -237,6 +245,19 @@ return [
     'processing-status' => [
         'track-from-date'                      => getenv('OPG_LPA_FRONT_TRACK_FROM_DATE') ?: '2019-04-01',
         'expected-working-days-before-receipt' => 15,
+    ],
+    'telemetry' => [
+        // fraction of requests which will be sampled, e.g. 0.05
+        'requestsSampledFraction' => getenv('OPG_LPA_TELEMETRY_REQUESTS_SAMPLED_FRACTION') ?: null,
+
+        'exporter' => [
+            'serviceName' => 'service-front',
+
+            // if this value is null, a console exporter will be used;
+            // for a standard XRay (over UDP) exporter, use host='localhost' and port=2000
+            'host' => getenv('OPG_LPA_TELEMETRY_HOST') ?: null,
+            'port' => getenv('OPG_LPA_TELEMETRY_PORT') ?: null,
+        ],
     ],
     'email'             => [
         'notify'              => [

--- a/service-front/config/pipeline.php
+++ b/service-front/config/pipeline.php
@@ -10,6 +10,7 @@ use App\Middleware\IdentityTokenRefreshMiddleware;
 use App\Middleware\PersistentSessionDetailsMiddleware;
 use App\Middleware\RegisterSessionSaveHandlerMiddleware;
 use App\Middleware\RouteNameMiddleware;
+use App\Middleware\TelemetryMiddleware;
 use App\Middleware\TermsAndConditionsMiddleware;
 use App\Middleware\UserDetailsMiddleware;
 use App\Middleware\UserIdMiddleware;
@@ -32,6 +33,7 @@ use Psr\Container\ContainerInterface;
 
 return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container): void {
     $app->pipe(ErrorHandler::class);
+    $app->pipe(TelemetryMiddleware::class);
     $app->pipe(ServerUrlMiddleware::class);
     $app->pipe(RegisterSessionSaveHandlerMiddleware::class);
     $app->pipe(SessionMiddleware::class);

--- a/service-front/src/App/src/Middleware/TelemetryMiddleware.php
+++ b/service-front/src/App/src/Middleware/TelemetryMiddleware.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use MakeShared\Telemetry\Tracer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * A no-op middleware required solely to satisfy the Mezzio\Router\Route constructor,
+ * which demands a MiddlewareInterface instance. RouteResult constructs a Route object
+ * in order to produce a RouteResult, but the Route's middleware is never invoked.
+ */
+class TelemetryMiddleware implements MiddlewareInterface
+{
+    public function __construct(private readonly Tracer $tracer)
+    {
+    }
+
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler
+    ): ResponseInterface {
+        $this->tracer->startRootSegment();
+
+        try {
+            return $handler->handle($request);
+        } finally {
+            $this->tracer->stopRootSegment();
+        }
+    }
+}

--- a/service-front/src/App/src/Middleware/TelemetryMiddleware.php
+++ b/service-front/src/App/src/Middleware/TelemetryMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Middleware;
 
+use MakeShared\Telemetry\Attribute\Http;
 use MakeShared\Telemetry\Tracer;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -25,11 +26,17 @@ class TelemetryMiddleware implements MiddlewareInterface
         ServerRequestInterface $request,
         RequestHandlerInterface $handler
     ): ResponseInterface {
-        $this->tracer->startRootSegment();
+        $rootSegment = $this->tracer->startRootSegment();
 
         try {
-            return $handler->handle($request);
+            $response = $handler->handle($request);
+            return $response;
         } finally {
+            if ($rootSegment !== null && isset($response)) {
+                $httpAttribute = new Http($request, $response);
+                $rootSegment->setAttribute('http', $httpAttribute);
+            }
+
             $this->tracer->stopRootSegment();
         }
     }

--- a/service-front/src/App/src/Service/ApiClient/ApiClientFactory.php
+++ b/service-front/src/App/src/Service/ApiClient/ApiClientFactory.php
@@ -7,6 +7,7 @@ namespace App\Service\ApiClient;
 use Http\Adapter\Guzzle7\Client as GuzzleClient;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use MakeShared\Telemetry\Tracer;
 
 class ApiClientFactory
 {
@@ -15,11 +16,13 @@ class ApiClientFactory
         $config = $container->get('config');
         $apiUri = $config['api_client']['api_uri'] ?? '';
 
+        $tracer = $container->get(Tracer::class);
+
         return new Client(
             new GuzzleClient(),
             (string) $apiUri,
             [],
-            null,
+            $tracer,
             $container->get(LoggerInterface::class),
         );
     }

--- a/shared/module/MakeShared/src/Telemetry/Attribute/Http.php
+++ b/shared/module/MakeShared/src/Telemetry/Attribute/Http.php
@@ -7,16 +7,15 @@ namespace MakeShared\Telemetry\Attribute;
 use JsonSerializable;
 use Laminas\Http\Request;
 use Laminas\Http\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
 
 class Http implements JsonSerializable
 {
-    private Request $request;
-    private Response $response;
-
-    public function __construct(Request $request, Response $response)
-    {
-        $this->request = $request;
-        $this->response = $response;
+    public function __construct(
+        private readonly Request|RequestInterface $request,
+        private readonly Response|ResponseInterface $response
+    ) {
     }
 
     public function jsonSerialize(): mixed

--- a/shared/module/MakeShared/src/Telemetry/Exporter/ExporterFactory.php
+++ b/shared/module/MakeShared/src/Telemetry/Exporter/ExporterFactory.php
@@ -3,6 +3,7 @@
 namespace MakeShared\Telemetry\Exporter;
 
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Psr\Log\LoggerInterface;
 
 class ExporterFactory
 {
@@ -13,14 +14,14 @@ class ExporterFactory
     public function createLogExporter(): ExporterInterface
     {
         $exporter = $this->container->get(LogExporter::class);
-        $exporter->setLogger($this->container->get('Logger'));
+        $exporter->setLogger($this->container->get(LoggerInterface::class));
         return $exporter;
     }
 
     public function createXRayExporter(string $host, int $port): ExporterInterface
     {
         $exporter = $this->container->build(XrayExporter::class, [$host,$port]);
-        $exporter->setLogger($this->container->get('Logger'));
+        $exporter->setLogger($this->container->get(LoggerInterface::class));
         return $exporter;
     }
 }

--- a/shared/module/MakeShared/src/Telemetry/Tracer.php
+++ b/shared/module/MakeShared/src/Telemetry/Tracer.php
@@ -155,6 +155,8 @@ class Tracer
             $sampled = isset($traceHeader['Sampled']) && $traceHeader['Sampled'] === '1';
         }
 
+        $attributes['origin'] = 'AWS::ECS::Container';
+
         $this->rootSegment = new Segment(
             $this->serviceName,
             $traceHeader['Root'],


### PR DESCRIPTION
## Purpose

During the move to mezzio we turned off telemetry in the frontend container, which also meant the API container stopped reporting anything. Turn it back on so we can monitor performance.

Fixes LPAL-2395 #patch

## Approach

- Middleware to start and close the root segment
- Dependency configuration to build the Tracer
- Pass the tracer to the API client to propagate context
- Use PSR classes rather than aliases in the ExporterFactory

