### PR TITLE
remove unused output

### DIFF
--- a/terraform/environment/modules/environment/outputs.tf
+++ b/terraform/environment/modules/environment/outputs.tf
@@ -50,7 +50,3 @@ output "vpc_id" {
 output "app_subnet_ids" {
   value = [for subnet in data.aws_subnet.application : subnet.id]
 }
-
-output "mock_onelogin_loadbalancer" {
-  value = var.environment.feature_flags.onelogin_enabled ? module.mock_onelogin[0].load_balancer : null
-}


### PR DESCRIPTION
## Purpose

An invalid output caused the demo environment deployment to fail. The output isn't used and can be removed

## Approach

- remove unused output