### PR TITLE
Move logic out of onDispatch methods

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -632,21 +632,21 @@
         "filename": "service-api/module/Application/tests/Controller/Version2/Auth/AuthenticateControllerTest.php",
         "hashed_secret": "61d6504733ca7757e259c644acd085c4dd471019",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 20
       },
       {
         "type": "Secret Keyword",
         "filename": "service-api/module/Application/tests/Controller/Version2/Auth/AuthenticateControllerTest.php",
         "hashed_secret": "732e9daed0822be0734067dfb60db59150de3f28",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 124
       },
       {
         "type": "Secret Keyword",
         "filename": "service-api/module/Application/tests/Controller/Version2/Auth/AuthenticateControllerTest.php",
         "hashed_secret": "423f0b8f33972ec13a48bd7fc3ece6bd303e9eaf",
         "is_verified": false,
-        "line_number": 183
+        "line_number": 182
       }
     ],
     "service-api/module/Application/tests/Controller/Version2/Auth/EmailControllerTest.php": [
@@ -974,5 +974,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-26T14:35:38Z"
+  "generated_at": "2026-08-28T08:20:46Z"
 }

--- a/service-api/module/Application/src/Controller/StatusController.php
+++ b/service-api/module/Application/src/Controller/StatusController.php
@@ -2,13 +2,11 @@
 
 namespace Application\Controller;
 
-use Application\Library\ApiProblem\ApiProblem;
 use Application\Library\ApiProblem\ApiProblemException;
 use Application\Library\ApiProblem\ApiProblemResponse;
 use Application\Library\Authentication\Identity\Guest;
 use Application\Library\Authorization\UnauthorizedException;
 use Application\Library\Http\Response\Json;
-use Application\Model\DataAccess\Repository\Application\LockedException;
 use Application\Model\Service\Applications\Service as ApplicationsService;
 use Application\Model\Service\ProcessingStatus\Service as ProcessingStatusService;
 use Exception;
@@ -86,13 +84,7 @@ class StatusController extends AbstractRestfulController implements LoggerAwareI
             throw new UnauthorizedException('You need to be authenticated to access this service');
         }
 
-        try {
-            return parent::onDispatch($e);
-        } catch (UnauthorizedException $ex) {
-            return new ApiProblemResponse(new ApiProblem(401, 'Access Denied'));
-        } catch (LockedException $ex) {
-            return new ApiProblemResponse(new ApiProblem(403, 'LPA has been locked'));
-        }
+        return parent::onDispatch($e);
     }
 
     // $lpaId: ID of LPA to update

--- a/service-api/module/Application/src/Controller/StatusController.php
+++ b/service-api/module/Application/src/Controller/StatusController.php
@@ -3,7 +3,6 @@
 namespace Application\Controller;
 
 use Application\Library\ApiProblem\ApiProblemException;
-use Application\Library\ApiProblem\ApiProblemResponse;
 use Application\Library\Authentication\Identity\Guest;
 use Application\Library\Authorization\UnauthorizedException;
 use Application\Library\Http\Response\Json;
@@ -12,7 +11,6 @@ use Application\Model\Service\ProcessingStatus\Service as ProcessingStatusServic
 use Exception;
 use Laminas\Authentication\AuthenticationService;
 use Laminas\Mvc\Controller\AbstractRestfulController;
-use Laminas\Mvc\MvcEvent;
 use MakeShared\DataModel\Lpa\Lpa;
 use MakeShared\Logging\LoggerTrait;
 use Psr\Log\LoggerAwareInterface;
@@ -35,9 +33,6 @@ class StatusController extends AbstractRestfulController implements LoggerAwareI
 
     /* @var $processingStatusService ProcessingStatusService */
     private $processingStatusService;
