### PR TITLE
LPAL-2378 - Boundaried CI role for Terraform in product accounts

### DIFF
--- a/terraform/environment/.envrc
+++ b/terraform/environment/.envrc
@@ -1,5 +1,6 @@
 tfswitch
 export TF_VAR_default_role=operator
+export TF_VAR_boundaried_default_role=operator
 export TF_VAR_management_role=operator
 export TF_CLI_ARGS_init="-backend-config=\"assume_role={role_arn=\\\"arn:aws:iam::311462405659:role/operator\\\"}\" -upgrade -reconfigure"
 export TF_VAR_pagerduty_token=$(aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id pagerduty_api_key | jq -r .'SecretString')

--- a/terraform/environment/data_sources.tf
+++ b/terraform/environment/data_sources.tf
@@ -1,1 +1,5 @@
 data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy" "default_boundary" {
+  name = "opg-lpa-non-ci-boundary"
+}

--- a/terraform/environment/iam_ecs_cluster.tf
+++ b/terraform/environment/iam_ecs_cluster.tf
@@ -1,8 +1,9 @@
 # ECS Cluster Execution Role
 resource "aws_iam_role" "execution_role" {
-  name               = "${local.environment_name}-execution-role-ecs-cluster"
-  assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.shared_component_tag
+  name                 = "${local.environment_name}-execution-role-ecs-cluster"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_assume_policy.json
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
+  tags                 = local.shared_component_tag
 }
 
 data "aws_iam_policy_document" "ecs_assume_policy" {

--- a/terraform/environment/iam_ecs_task_roles.tf
+++ b/terraform/environment/iam_ecs_task_roles.tf
@@ -1,7 +1,3 @@
-data "aws_iam_policy" "default_boundary" {
-  name = "opg-lpa-non-ci-boundary"
-}
-
 //----------------
 // API IAM ECS task role
 

--- a/terraform/environment/iam_ecs_task_roles.tf
+++ b/terraform/environment/iam_ecs_task_roles.tf
@@ -1,10 +1,15 @@
+data "aws_iam_policy" "default_boundary" {
+  name = "opg-lpa-non-ci-boundary"
+}
+
 //----------------
 // API IAM ECS task role
 
 resource "aws_iam_role" "api_task_role" {
-  name               = "${local.environment_name}-api-task-role"
-  assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.api_component_tag
+  name                 = "${local.environment_name}-api-task-role"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_assume_policy.json
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
+  tags                 = local.api_component_tag
 }
 
 
@@ -13,9 +18,10 @@ resource "aws_iam_role" "api_task_role" {
 //----------------
 
 resource "aws_iam_role" "admin_task_role" {
-  name               = "${local.environment_name}-admin-task-role"
-  assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.admin_component_tag
+  name                 = "${local.environment_name}-admin-task-role"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_assume_policy.json
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
+  tags                 = local.admin_component_tag
 }
 
 //----------------
@@ -23,9 +29,10 @@ resource "aws_iam_role" "admin_task_role" {
 //----------------
 
 resource "aws_iam_role" "front_task_role" {
-  name               = "${local.environment_name}-front-task-role"
-  assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.front_component_tag
+  name                 = "${local.environment_name}-front-task-role"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_assume_policy.json
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
+  tags                 = local.front_component_tag
 
 }
 
@@ -33,26 +40,29 @@ resource "aws_iam_role" "front_task_role" {
 // PDF ECS task role
 
 resource "aws_iam_role" "pdf_task_role" {
-  name               = "${local.environment_name}-pdf-task-role"
-  assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.pdf_component_tag
+  name                 = "${local.environment_name}-pdf-task-role"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_assume_policy.json
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
+  tags                 = local.pdf_component_tag
 }
 
 
 //----------------
 // Seed ECS task role
 resource "aws_iam_role" "seeding_task_role" {
-  name               = "${local.environment_name}-seeding-task-role"
-  assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.seeding_component_tag
+  name                 = "${local.environment_name}-seeding-task-role"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_assume_policy.json
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
+  tags                 = local.seeding_component_tag
 }
 
 //----------------
 // Mock ECS task role
 resource "aws_iam_role" "mock_onelogin" {
-  name               = "${local.environment_name}-mock-onelogin-task-role"
-  assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.seeding_component_tag
+  name                 = "${local.environment_name}-mock-onelogin-task-role"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_assume_policy.json
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
+  tags                 = local.seeding_component_tag
 }
 
 //------------------------------------------------
@@ -70,9 +80,10 @@ data "aws_iam_policy_document" "cloudwatch_events_assume_policy" {
 }
 
 resource "aws_iam_role" "cloudwatch_events_ecs_role" {
-  name               = "${local.environment_name}-cloudwatch_events_ecs_cron"
-  assume_role_policy = data.aws_iam_policy_document.cloudwatch_events_assume_policy.json
-  tags               = local.api_component_tag
+  name                 = "${local.environment_name}-cloudwatch_events_ecs_cron"
+  assume_role_policy   = data.aws_iam_policy_document.cloudwatch_events_assume_policy.json
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
+  tags                 = local.api_component_tag
 }
 
 data "aws_iam_policy_document" "cloudwatch_events_role_policy" {

--- a/terraform/environment/iam_rds_proxy.tf
+++ b/terraform/environment/iam_rds_proxy.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_role" "rds_proxy" {
-  name               = lower("rds-proxy-${local.environment_name}")
-  assume_role_policy = data.aws_iam_policy_document.rds_proxy.json
+  name                 = lower("rds-proxy-${local.environment_name}")
+  assume_role_policy   = data.aws_iam_policy_document.rds_proxy.json
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
 }
 
 data "aws_iam_policy_document" "rds_proxy" {

--- a/terraform/environment/terraform.tf
+++ b/terraform/environment/terraform.tf
@@ -17,7 +17,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.boundaried_default_role}"
     session_name = "terraform-session"
   }
 
@@ -29,7 +29,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.boundaried_default_role}"
     session_name = "terraform-session"
   }
 
@@ -41,7 +41,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.boundaried_default_role}"
     session_name = "terraform-session"
   }
 
