### PR TITLE
Fetch lpa ID from params in controller actions

### DIFF
--- a/service-api/module/Application/src/Controller/Version2/Lpa/AbstractLpaController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/AbstractLpaController.php
@@ -2,15 +2,11 @@
 
 namespace Application\Controller\Version2\Lpa;
 
-use Application\Library\ApiProblem\ApiProblem;
-use Application\Library\ApiProblem\ApiProblemException;
-use Application\Library\ApiProblem\ApiProblemResponse;
 use Application\Library\Authentication\Identity\Guest;
 use Application\Library\Authorization\UnauthorizedException;
 use Application\Model\Service\AbstractService;
 use Laminas\Authentication\AuthenticationService;
 use Laminas\Mvc\Controller\AbstractRestfulController;
-use Laminas\Mvc\MvcEvent;
 
 abstract class AbstractLpaController extends AbstractRestfulController
 {
@@ -21,11 +17,6 @@ abstract class AbstractLpaController extends AbstractRestfulController
      * @var string
      */
     protected $identifierName = 'lpaId';
-
-    /**
-     * @var string
-     */
-    protected $lpaId;
 
     /**
      * @var AuthenticationService
@@ -54,21 +45,6 @@ abstract class AbstractLpaController extends AbstractRestfulController
      * @return AbstractService
      */
     abstract protected function getService();
-
-    /**
-     * Execute the request
-     *
-     * @param MvcEvent $e
-     * @return mixed|ApiProblem|ApiProblemResponse
-     * @throws ApiProblemException
-     */
-    public function onDispatch(MvcEvent $e)
-    {
-        //  The lpaId MAY be present in the URL
-        $this->lpaId = $e->getRouteMatch()->getParam('lpaId');
-
-        return parent::onDispatch($e);
-    }
 
     /**
      * TODO - Move this code into the dispatch above? Need to make sure that the correct results are returned or thrown

--- a/service-api/module/Application/src/Controller/Version2/Lpa/CertificateProviderController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/CertificateProviderController.php
@@ -29,7 +29,7 @@ class CertificateProviderController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -49,7 +49,7 @@ class CertificateProviderController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->delete($this->lpaId);
+        $result = $this->getService()->delete($this->params()->fromRoute('lpaId'));
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/CorrespondentController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/CorrespondentController.php
@@ -29,7 +29,7 @@ class CorrespondentController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -49,7 +49,7 @@ class CorrespondentController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->delete($this->lpaId);
+        $result = $this->getService()->delete($this->params()->fromRoute('lpaId'));
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/DonorController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/DonorController.php
@@ -28,7 +28,7 @@ class DonorController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/InstructionController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/InstructionController.php
@@ -28,7 +28,7 @@ class InstructionController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/LockController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/LockController.php
@@ -27,7 +27,7 @@ class LockController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->create($this->lpaId);
+        $result = $this->getService()->create($this->params()->fromRoute('lpaId'));
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/NotifiedPeopleController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/NotifiedPeopleController.php
@@ -33,7 +33,7 @@ class NotifiedPeopleController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->create($this->lpaId, $data);
+        $result = $this->getService()->create($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -54,7 +54,7 @@ class NotifiedPeopleController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data, $id);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data, $id);
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -74,7 +74,7 @@ class NotifiedPeopleController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->delete($this->lpaId, $id);
+        $result = $this->getService()->delete($this->params()->fromRoute('lpaId'), $id);
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/PaymentController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/PaymentController.php
@@ -28,7 +28,7 @@ class PaymentController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/PdfController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/PdfController.php
@@ -41,7 +41,7 @@ class PdfController extends AbstractLpaController
             $traceId = $traceHeader instanceof \Laminas\Http\Header\HeaderInterface ? $traceHeader->getFieldValue() : '';
         }
 
-        $result = $this->getService()->fetch($this->lpaId, $id, $traceId);
+        $result = $this->getService()->fetch($this->params()->fromRoute('lpaId'), $id, $traceId);
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/PreferenceController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/PreferenceController.php
@@ -28,7 +28,7 @@ class PreferenceController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/PrimaryAttorneyController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/PrimaryAttorneyController.php
@@ -33,7 +33,7 @@ class PrimaryAttorneyController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->create($this->lpaId, $data);
+        $result = $this->getService()->create($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -54,7 +54,7 @@ class PrimaryAttorneyController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data, $id);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data, $id);
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -74,7 +74,7 @@ class PrimaryAttorneyController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->delete($this->lpaId, $id);
+        $result = $this->getService()->delete($this->params()->fromRoute('lpaId'), $id);
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/PrimaryAttorneyDecisionsController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/PrimaryAttorneyDecisionsController.php
@@ -28,7 +28,7 @@ class PrimaryAttorneyDecisionsController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/RepeatCaseNumberController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/RepeatCaseNumberController.php
@@ -29,7 +29,7 @@ class RepeatCaseNumberController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -49,7 +49,7 @@ class RepeatCaseNumberController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->delete($this->lpaId);
+        $result = $this->getService()->delete($this->params()->fromRoute('lpaId'));
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/ReplacementAttorneyController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/ReplacementAttorneyController.php
@@ -33,7 +33,7 @@ class ReplacementAttorneyController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->create($this->lpaId, $data);
+        $result = $this->getService()->create($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -54,7 +54,7 @@ class ReplacementAttorneyController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data, $id);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data, $id);
 
         if ($result instanceof ApiProblem) {
             return $result;
@@ -74,7 +74,7 @@ class ReplacementAttorneyController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->delete($this->lpaId, $id);
+        $result = $this->getService()->delete($this->params()->fromRoute('lpaId'), $id);
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/ReplacementAttorneyDecisionsController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/ReplacementAttorneyDecisionsController.php
@@ -28,7 +28,7 @@ class ReplacementAttorneyDecisionsController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/SeedController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/SeedController.php
@@ -29,7 +29,7 @@ class SeedController extends AbstractLpaController
         $this->checkAccess();
 
         $result = $this->getService()->fetch(
-            $this->lpaId,
+            $this->params()->fromRoute('lpaId'),
             $this->authenticationService->getIdentity()->getId()
         );
 
@@ -59,7 +59,7 @@ class SeedController extends AbstractLpaController
         $this->checkAccess();
 
         $result = $this->getService()->update(
-            $this->lpaId,
+            $this->params()->fromRoute('lpaId'),
             $data,
             $this->authenticationService->getIdentity()->getId()
         );

--- a/service-api/module/Application/src/Controller/Version2/Lpa/TypeController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/TypeController.php
@@ -28,7 +28,7 @@ class TypeController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/WhoAreYouController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/WhoAreYouController.php
@@ -28,7 +28,7 @@ class WhoAreYouController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;

--- a/service-api/module/Application/src/Controller/Version2/Lpa/WhoIsRegisteringController.php
+++ b/service-api/module/Application/src/Controller/Version2/Lpa/WhoIsRegisteringController.php
@@ -28,7 +28,7 @@ class WhoIsRegisteringController extends AbstractLpaController
     {
         $this->checkAccess();
 
-        $result = $this->getService()->update($this->lpaId, $data);
+        $result = $this->getService()->update($this->params()->fromRoute('lpaId'), $data);
 
         if ($result instanceof ApiProblem) {
             return $result;


### PR DESCRIPTION
## Purpose

Removes the last custom `onDispatch` method.

Fixes LPAL-2145 #patch

## Approach

Rather than attempting to fetch the LPA ID in a hidden onDispatch method on every action, fetch it from route parameters explicitly when it's actually needed.