### PR TITLE
LPAL-2367| ENV CHANGES - removing references to the old kms keys before keys deleted in region 

### DIFF
--- a/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
+++ b/terraform/environment/modules/environment/ecs_iam_task_role_permissions.tf
@@ -85,7 +85,6 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
-      data.aws_kms_key.lpa_pdf_cache.arn,
       data.aws_kms_alias.pdf_cache_s3_encryption_key.target_key_arn,
       data.aws_kms_alias.elasticache_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
@@ -100,7 +99,6 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "kms:GenerateDataKey",
     ]
     resources = [
-      data.aws_kms_key.lpa_pdf_sqs.arn,
       data.aws_kms_alias.pdf_sqs_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
     ]
@@ -236,7 +234,6 @@ data "aws_iam_policy_document" "front_permissions_role" {
     ]
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
-      data.aws_kms_key.lpa_pdf_cache.arn,
       data.aws_kms_alias.pdf_cache_s3_encryption_key.target_key_arn,
       data.aws_kms_alias.elasticache_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
@@ -329,7 +326,6 @@ data "aws_iam_policy_document" "pdf_permissions_role" {
     ]
     resources = [
       data.aws_s3_bucket.lpa_pdf_cache.arn,
-      data.aws_kms_key.lpa_pdf_cache.arn,
       data.aws_kms_alias.pdf_cache_s3_encryption_key.target_key_arn,
       data.aws_kms_alias.elasticache_encryption_key.target_key_arn,
       data.aws_kms_alias.dynamodb_encryption_key.target_key_arn,
@@ -343,7 +339,6 @@ data "aws_iam_policy_document" "pdf_permissions_role" {
       "kms:GenerateDataKey",
     ]
     resources = [
-      data.aws_kms_key.lpa_pdf_sqs.arn,
       data.aws_kms_alias.pdf_sqs_encryption_key.target_key_arn,
     ]
   }

--- a/terraform/environment/modules/environment/shared_data_sources.tf
+++ b/terraform/environment/modules/environment/shared_data_sources.tf
@@ -1,7 +1,3 @@
-data "aws_kms_key" "lpa_pdf_sqs" {
-  key_id = "alias/mrk_pdf_sqs_encryption_key-${var.account_name}"
-}
-
 data "aws_security_group" "new_front_cache_region" {
   filter {
     name   = "group-name"
@@ -19,10 +15,6 @@ data "aws_s3_bucket" "access_log" {
 
 data "aws_s3_bucket" "lpa_pdf_cache" {
   bucket = lower("online-lpa-pdf-cache-${var.account_name}-${var.region_name}")
-}
-
-data "aws_kms_key" "lpa_pdf_cache" {
-  key_id = "alias/lpa_pdf_cache-${var.account_name}"
 }
 
 data "aws_acm_certificate" "certificate_front" {


### PR DESCRIPTION


## Purpose

Removing references and usage to  old kms keys in env level ( have now been replaced with the kms-key module for enhanced security) 

removed from: 
ecs-task-role-iam-permissions
- data.aws_kms_key.lpa_pdf_cache.arn
- data.aws_kms_key.lpa_pdf_sqs.arn,

shared data sources for both 

Region PR will delete keys once env changes merged so resources are not broken 

Fixes LPAL-2367

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
