### PR TITLE
update otel to 0.48.0

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -44,7 +44,7 @@ jobs:
     name: "OTEL_Image_Pull_and_Scan"
     runs-on: ubuntu-latest
     env:
-      otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0
+      otel_image_version: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.48.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/terraform/environment/modules/environment/locals.tf
+++ b/terraform/environment/modules/environment/locals.tf
@@ -49,7 +49,7 @@ locals {
     {
       cpu         = 0,
       essential   = true,
-      image       = "311462405659.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.42.0",
+      image       = "311462405659.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.48.0",
       mountPoints = [],
       name        = "aws-otel-collector",
       command = [


### PR DESCRIPTION
## Purpose

Keep otel collector sidecar up to date.

## Approach

- use version 0.48.0 of the otel sidecar container