### PR TITLE
Generate response for unhandled exceptions in the API

### DIFF
--- a/service-api/module/Application/src/Library/Listener/ErrorListener.php
+++ b/service-api/module/Application/src/Library/Listener/ErrorListener.php
@@ -8,9 +8,18 @@ use Application\Library\ApiProblem\ApiProblemResponse;
 use Application\Library\ApiProblem\ApiProblemExceptionInterface;
 use Laminas\EventManager\AbstractListenerAggregate;
 use Laminas\EventManager\EventManagerInterface;
+use Psr\Log\LoggerInterface;
 
 class ErrorListener extends AbstractListenerAggregate
 {
+    /**
+     * Psalm cannot determine that this is auto-wired
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
     // priority is set to 100 here so that the global MvcEventListener
     // has a chance to log it before it's converted into an API exception
     public function attach(EventManagerInterface $events, $priority = 100)
@@ -36,13 +45,19 @@ class ErrorListener extends AbstractListenerAggregate
             $response = new ApiProblemResponse($problem);
             $e->setResponse($response);
         } elseif ($exception) {
-            $logger = $e->getApplication()->getServiceManager()->get('Logger');
-            $logger->error($exception->getMessage(), [
+            $this->logger->error($exception->getMessage(), [
                 'class' => $exception::class,
                 'file' => $exception->getFile(),
                 'line' => $exception->getLine(),
                 'stackTrace' => $exception->getTraceAsString(),
             ]);
+
+            if ($e->getResponse()->getContent() === '') {
+                $problem = new ApiProblem(500, 'An unexpected error occurred');
+                $response = new ApiProblemResponse($problem);
+                $e->setResponse($response);
+                $e->stopPropagation();
+            }
         }
 
         return $response;

--- a/service-api/module/Application/tests/Library/Listener/ErrorListenerTest.php
+++ b/service-api/module/Application/tests/Library/Listener/ErrorListenerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace ApplicationTest;
+
+use Application\Library\ApiProblem\ApiProblemResponse;
+use Application\Library\ApiProblem\ApiProblemException;
+use Psr\Log\LoggerInterface;
+use Application\Library\Listener\ErrorListener;
+use Exception;
+use Laminas\Http\Response;
+use Laminas\Mvc\Application;
+use Laminas\Mvc\MvcEvent;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class ErrorListenerTest extends TestCase
+{
+    private LoggerInterface&MockInterface $logger;
+    private ErrorListener $listener;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logger = Mockery::mock(LoggerInterface::class);
+        $this->listener = new ErrorListener($this->logger);
+    }
+
+    public function testNonExceptionIgnored(): void
+    {
+        $event = $this->createMock(MvcEvent::class);
+        $event->expects($this->once())
+            ->method('getParam')
+            ->with('exception')
+            ->willReturn(null);
+
+        $response = $this->listener->onError($event);
+
+        $this->assertNull($response);
+    }
+
+    public function testApiProblemConverted(): void
+    {
+        $event = $this->createMock(MvcEvent::class);
+
+        $event->setApplication(Mockery::mock(Application::class));
+
+        $event->expects($this->once())
+            ->method('getParam')
+            ->with('exception')
+            ->willReturn(new ApiProblemException('Information not found', 404));
+
+        $event->expects($this->once())
+            ->method('stopPropagation');
+
+        $event->expects($this->once())
+            ->method('setResponse')
+            ->with($this->callback(function ($response) {
+                return $response instanceof ApiProblemResponse
+                    && $response->getStatusCode() === 404
+                    && str_contains($response->getContent(), '"detail":"Information not found"');
+            }));
+
+        $this->listener->onError($event);
+    }
+
+    public function testOtherExceptionsLoggedAndConverted(): void
+    {
+        $event = $this->createMock(MvcEvent::class);
+        $event->expects($this->once())
+            ->method('getParam')
+            ->with('exception')
+            ->willReturn(new Exception('Something unknown went wrong'));
+
+        $event->expects($this->once())
+            ->method('getResponse')
+            ->willReturn(new Response());
+
+        $event->expects($this->once())
+            ->method('stopPropagation');
+
+        $event->expects($this->once())
+            ->method('setResponse')
+            ->with($this->callback(function ($response) {
+                return $response instanceof ApiProblemResponse
+                    && $response->getStatusCode() === 500
+                    && str_contains($response->getContent(), '"detail":"An unexpected error occurred"');
+            }));
+
+        $this->logger->shouldReceive('error')
+            ->once()
+            ->with('Something unknown went wrong', Mockery::on(function ($context) {
+                return $context['class'] === Exception::class
+                    && isset($context['file'])
+                    && isset($context['line'])
+                    && isset($context['stackTrace']);
+            }));
+
+        $this->listener->onError($event);
+    }
+
+    public function testExistingResponseKept(): void
+    {
+        $event = $this->createMock(MvcEvent::class);
+        $event->expects($this->once())
+            ->method('getParam')
+            ->with('exception')
+            ->willReturn(new Exception('Something unknown went wrong'));
+
+        $existingResponse = new Response();
+        $existingResponse->setContent('Existing response content');
+        $event->expects($this->once())
+            ->method('getResponse')
+            ->willReturn($existingResponse);
+
+        $event->expects($this->never())
+            ->method('stopPropagation');
+
+        $event->expects($this->never())
+            ->method('setResponse');
+
+        $this->logger->shouldReceive('error')
+            ->once()
+            ->with('Something unknown went wrong', Mockery::on(function ($context) {
+                return $context['class'] === Exception::class
+                    && isset($context['file'])
+                    && isset($context['line'])
+                    && isset($context['stackTrace']);
+            }));
+
+        $this->listener->onError($event);
+    }
+}


### PR DESCRIPTION
## Purpose

Currently the API returns a blank HTML document if an exception that doesn't implement `ApiProblemExceptionInterface` is thrown. This causes PHP Warnings in the API logs.

Fixes LPAL-2446 #patch

## Approach

Update ErrorListener to create a proper JSON response body for exceptions if there isn't already one attached to the MVC event.

