### PR TITLE
LPAL-2438 - enable block mode for rate limit rule in WAF

### DIFF
--- a/terraform/region/modules/region/waf.tf
+++ b/terraform/region/modules/region/waf.tf
@@ -270,7 +270,7 @@ resource "aws_wafv2_web_acl" "main" {
     priority = 60
 
     action {
-      count {}
+      block {}
     }
 
     statement {


### PR DESCRIPTION
## Purpose

After evaluation in count mode, it's established that the rate limit rule will not cause normal customer activity will not be caught.

Fixes LPAL-2438

## Approach

- Enable blocking in the Rate Limit IP rule

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule
