### PR TITLE
LPAL-1960 - reorder rules so that no user agent happens much later

### DIFF
--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -175,35 +175,6 @@ resource "aws_wafv2_web_acl" "main" {
   }
 
   rule {
-    name     = "AWS-AWSManagedRulesCommonRuleSet"
-    priority = 30
-
-    override_action {
-      none {}
-    }
-
-    statement {
-      managed_rule_group_statement {
-        name        = "AWSManagedRulesCommonRuleSet"
-        vendor_name = "AWS"
-
-        rule_action_override {
-          name = "NoUserAgent_HEADER"
-          action_to_use {
-            count {}
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "AWS-AWSManagedRulesCommonRuleSet"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
     name     = "AWS-AWSManagedRulesLinuxRuleSet"
     priority = 35
 
@@ -321,6 +292,35 @@ resource "aws_wafv2_web_acl" "main" {
     cloudwatch_metrics_enabled = true
     metric_name                = "${local.account_name}-${local.region_name}-web-acl"
     sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 70
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        rule_action_override {
+          name = "NoUserAgent_HEADER"
+          action_to_use {
+            count {}
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
   }
 }
 


### PR DESCRIPTION
## Purpose

Make common rule set run later in WAF rules, so that other rules apply first

Fixes LPAL-1960

## Approach

- Move common rule set to later in order