@@ -54,7 +54,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.boundaried_default_role}"
     session_name = "terraform-session"
   }
 
@@ -102,7 +102,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.boundaried_default_role}"
     session_name = "terraform-session"
   }
 }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -17,7 +17,7 @@ variable "boundaried_default_role" {
 }
 
 variable "management_role" {
-  default     = "opg-lpa-ci-boundary"
+  default     = "opg-lpa-ci"
   type        = string
   description = "The default role to use to create resources in the management account"
 }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -5,6 +5,12 @@ variable "pagerduty_token" {
 }
 
 variable "default_role" {
+  default     = "opg-lpa-ci"
+  type        = string
+  description = "The default role to use to create resources"
+}
+
+variable "boundaried_default_role" {
   default     = "opg-lpa-ci-boundary"
   type        = string
   description = "The default role to use to create resources"

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -5,13 +5,13 @@ variable "pagerduty_token" {
 }
 
 variable "default_role" {
-  default     = "opg-lpa-ci"
+  default     = "opg-lpa-ci-boundary"
   type        = string
   description = "The default role to use to create resources"
 }
 
 variable "management_role" {
-  default     = "opg-lpa-ci"
+  default     = "opg-lpa-ci-boundary"
   type        = string
   description = "The default role to use to create resources in the management account"
 }

--- a/terraform/region/aws_iam_backup_account_role.tf
+++ b/terraform/region/aws_iam_backup_account_role.tf
@@ -1,8 +1,7 @@
 resource "aws_iam_role" "make_cross_account_backup_role" {
-  provider             = aws.backup
-  name                 = "${local.environment_name}-make-cross-account-backup-role"
-  permissions_boundary = data.aws_iam_policy.default_boundary.arn
-  assume_role_policy   = data.aws_iam_policy_document.make-cross-account-backup-role-permissions.json
+  provider           = aws.backup
+  name               = "${local.environment_name}-make-cross-account-backup-role"
+  assume_role_policy = data.aws_iam_policy_document.make-cross-account-backup-role-permissions.json
 }
 
 resource "aws_iam_role_policy_attachment" "make_cross_account_backup_role" {

--- a/terraform/region/aws_iam_backup_account_role.tf
+++ b/terraform/region/aws_iam_backup_account_role.tf
@@ -1,7 +1,8 @@
 resource "aws_iam_role" "make_cross_account_backup_role" {
-  provider           = aws.backup
-  name               = "${local.environment_name}-make-cross-account-backup-role"
-  assume_role_policy = data.aws_iam_policy_document.make-cross-account-backup-role-permissions.json
+  provider             = aws.backup
+  name                 = "${local.environment_name}-make-cross-account-backup-role"
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
+  assume_role_policy   = data.aws_iam_policy_document.make-cross-account-backup-role-permissions.json
 }
 
 resource "aws_iam_role_policy_attachment" "make_cross_account_backup_role" {

--- a/terraform/region/aws_iam_backup_role.tf
+++ b/terraform/region/aws_iam_backup_role.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_role" "aurora_backup_role" {
-  name               = "aurora_cluster_backup_role"
-  assume_role_policy = data.aws_iam_policy_document.aurora_cluster_backup_role.json
+  name                 = "aurora_cluster_backup_role"
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
+  assume_role_policy   = data.aws_iam_policy_document.aurora_cluster_backup_role.json
 }
 
 resource "aws_iam_role_policy_attachment" "aurora_backup_role" {

--- a/terraform/region/aws_iam_ip_blocker_role.tf
+++ b/terraform/region/aws_iam_ip_blocker_role.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_role" "ip_blocker" {
-  assume_role_policy = data.aws_iam_policy_document.ip_blocker_policy.json
-  name               = "lambda-block-ips"
+  assume_role_policy   = data.aws_iam_policy_document.ip_blocker_policy.json
+  name                 = "lambda-block-ips"
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
 }
 
 data "aws_iam_policy_document" "ip_blocker_policy" {

--- a/terraform/region/aws_iam_rds_enhanced_monitoring_role.tf
+++ b/terraform/region/aws_iam_rds_enhanced_monitoring_role.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_role" "rds_enhanced_monitoring" {
-  name               = "rds-enhanced-monitoring"
-  assume_role_policy = data.aws_iam_policy_document.rds_enhanced_monitoring.json
+  name                 = "rds-enhanced-monitoring"
+  assume_role_policy   = data.aws_iam_policy_document.rds_enhanced_monitoring.json
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
   # tags               = local.db_component_tag
 }
 

--- a/terraform/region/aws_iam_vpc_flow_logs_role.tf
+++ b/terraform/region/aws_iam_vpc_flow_logs_role.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_role" "vpc_flow_logs" {
-  name               = "vpc_flow_logs"
-  assume_role_policy = data.aws_iam_policy_document.vpc_flow_logs_role_assume_role_policy.json
+  name                 = "vpc_flow_logs"
+  assume_role_policy   = data.aws_iam_policy_document.vpc_flow_logs_role_assume_role_policy.json
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
   # tags               = local.shared_component_tag
 }
 

--- a/terraform/region/data_sources.tf
+++ b/terraform/region/data_sources.tf
@@ -9,3 +9,7 @@ data "aws_region" "current" {}
 data "aws_region" "eu_west_2" {
   provider = aws.eu-west-2
 }
+
+data "aws_iam_policy" "default_boundary" {
+  name = "opg-lpa-non-ci-boundary"
+}

--- a/terraform/region/modules/region/modules/lambda_function/iam.tf
+++ b/terraform/region/modules/region/modules/lambda_function/iam.tf
@@ -1,7 +1,12 @@
+data "aws_iam_policy" "default_boundary" {
+  name = "opg-lpa-non-ci-boundary"
+}
+
 resource "aws_iam_role" "lambda_role" {
-  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
-  name_prefix        = var.lambda_name
-  tags               = var.tags
+  assume_role_policy   = data.aws_iam_policy_document.lambda_assume.json
+  name_prefix          = var.lambda_name
+  permissions_boundary = data.aws_iam_policy.default_boundary.arn
+  tags                 = var.tags
 }
 
 data "aws_iam_policy_document" "lambda_assume" {

--- a/terraform/region/terraform.tf
+++ b/terraform/region/terraform.tf
@@ -17,7 +17,7 @@ provider "aws" {
     tags = local.default_opg_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
+    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.var.boundaried_default_role}"
     session_name = "terraform-session"
   }
 }