-
-    /* @var $routeUserId string */
-    private $routeUserId;
 
     /**
      * Get the service to use
@@ -64,33 +59,10 @@ class StatusController extends AbstractRestfulController implements LoggerAwareI
         $this->processingStatusService = $processingStatusService;
     }
 
-    /**
-     * @param MvcEvent $e
-     * @return mixed|ApiProblemResponse
-     * @throws ApiProblemException
-     */
-    public function onDispatch(MvcEvent $e)
-    {
-        //  If possible get the user and LPA from the ID values in the route
-        $this->routeUserId = $e->getRouteMatch()->getParam('userId');
-
-        if (empty($this->routeUserId)) {
-            //  userId MUST be present in the URL
-            throw new ApiProblemException('User identifier missing from URL', 400);
-        }
-
-        $identity = $this->authenticationService->getIdentity();
-        if ($identity === null || $identity instanceof Guest) {
-            throw new UnauthorizedException('You need to be authenticated to access this service');
-        }
-
-        return parent::onDispatch($e);
-    }
-
     // $lpaId: ID of LPA to update
     // $metaData: existing metadata for the LPA; [] if no metadata exists yet
     // $data: data to use to update the existing metadata
-    private function updateMetadata(string $lpaId, $metaData, array $data): void
+    private function updateMetadata(string $lpaId, string $userId, $metaData, array $data): void
     {
         // Update metadata in DB
         $newMeta[LPA::SIRIUS_PROCESSING_STATUS] = $data['status'];
@@ -106,7 +78,7 @@ class StatusController extends AbstractRestfulController implements LoggerAwareI
 
         if ($this->hasDifference($newMeta, $metaData)) {
             $metaData = array_merge($metaData, $newMeta);
-            $this->getService()->patch(['metadata' => $metaData], $lpaId, $this->routeUserId);
+            $this->getService()->patch(['metadata' => $metaData], $lpaId, $userId);
             $this->getLogger()->debug('Updated MetaData for LPA', [
                 'lpaId' => $lpaId,
                 'metaData' => $metaData
@@ -157,16 +129,23 @@ class StatusController extends AbstractRestfulController implements LoggerAwareI
      */
     public function get($id)
     {
-        if (empty($this->routeUserId)) {
+        $userId = $this->params()->fromRoute('userId');
+
+        if (empty($userId)) {
             //  userId MUST be present in the URL
             throw new ApiProblemException('User identifier missing from URL', 400);
+        }
+
+        $identity = $this->authenticationService->getIdentity();
+        if ($identity === null || $identity instanceof Guest) {
+            throw new UnauthorizedException('You need to be authenticated to access this service');
         }
 
         $explodedIds = explode(',', $id);
 
         // Fetch requested LPAs from db, provided they are owned by the user;
         // this is [] if the db is not available for any reason
-        $lpasFromDb = $this->applicationsService->filterByIdsAndUser($explodedIds, $this->routeUserId);
+        $lpasFromDb = $this->applicationsService->filterByIdsAndUser($explodedIds, $userId);
 
         // Convert db results into a map from ID to metadata
         $lpaMetas = array_reduce($lpasFromDb, function ($sofar, $lpa) {
@@ -257,7 +236,7 @@ class StatusController extends AbstractRestfulController implements LoggerAwareI
                     // in updateMetadata)
                     $metaData = $this->getValue($lpaMetas, $lpaId, []);
                     if ($this->getValue($dbResult, 'inDb')) {
-                        $this->updateMetadata($lpaId, $metaData, $data);
+                        $this->updateMetadata($lpaId, $userId, $metaData, $data);
                     }
 
                     // set found to true here as we got a processing status

--- a/service-api/module/Application/src/Controller/Version2/Auth/AbstractAuthController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/AbstractAuthController.php
@@ -2,14 +2,10 @@
 
 namespace Application\Controller\Version2\Auth;
 
-use Application\Library\ApiProblem\ApiProblem;
-use Application\Library\ApiProblem\ApiProblemException;
-use Application\Library\ApiProblem\ApiProblemResponse;
 use Application\Model\Service\AbstractService;
 use Application\Model\Service\Authentication\Service as AuthenticationService;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Mvc\Controller\AbstractRestfulController;
-use Laminas\Mvc\MvcEvent;
 use MakeShared\Logging\LoggerTrait;
 use Psr\Log\LoggerAwareInterface;
 
@@ -49,24 +45,6 @@ abstract class AbstractAuthController extends AbstractRestfulController implemen
      * @return AbstractService
      */
     abstract protected function getService();
-
-    /**
-     * Execute the request
-     *
-     * @param MvcEvent $e
-     * @return mixed|ApiProblem|ApiProblemResponse
-     * @throws ApiProblemException
-     */
-    public function onDispatch(MvcEvent $e)
-    {
-        $return = parent::onDispatch($e);
-
-        if ($return instanceof ApiProblem) {
-            return new ApiProblemResponse($return);
-        }
-
-        return $return;
-    }
 
     /**
      * @param $userId

--- a/service-api/module/Application/src/Controller/Version2/Auth/SharedSpaceController.php
+++ b/service-api/module/Application/src/Controller/Version2/Auth/SharedSpaceController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Application\Controller\Version2\Auth;
 
 use Application\Library\ApiProblem\ApiProblem;
-use Application\Library\ApiProblem\ApiProblemResponse;
 use Application\Library\Http\Response\Json;
 use Application\Library\Http\Response\NoContent;
 use Application\Model\Entity\MemberInvite;
@@ -19,7 +18,6 @@ use DateInterval;
 use DateTimeImmutable;
 use Fig\Http\Message\StatusCodeInterface;
 use Laminas\Mvc\Controller\AbstractRestfulController;
-use Laminas\Mvc\MvcEvent;
 use MakeShared\DataModel\Lpa\Lpa;
 use Throwable;
 use Traversable;
@@ -31,27 +29,6 @@ class SharedSpaceController extends AbstractRestfulController
         private readonly SharedSpaceService $sharedSpaceService,
         private readonly ApplicationsService $applicationsService,
     ) {
-    }
-
-    /**
-     * AbstractRestfulController doesn't know how to turn a bare ApiProblem
-     * value returned from an action into a Response with the correct HTTP
-     * status code - without this, ApiProblem responses (e.g. 400/401/403/500)
-     * are sent to clients as a 200 with a malformed body. See
-     * AbstractAuthController::onDispatch() for the equivalent used by
-     * controllers that extend it.
-     *
-     * @return mixed|ApiProblemResponse
-     */
-    public function onDispatch(MvcEvent $e)
-    {
-        $return = parent::onDispatch($e);
-
-        if ($return instanceof ApiProblem) {
-            return new ApiProblemResponse($return);
-        }
-
-        return $return;
     }
 
     /**

--- a/service-api/module/Application/src/Controller/Version2/Lpa/AbstractLpaController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/AbstractLpaController.php
@@ -84,7 +84,7 @@ abstract class AbstractLpaController extends AbstractRestfulController
         }
 
         if (
-            $identity->getId() !== $this->params->fromRoute('userId') &&
+            $identity->getId() !== $this->params()->fromRoute('userId') &&
             !$identity->hasRole('admin') &&
             !$identity->hasRole('admin-service')
         ) {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/AbstractLpaController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/AbstractLpaController.php
@@ -25,11 +25,6 @@ abstract class AbstractLpaController extends AbstractRestfulController
     /**
      * @var string
      */
-    protected $routeUserId;
-
-    /**
-     * @var string
-     */
     protected $lpaId;
 
     /**
@@ -69,14 +64,6 @@ abstract class AbstractLpaController extends AbstractRestfulController
      */
     public function onDispatch(MvcEvent $e)
     {
-        //  If possible get the user and LPA from the ID values in the route
-        $this->routeUserId = $e->getRouteMatch()->getParam('userId');
-
-        if (empty($this->routeUserId)) {
-            //  userId MUST be present in the URL
-            throw new ApiProblemException('User identifier missing from URL', 400);
-        }
-
         //  The lpaId MAY be present in the URL
         $this->lpaId = $e->getRouteMatch()->getParam('lpaId');
 
@@ -97,7 +84,7 @@ abstract class AbstractLpaController extends AbstractRestfulController
         }
 
         if (
-            $identity->getId() !== $this->routeUserId &&
+            $identity->getId() !== $this->params->fromRoute('userId') &&
             !$identity->hasRole('admin') &&
             !$identity->hasRole('admin-service')
         ) {

--- a/service-api/module/Application/src/Controller/Version2/Lpa/AbstractLpaController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/AbstractLpaController.php
@@ -7,7 +7,6 @@ use Application\Library\ApiProblem\ApiProblemException;
 use Application\Library\ApiProblem\ApiProblemResponse;
 use Application\Library\Authentication\Identity\Guest;
 use Application\Library\Authorization\UnauthorizedException;
-use Application\Model\DataAccess\Repository\Application\LockedException;
 use Application\Model\Service\AbstractService;
 use Laminas\Authentication\AuthenticationService;
 use Laminas\Mvc\Controller\AbstractRestfulController;
@@ -81,19 +80,7 @@ abstract class AbstractLpaController extends AbstractRestfulController
         //  The lpaId MAY be present in the URL
         $this->lpaId = $e->getRouteMatch()->getParam('lpaId');
 
-        try {
-            $return = parent::onDispatch($e);
-        } catch (UnauthorizedException $ex) {
-            $return = new ApiProblem(401, 'Access Denied');
-        } catch (LockedException $ex) {
-            $return = new ApiProblem(403, 'LPA has been locked');
-        }
-
-        if ($return instanceof ApiProblem) {
-            return new ApiProblemResponse($return);
-        }
-
-        return $return;
+        return parent::onDispatch($e);
     }
 
     /**

--- a/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/ApplicationController.php
@@ -31,7 +31,10 @@ class ApplicationController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->fetch($id, $this->routeUserId);
+        $result = $this->getService()->fetch(
+            $id,
+            $this->authenticationService->getIdentity()->getId()
+        );
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -75,7 +78,10 @@ class ApplicationController extends AbstractLpaController
         unset($filteredQuery['perPage']);
 
         //  Get the collection of applications with the query data
-        $result = $this->getService()->fetchAll($this->routeUserId, $filteredQuery);
+        $result = $this->getService()->fetchAll(
+            $this->authenticationService->getIdentity()->getId(),
+            $filteredQuery
+        );
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -111,7 +117,10 @@ class ApplicationController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->create($data, $this->routeUserId);
+        $result = $this->getService()->create(
+            $data,
+            $this->authenticationService->getIdentity()->getId()
+        );
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -140,7 +149,11 @@ class ApplicationController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->patch($data, $id, $this->routeUserId);
+        $result = $this->getService()->patch(
+            $data,
+            $id,
+            $this->authenticationService->getIdentity()->getId()
+        );
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -160,7 +173,10 @@ class ApplicationController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->delete($id, $this->routeUserId);
+        $result = $this->getService()->delete(
+            $id,
+            $this->authenticationService->getIdentity()->getId()
+        );
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/SeedController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/SeedController.php
@@ -28,7 +28,10 @@ class SeedController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->fetch($this->lpaId, $this->routeUserId);
+        $result = $this->getService()->fetch(
+            $this->lpaId,
+            $this->authenticationService->getIdentity()->getId()
+        );
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -55,7 +58,11 @@ class SeedController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data, $this->routeUserId);
+        $result = $this->getService()->update(
+            $this->lpaId,
+            $data,
+            $this->authenticationService->getIdentity()->getId()
+        );
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Library/Listener/ErrorListener.php
+++ b/service-api/module/Application/src/Library/Listener/ErrorListener.php
@@ -26,6 +26,7 @@ class ErrorListener extends AbstractListenerAggregate
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, [$this, 'onError'], 100);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER_ERROR, [$this, 'onError'], 100);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER, [$this, 'onRender'], 100);
     }
 
     /**
@@ -61,5 +62,14 @@ class ErrorListener extends AbstractListenerAggregate
         }
 
         return $response;
+    }
+
+    public function onRender(MvcEvent $e): void
+    {
+        if ($e->getResult() instanceof ApiProblem) {
+            $response = new ApiProblemResponse($e->getResult());
+            $e->setResponse($response);
+            $e->stopPropagation();
+        }
     }
 }

--- a/service-api/module/Application/src/Library/Listener/ErrorListener.php
+++ b/service-api/module/Application/src/Library/Listener/ErrorListener.php
@@ -66,7 +66,7 @@ class ErrorListener extends AbstractListenerAggregate
 
     public function onRender(MvcEvent $e): void
     {
-        if ($e->getResult() instanceof ApiProblem) {
+        if ($e->getResult() instanceof ApiProblem && $e->getResponse()->getContent() === '') {
             $response = new ApiProblemResponse($e->getResult());
             $e->setResponse($response);
             $e->stopPropagation();

--- a/service-api/module/Application/src/Model/DataAccess/Repository/Application/LockedException.php
+++ b/service-api/module/Application/src/Model/DataAccess/Repository/Application/LockedException.php
@@ -2,12 +2,18 @@
 
 namespace Application\Model\DataAccess\Repository\Application;
 
+use Application\Library\ApiProblem\ApiProblemExceptionInterface;
+
 /**
  * Thrown if a an amend is attempted on a locked LPA.
  *
  * Class LockedException
  * @package Application\Model\DataAccess\Repository\Application
  */
-class LockedException extends \RuntimeException
+class LockedException extends \RuntimeException implements ApiProblemExceptionInterface
 {
+    public function __construct(string $message = "", int $code = 403, \Throwable|null $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/service-api/module/Application/tests/Controller/Version2/Auth/AuthenticateControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Auth/AuthenticateControllerTest.php
@@ -4,7 +4,6 @@ namespace ApplicationTest\Controller\Version2\Auth;
 
 use Application\Controller\Version2\Auth\AuthenticateController;
 use Application\Library\ApiProblem\ApiProblem;
-use Application\Library\ApiProblem\ApiProblemResponse;
 use DateTime;
 use Laminas\Http\Header\HeaderInterface;
 use Laminas\Mvc\MvcEvent;
@@ -376,27 +375,6 @@ class AuthenticateControllerTest extends AbstractAuthControllerTestCase
         $resultArray = $result->getVariables();
         $this->assertEquals(true, $resultArray['valid']);
         $this->assertEquals(20, $resultArray['remainingSeconds']);
-    }
-
-    // Test conversion of ApiProblem results to ApiProblemResponse
-    // in the AbstractAuthController->onDispatch() method; because the abstract class
-    // can't be instantiated, we test here instead
-    public function testOnDispatchApiProblem(): void
-    {
-        $rm = Mockery::mock(RouteMatch::class);
-        $rm->shouldReceive('getParam')->with('action', false)->andReturn('session-expiry');
-
-        // deliberately fail authentication so we get an ApiProblem
-        $this->request->shouldReceive('getHeader')->with('CheckedToken')->andReturn(null);
-
-        $e = Mockery::mock(MvcEvent::class);
-        $e->shouldReceive('getRouteMatch')->andReturn($rm);
-        $e->shouldReceive('getRequest')->andReturn($this->request);
-        $e->shouldReceive('setResult');
-
-        $result = $this->getController(AuthenticateController::class)->onDispatch($e);
-
-        $this->assertInstanceOf(ApiProblemResponse::class, $result);
     }
 
     // Test setSessionExpiry as triggered by onDispatch(); the result should not be modified

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/AbstractControllerTestCase.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/AbstractControllerTestCase.php
@@ -61,7 +61,7 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
 
     public function setUp(): void
     {
-        $this->userId = 12345;
+        $this->userId = '12345';
         $this->lpaId = 98765;
 
         $response = Mockery::mock(Response::class);
@@ -73,8 +73,8 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
         $this->eventManager->shouldReceive('triggerEventUntil')->andReturn($response);
 
         $this->identity = Mockery::mock(User::class);
-        $this->identity->shouldReceive('getId')->andReturn(99999);
-        $this->identity->shouldReceive('id')->andReturn(99999);
+        $this->identity->shouldReceive('getId')->andReturn(12345);
+        $this->identity->shouldReceive('id')->andReturn(12345);
         $this->identity->shouldReceive('hasRole')->withArgs(['admin'])->andReturn(true);
         $this->identity->shouldReceive('hasRole')->withArgs(['admin-service'])->andReturn(false);
         $this->identity->shouldReceive('email')->andReturn('identity@email.address');
@@ -83,7 +83,7 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
         $authenticationService->shouldReceive('getIdentity')->andReturn($this->identity);
 
         $this->routeMatch = Mockery::mock(RouteMatch::class);
-        $this->routeMatch->shouldReceive('getParam')->withArgs(['userId'])->andReturn($this->userId);
+        $this->routeMatch->shouldReceive('getParam')->withArgs(['userId', null])->andReturn($this->userId);
         $this->routeMatch->shouldReceive('getParam')->withArgs(['lpaId'])->andReturn($this->lpaId);
         $this->routeMatch->shouldReceive('getParam')->withArgs(['lpaId', false])->andReturn($this->lpaId);
         $this->routeMatch->shouldReceive('getParam')->withArgs(['action', false])->andReturn(false);
@@ -128,6 +128,7 @@ abstract class AbstractControllerTestCase extends MockeryTestCase
     protected function callDispatch(AbstractLpaController $abstractController, array $parameters = [])
     {
         $abstractController->setEventManager($this->eventManager);
+        $abstractController->getEvent()->setRouteMatch($this->routeMatch);
 
         $params = new Parameters($parameters);
 

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/AbstractLpaControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/AbstractLpaControllerTest.php
@@ -2,14 +2,8 @@
 
 namespace ApplicationTest\Controller\Version2\Lpa;
 
-use Application\Library\ApiProblem\ApiProblemException;
-use Application\Library\ApiProblem\ApiProblemResponse;
-use Application\Library\Authorization\UnauthorizedException;
-use Application\Model\DataAccess\Repository\Application\LockedException;
 use Application\Model\Service\AbstractService;
 use Laminas\Http\Response;
-use Laminas\Mvc\MvcEvent;
-use Laminas\Router\RouteMatch;
 use Mockery;
 use Mockery\MockInterface;
 
@@ -33,62 +27,5 @@ class AbstractLpaControllerTest extends AbstractControllerTestCase
 
         $this->assertNotNull($result);
         $this->assertInstanceOf(Response::class, $result);
-    }
-
-    public function testOnDispatchNoUserId()
-    {
-        $routeMatch = Mockery::mock(RouteMatch::class);
-        $routeMatch->shouldReceive('getParam')->withArgs(['userId'])->andReturn(null)->once();
-
-        $mvcEvent = Mockery::mock(MvcEvent::class);
-        $mvcEvent->shouldReceive('getRouteMatch')->andReturn($routeMatch)->once();
-
-        $this->expectException(ApiProblemException::class);
-        $this->expectExceptionMessage('User identifier missing from URL');
-
-        $controller = new TestableAbstractLpaController($this->authenticationService, $this->service);
-        $result = $controller->onDispatch($mvcEvent);
-
-        $this->assertNotNull($result);
-        $this->assertInstanceOf(Response::class, $result);
-    }
-
-    public function testOnDispatchUnathorised()
-    {
-        // Override expectations set in setUp
-        $this->routeMatch->mockery_findExpectation('getParam', ['userId'])->andReturn(10)->once();
-        $this->routeMatch->mockery_findExpectation('getParam', ['lpaId'])->andReturn(20)->once();
-        $this->mvcEvent->mockery_findExpectation('getRequest', [])->andThrow(UnauthorizedException::class)->once();
-
-        $controller = new TestableAbstractLpaController($this->authenticationService, $this->service);
-        $result = $controller->onDispatch($this->mvcEvent);
-
-        $this->assertNotNull($result);
-        $this->assertInstanceOf(ApiProblemResponse::class, $result);
-        $this->assertEquals('{"type":"http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",' .
-            '"title":"Unauthorized",' .
-            '"status":401,' .
-            '"detail":"Access Denied"}', $result->getContent());
-    }
-
-    public function testOnDispatchLocked()
-    {
-        // Override expectations set in setUp
-        $this->routeMatch->mockery_findExpectation('getParam', ['userId'])->andReturn(10)->once();
-        $this->routeMatch->mockery_findExpectation('getParam', ['lpaId'])->andReturn(20)->once();
-        $this->mvcEvent->mockery_findExpectation('getRequest', [])->andThrow(LockedException::class)->once();
-
-        $controller = new TestableAbstractLpaController($this->authenticationService, $this->service);
-        $result = $controller->onDispatch($this->mvcEvent);
-
-        $this->assertNotNull($result);
-        $this->assertInstanceOf(ApiProblemResponse::class, $result);
-        $this->assertEquals(
-            '{"type":"http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",' .
-            '"title":"Forbidden",' .
-            '"status":403,' .
-            '"detail":"LPA has been locked"}',
-            $result->getContent()
-        );
     }
 }

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/PdfControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/PdfControllerTest.php
@@ -120,6 +120,7 @@ class PdfControllerTest extends AbstractControllerTestCase
         $request->shouldReceive('getHeader')->with('X-Request-ID')->andReturn(false);
 
         $controller->setEventManager($this->eventManager);
+        $controller->getEvent()->setRouteMatch($this->routeMatch);
         $controller->dispatch($request);
         $this->callOnDispatch($controller);
 

--- a/service-api/module/Application/tests/Controller/Version2/Lpa/StatusControllerTest.php
+++ b/service-api/module/Application/tests/Controller/Version2/Lpa/StatusControllerTest.php
@@ -9,6 +9,7 @@ use Application\Library\Http\Response\Json;
 use Application\Model\Service\Applications\Service as ApplicationsService;
 use Application\Model\Service\DataModelEntity;
 use Application\Model\Service\ProcessingStatus\Service as ProcessingStatusService;
+use Laminas\Router\RouteMatch;
 use Mockery;
 use MakeShared\DataModel\Lpa\Lpa;
 use Psr\Log\LoggerInterface;
@@ -51,11 +52,12 @@ class StatusControllerTest extends AbstractControllerTestCase
         );
         $logger = Mockery::spy(LoggerInterface::class);
         $this->statusController->setLogger($logger);
+
+        $this->statusController->getEvent()->setRouteMatch($this->routeMatch);
     }
 
     public function testGetWithFirstUpdateOnValidCase()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => []]);
 
@@ -110,8 +112,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetWithUpdatesOnValidCase()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [Lpa::SIRIUS_PROCESSING_STATUS => 'Received']]);
 
@@ -166,8 +166,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetWithUpdatesOnValidCaseWithSameStatusDifferentReturnDate()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [Lpa::SIRIUS_PROCESSING_STATUS => 'Received']]);
 
@@ -222,8 +220,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetWithUpdatesOnValidCaseWithDateReturn()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [Lpa::SIRIUS_PROCESSING_STATUS => 'Received']]);
 
