### PR TITLE
LPAL-2427 - use boundaried ci roles for non product accounts

### DIFF
--- a/terraform/environment/.envrc
+++ b/terraform/environment/.envrc
@@ -1,7 +1,5 @@
 tfswitch
 export TF_VAR_default_role=operator
-export TF_VAR_boundaried_default_role=operator
-export TF_VAR_management_role=operator
 export TF_CLI_ARGS_init="-backend-config=\"assume_role={role_arn=\\\"arn:aws:iam::311462405659:role/operator\\\"}\" -upgrade -reconfigure"
 export TF_VAR_pagerduty_token=$(aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id pagerduty_api_key | jq -r .'SecretString')
 

--- a/terraform/environment/terraform.tf
+++ b/terraform/environment/terraform.tf
@@ -17,7 +17,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.boundaried_default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 
@@ -29,7 +29,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.boundaried_default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 
@@ -41,7 +41,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.boundaried_default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 
@@ -54,7 +54,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.boundaried_default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 
@@ -67,7 +67,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::311462405659:role/${var.management_role}"
+    role_arn     = "arn:aws:iam::311462405659:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }
@@ -79,7 +79,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::631181914621:role/${var.management_role}"
+    role_arn     = "arn:aws:iam::631181914621:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }
@@ -103,7 +103,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.boundaried_default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }
@@ -116,7 +116,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.boundaried_default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -5,21 +5,9 @@ variable "pagerduty_token" {
 }
 
 variable "default_role" {
-  default     = "opg-lpa-ci"
-  type        = string
-  description = "The default role to use to create resources"
-}
-
-variable "boundaried_default_role" {
   default     = "opg-lpa-ci-boundary"
   type        = string
   description = "The default role to use to create resources"
-}
-
-variable "management_role" {
-  default     = "opg-lpa-ci"
-  type        = string
-  description = "The default role to use to create resources in the management account"
 }
 
 variable "environments" {

--- a/terraform/region/.envrc
+++ b/terraform/region/.envrc
@@ -1,6 +1,5 @@
 tfswitch
 export TF_VAR_default_role=operator
-export TF_VAR_boundaried_default_role=operator
 export TF_CLI_ARGS_init="-backend-config=\"assume_role={role_arn=\\\"arn:aws:iam::311462405659:role/operator\\\"}\" -upgrade -reconfigure"
 export TF_WORKSPACE=development
 export TF_VAR_pagerduty_token=$(aws-vault exec moj-lpa-dev -- aws secretsmanager get-secret-value --secret-id pagerduty_api_key | jq -r .'SecretString')

--- a/terraform/region/terraform.tf
+++ b/terraform/region/terraform.tf
@@ -17,7 +17,7 @@ provider "aws" {
     tags = local.default_opg_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.boundaried_default_role}"
+    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }
@@ -29,7 +29,7 @@ provider "aws" {
     tags = local.default_opg_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.boundaried_default_role}"
+    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }
@@ -41,7 +41,7 @@ provider "aws" {
     tags = local.default_opg_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.boundaried_default_role}"
+    role_arn     = "arn:aws:iam::${local.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }

--- a/terraform/region/variables.tf
+++ b/terraform/region/variables.tf
@@ -1,11 +1,5 @@
 variable "default_role" {
   description = "default aws IAM role to use. defaults to the CI Role"
-  default     = "opg-lpa-ci"
-  type        = string
-}
-
-variable "boundaried_default_role" {
-  description = "default aws IAM role to use. defaults to the CI Role"
   default     = "opg-lpa-ci-boundary"
   type        = string
 }


### PR DESCRIPTION
## Purpose

Replace classic ci role with boundaried ci role in management, identity and backup accounts

Fixes LPAL-2427

## Approach

- refactor `boundaried_default_role` and `management_role` back into `default_role` with boundaried ci role name as the default value