@@ -29,7 +29,7 @@ provider "aws" {
     tags = local.default_opg_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
+    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.var.boundaried_default_role}"
     session_name = "terraform-session"
   }
 }
@@ -41,7 +41,7 @@ provider "aws" {
     tags = local.default_opg_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
+    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.var.boundaried_default_role}"
     session_name = "terraform-session"
   }
 }

--- a/terraform/region/terraform.tf
+++ b/terraform/region/terraform.tf
@@ -17,7 +17,7 @@ provider "aws" {
     tags = local.default_opg_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.var.boundaried_default_role}"
+    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.boundaried_default_role}"
     session_name = "terraform-session"
   }
 }
@@ -29,7 +29,7 @@ provider "aws" {
     tags = local.default_opg_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.var.boundaried_default_role}"
+    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.boundaried_default_role}"
     session_name = "terraform-session"
   }
 }
@@ -41,7 +41,7 @@ provider "aws" {
     tags = local.default_opg_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.var.boundaried_default_role}"
+    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.boundaried_default_role}"
     session_name = "terraform-session"
   }
 }

--- a/terraform/region/variables.tf
+++ b/terraform/region/variables.tf
@@ -4,6 +4,12 @@ variable "default_role" {
   type        = string
 }
 
+variable "boundaried_default_role" {
+  description = "default aws IAM role to use. defaults to the CI Role"
+  default     = "opg-lpa-ci-boundary"
+  type        = string
+}
+
 variable "pagerduty_token" {
   description = "The API token of the PagerDuty service"
   type        = string


### PR DESCRIPTION
## Purpose

Use boundaried CI roles for terraform steps

Fixes LPAL-2378

## Approach

- use boundaried ci role in environment
- use boundaried ci role in region
- apply non-ci permission boundary to every iam role