@@ -278,8 +274,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetWithUpdatesOnRejectDateForProcessedCase()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [
                 Lpa::SIRIUS_PROCESSING_STATUS => 'Waiting',
@@ -334,8 +328,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetWithUpdatesForProcessedCase()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [
                 Lpa::SIRIUS_PROCESSING_STATUS => 'Processed',
@@ -394,7 +386,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetWithNoUpdateOnValidCase()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [Lpa::SIRIUS_PROCESSING_STATUS => 'Checking']]);
 
@@ -425,8 +416,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetWithNoUpdateOnValidCaseWithNoPreviousStatus()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => []]);
 
@@ -451,8 +440,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetWithSameStatusAndDates()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa([
             'id' => 98765,
             'completedAt' => new MillisecondDateTime('2019-02-01'),
@@ -490,8 +477,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetNotFoundInDBAndCannotBeSaved()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [Lpa::SIRIUS_PROCESSING_STATUS => 'Checking']]);
 
@@ -524,8 +509,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetLpaAlreadyProcessedWithRegistrationDateSet()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [
                 Lpa::SIRIUS_PROCESSING_STATUS => 'Processed',
@@ -576,8 +559,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetLpaAlreadyProcessedWithRejectedDateSet()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [
                 Lpa::SIRIUS_PROCESSING_STATUS => 'Processed',
@@ -612,8 +593,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetLpaAlreadyProcessedWithReturnUnpaidSetTrue()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98766, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [
                 Lpa::SIRIUS_PROCESSING_STATUS => 'Pending'
@@ -651,8 +630,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetLpaAlreadyProcessedWithReturnUnpaidSetNull()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98766, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [
                 Lpa::SIRIUS_PROCESSING_STATUS => 'Pending'
@@ -689,13 +666,15 @@ class StatusControllerTest extends AbstractControllerTestCase
     {
         $this->expectException(ApiProblemException::class);
         $this->expectExceptionMessage('User identifier missing from URL');
+
+        $emptyRouteMatch = new RouteMatch([]);
+        $this->statusController->getEvent()->setRouteMatch($emptyRouteMatch);
+
         $this->statusController->get('98765');
     }
 
     public function testMultipleStatusUpdateOnValidCases()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa1 = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => []]);
 
@@ -771,8 +750,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetLpaWithInvalidDate()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [
                 Lpa::SIRIUS_PROCESSING_STATUS => 'Processed',
@@ -807,8 +784,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetLpaWithWithdrawnDate()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [
                 Lpa::SIRIUS_PROCESSING_STATUS => 'Processed',
@@ -843,8 +818,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetLpaProcessingStatusNotFound()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [
                 Lpa::SIRIUS_PROCESSING_STATUS => 'Checking',
@@ -876,8 +849,6 @@ class StatusControllerTest extends AbstractControllerTestCase
 
     public function testGetLpaDeleted()
     {
-        $this->statusController->onDispatch($this->mvcEvent);
-
         $lpa = new Lpa(['id' => 98765, 'completedAt' => new MillisecondDateTime('2019-02-01'),
             'metadata' => [
                 Lpa::SIRIUS_PROCESSING_STATUS => 'Checking',


### PR DESCRIPTION
## Purpose

Application logic inside onDispatch methods is hard to discover and tightly coupled to the Laminas MVC framework. To reduce our direct dependency on Laminas MVC, move some of this logic to controller actions or listeners.

The only remaining onDispatch logic is AbstractLpaController setting `$lpaId`: this can be replaced with a call to `$this->params()->fromRoute()` but I've left that for a future PR since it touches quite a few files.

Fixes LPAL-2145

## Approach

### Move ApiProblem conversion to top level

Various API controller actions return an `ApiProblem` as their result. As this does not implement `ResponseInterface`, it needs to be converted by custom code into a response. This code exists in a few different controllers `onDispatch` events, which isn't very discoverable.

Remove the `onDispatch` code for this from controllers and abstract controllers, and move it into the `ErrorListener` which can apply the same logic during the render event.

Make `LockedException` implement `ApiProblemExceptionInterface` so that it doesn't need any additional handling.

### Move StatusController:onDispatch logic into action

StatusController only has one action, so move the logic from onDispatch into it. This makes the action clearer, rather than hiding some of the behaviour in a framework method.

### Remove routeUserId from AbstractLpaController

Instead of trusting the ID in the URL, use the ID of the currently logged-in user. This pushes authorization onto trusted resources, rather than the web framework, and removes hard-to-discover behaviour from the onDispatch method.
