### PR TITLE
LPAL-2408 ur environment only allow research participants to access the environment

### DIFF
--- a/terraform/environment/cognito_client.tf
+++ b/terraform/environment/cognito_client.tf
@@ -47,24 +47,24 @@ resource "aws_cognito_user_pool_client" "make_a_lasting_power_of_attorney_admin"
 
 # ur environment
 data "aws_cognito_user_pools" "make_a_lasting_power_of_attorney_front" {
-  count    = local.environment_name == "ur" ? 1 : 0
+  count    = local.environment.cognito.front_cognito_auth_enabled ? 1 : 0
   provider = aws.identity
   name     = "make-a-lasting-power-of-attorney-ur-front"
 }
 
 data "aws_ssm_parameter" "make_a_lasting_power_of_attorney_front_domain" {
-  count    = local.environment_name == "ur" ? 1 : 0
+  count    = local.environment.cognito.front_cognito_auth_enabled ? 1 : 0
   provider = aws.identity
   name     = "make_a_lasting_power_of_attorney_ur_front_domain"
 }
 
 locals {
-  front_cognito_user_pool_id          = local.environment_name == "ur" ? tolist(data.aws_cognito_user_pools.make_a_lasting_power_of_attorney_front[0].ids)[0] : ""
-  front_cognito_user_pool_domain_name = local.environment_name == "ur" ? "https://${data.aws_ssm_parameter.make_a_lasting_power_of_attorney_front_domain[0].value}.auth.eu-west-1.amazoncognito.com" : ""
+  front_cognito_user_pool_id          = local.environment.cognito.front_cognito_auth_enabled ? tolist(data.aws_cognito_user_pools.make_a_lasting_power_of_attorney_front[0].ids)[0] : ""
+  front_cognito_user_pool_domain_name = local.environment.cognito.front_cognito_auth_enabled ? "https://${data.aws_ssm_parameter.make_a_lasting_power_of_attorney_front_domain[0].value}.auth.eu-west-1.amazoncognito.com" : ""
 }
 
 resource "aws_cognito_user_pool_client" "make_a_lasting_power_of_attorney_front" {
-  count                                = local.environment_name == "ur" ? 1 : 0
+  count                                = local.environment.cognito.front_cognito_auth_enabled ? 1 : 0
   provider                             = aws.identity
   name                                 = "${local.environment_name}-front-auth"
   user_pool_id                         = local.front_cognito_user_pool_id

--- a/terraform/environment/cognito_client.tf
+++ b/terraform/environment/cognito_client.tf
@@ -44,3 +44,54 @@ resource "aws_cognito_user_pool_client" "make_a_lasting_power_of_attorney_admin"
   callback_urls = ["https://${module.environment_dns.admin_fqdn}/oauth2/idpresponse"]
   logout_urls   = ["https://${module.environment_dns.front_fqdn}/"]
 }
+
+# ur environment
+data "aws_cognito_user_pools" "make_a_lasting_power_of_attorney_front" {
+  count    = local.environment_name == "ur" ? 1 : 0
+  provider = aws.identity
+  name     = "make-a-lasting-power-of-attorney-ur-front"
+}
+
+data "aws_ssm_parameter" "make_a_lasting_power_of_attorney_front_domain" {
+  count    = local.environment_name == "ur" ? 1 : 0
+  provider = aws.identity
+  name     = "make_a_lasting_power_of_attorney_ur_front_domain"
+}
+
+locals {
+  front_cognito_user_pool_id          = local.environment_name == "ur" ? tolist(data.aws_cognito_user_pools.make_a_lasting_power_of_attorney_front[0].ids)[0] : ""
+  front_cognito_user_pool_domain_name = local.environment_name == "ur" ? "https://${data.aws_ssm_parameter.make_a_lasting_power_of_attorney_front_domain[0].value}.auth.eu-west-1.amazoncognito.com" : ""
+}
+
+resource "aws_cognito_user_pool_client" "make_a_lasting_power_of_attorney_front" {
+  count                                = local.environment_name == "ur" ? 1 : 0
+  provider                             = aws.identity
+  name                                 = "${local.environment_name}-front-auth"
+  user_pool_id                         = local.front_cognito_user_pool_id
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_scopes                 = ["openid"]
+  supported_identity_providers         = ["COGNITO"]
+  allowed_oauth_flows_user_pool_client = true
+  explicit_auth_flows = [
+    "ALLOW_CUSTOM_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+    "ALLOW_USER_SRP_AUTH",
+  ]
+
+  generate_secret = true
+
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "seconds"
+    refresh_token = "days"
+  }
+
+  access_token_validity  = 5
+  id_token_validity      = 3600
+  refresh_token_validity = 1
+  read_attributes        = []
+  write_attributes       = []
+
+  callback_urls = ["https://${module.environment_dns.front_fqdn}/oauth2/idpresponse"]
+  logout_urls   = ["https://${module.environment_dns.front_fqdn}/"]
+}

--- a/terraform/environment/main.tf
+++ b/terraform/environment/main.tf
@@ -13,12 +13,12 @@ module "eu-west-1" {
     user_pool_id_token_validity = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_admin.id_token_validity
   }
   front_cognito = {
-    enabled                     = local.environment_name == "ur" ? true : false
-    id                          = local.environment_name == "ur" ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id : ""
+    enabled                     = local.environment.cognito.front_cognito_auth_enabled && local.environment_name == "ur" ? true : false
+    id                          = local.environment.cognito.front_cognito_auth_enabled ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id : ""
     user_pool_id                = local.front_cognito_user_pool_id
     user_pool_domain_name       = local.front_cognito_user_pool_domain_name
-    user_pool_client_secret     = local.environment_name == "ur" ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].client_secret : ""
-    user_pool_id_token_validity = local.environment_name == "ur" ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id_token_validity : ""
+    user_pool_client_secret     = local.environment.cognito.front_cognito_auth_enabled ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].client_secret : ""
+    user_pool_id_token_validity = local.environment.cognito.front_cognito_auth_enabled ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id_token_validity : ""
   }
   ecs_execution_role = aws_iam_role.execution_role
   ecs_iam_task_roles = {
@@ -54,12 +54,12 @@ module "eu-west-2" {
     user_pool_id_token_validity = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_admin.id_token_validity
   }
   front_cognito = {
-    enabled                     = local.environment_name == "ur" ? true : false
-    id                          = local.environment_name == "ur" ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id : ""
+    enabled                     = local.environment.cognito.front_cognito_auth_enabled && local.environment_name == "ur" ? true : false
+    id                          = local.environment.cognito.front_cognito_auth_enabled ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id : ""
     user_pool_id                = local.front_cognito_user_pool_id
     user_pool_domain_name       = local.front_cognito_user_pool_domain_name
-    user_pool_client_secret     = local.environment_name == "ur" ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].client_secret : ""
-    user_pool_id_token_validity = local.environment_name == "ur" ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id_token_validity : ""
+    user_pool_client_secret     = local.environment.cognito.front_cognito_auth_enabled ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].client_secret : ""
+    user_pool_id_token_validity = local.environment.cognito.front_cognito_auth_enabled ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id_token_validity : ""
   }
   ecs_execution_role = aws_iam_role.execution_role
   ecs_iam_task_roles = {

--- a/terraform/environment/main.tf
+++ b/terraform/environment/main.tf
@@ -14,11 +14,11 @@ module "eu-west-1" {
   }
   front_cognito = {
     enabled                     = local.environment_name == "ur" ? true : false
-    id                          = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front.id
+    id                          = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id
     user_pool_id                = local.front_cognito_user_pool_id
     user_pool_domain_name       = local.front_cognito_user_pool_domain_name
-    user_pool_client_secret     = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front.client_secret
-    user_pool_id_token_validity = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front.id_token_validity
+    user_pool_client_secret     = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].client_secret
+    user_pool_id_token_validity = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id_token_validity
   }
   ecs_execution_role = aws_iam_role.execution_role
   ecs_iam_task_roles = {
@@ -55,11 +55,11 @@ module "eu-west-2" {
   }
   front_cognito = {
     enabled                     = local.environment_name == "ur" ? true : false
-    id                          = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front.id
+    id                          = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id
     user_pool_id                = local.front_cognito_user_pool_id
     user_pool_domain_name       = local.front_cognito_user_pool_domain_name
-    user_pool_client_secret     = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front.client_secret
-    user_pool_id_token_validity = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front.id_token_validity
+    user_pool_client_secret     = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].client_secret
+    user_pool_id_token_validity = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id_token_validity
   }
   ecs_execution_role = aws_iam_role.execution_role
   ecs_iam_task_roles = {

--- a/terraform/environment/main.tf
+++ b/terraform/environment/main.tf
@@ -12,6 +12,14 @@ module "eu-west-1" {
     user_pool_client_secret     = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_admin.client_secret
     user_pool_id_token_validity = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_admin.id_token_validity
   }
+  front_cognito = {
+    enabled                     = local.environment_name == "ur" ? true : false
+    id                          = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front.id
+    user_pool_id                = local.front_cognito_user_pool_id
+    user_pool_domain_name       = local.front_cognito_user_pool_domain_name
+    user_pool_client_secret     = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front.client_secret
+    user_pool_id_token_validity = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front.id_token_validity
+  }
   ecs_execution_role = aws_iam_role.execution_role
   ecs_iam_task_roles = {
     api               = aws_iam_role.api_task_role
@@ -44,6 +52,14 @@ module "eu-west-2" {
     user_pool_domain_name       = local.admin_cognito_user_pool_domain_name
     user_pool_client_secret     = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_admin.client_secret
     user_pool_id_token_validity = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_admin.id_token_validity
+  }
+  front_cognito = {
+    enabled                     = local.environment_name == "ur" ? true : false
+    id                          = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front.id
+    user_pool_id                = local.front_cognito_user_pool_id
+    user_pool_domain_name       = local.front_cognito_user_pool_domain_name
+    user_pool_client_secret     = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front.client_secret
+    user_pool_id_token_validity = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front.id_token_validity
   }
   ecs_execution_role = aws_iam_role.execution_role
   ecs_iam_task_roles = {

--- a/terraform/environment/main.tf
+++ b/terraform/environment/main.tf
@@ -14,11 +14,11 @@ module "eu-west-1" {
   }
   front_cognito = {
     enabled                     = local.environment_name == "ur" ? true : false
-    id                          = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id
+    id                          = local.environment_name == "ur" ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id : ""
     user_pool_id                = local.front_cognito_user_pool_id
     user_pool_domain_name       = local.front_cognito_user_pool_domain_name
-    user_pool_client_secret     = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].client_secret
-    user_pool_id_token_validity = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id_token_validity
+    user_pool_client_secret     = local.environment_name == "ur" ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].client_secret : ""
+    user_pool_id_token_validity = local.environment_name == "ur" ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id_token_validity : ""
   }
   ecs_execution_role = aws_iam_role.execution_role
   ecs_iam_task_roles = {
@@ -55,11 +55,11 @@ module "eu-west-2" {
   }
   front_cognito = {
     enabled                     = local.environment_name == "ur" ? true : false
-    id                          = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id
+    id                          = local.environment_name == "ur" ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id : ""
     user_pool_id                = local.front_cognito_user_pool_id
     user_pool_domain_name       = local.front_cognito_user_pool_domain_name
-    user_pool_client_secret     = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].client_secret
-    user_pool_id_token_validity = aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id_token_validity
+    user_pool_client_secret     = local.environment_name == "ur" ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].client_secret : ""
+    user_pool_id_token_validity = local.environment_name == "ur" ? aws_cognito_user_pool_client.make_a_lasting_power_of_attorney_front[0].id_token_validity : ""
   }
   ecs_execution_role = aws_iam_role.execution_role
   ecs_iam_task_roles = {

--- a/terraform/environment/modules/environment/load_balancer_front.tf
+++ b/terraform/environment/modules/environment/load_balancer_front.tf
@@ -120,7 +120,7 @@ resource "aws_security_group_rule" "front_loadbalancer_ingress" {
 #tfsec:ignore:aws-ec2-add-description-to-security-group - Adding description is destructive change needing downtime. to be revisited
 #tfsec:ignore:aws-ec2-no-public-ingress-sgr - public facing inbound rule
 resource "aws_security_group_rule" "front_loadbalancer_ingress_production" {
-  count             = var.environment_name == "production" ? 1 : 0
+  count             = var.environment.public_access_enabled ? 1 : 0
   type              = "ingress"
   from_port         = 443
   to_port           = 443

--- a/terraform/environment/modules/environment/load_balancer_front.tf
+++ b/terraform/environment/modules/environment/load_balancer_front.tf
@@ -45,7 +45,25 @@ resource "aws_lb_listener" "front_loadbalancer" {
   ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
 
   certificate_arn = data.aws_acm_certificate.certificate_front.arn
-
+  dynamic "default_action" {
+    for_each = var.front_cognito.enabled ? [1] : []
+    content {
+      type = "authenticate-oidc"
+      authenticate_oidc {
+        authentication_request_extra_params = {}
+        authorization_endpoint              = "${var.front_cognito.user_pool_domain_name}/oauth2/authorize"
+        client_id                           = var.front_cognito.id
+        client_secret                       = var.front_cognito.user_pool_client_secret
+        issuer                              = "https://cognito-idp.eu-west-1.amazonaws.com/${var.front_cognito.user_pool_id}"
+        on_unauthenticated_request          = "authenticate"
+        scope                               = "openid"
+        session_cookie_name                 = "AWSELBAuthSessionCookie"
+        session_timeout                     = var.front_cognito.user_pool_id_token_validity
+        token_endpoint                      = "${var.front_cognito.user_pool_domain_name}/oauth2/token"
+        user_info_endpoint                  = "${var.front_cognito.user_pool_domain_name}/oauth2/userInfo"
+      }
+    }
+  }
   default_action {
     target_group_arn = aws_lb_target_group.front.arn
     type             = "forward"

--- a/terraform/environment/modules/environment/variables.tf
+++ b/terraform/environment/modules/environment/variables.tf
@@ -14,6 +14,7 @@ variable "environment" {
     log_retention_in_days                  = number
     account_name_short                     = string
     associate_alb_with_waf_web_acl_enabled = bool
+    public_access_enabled                  = bool
     cognito = object({
       admin_cognito_auth_enabled = bool
     })

--- a/terraform/environment/modules/environment/variables.tf
+++ b/terraform/environment/modules/environment/variables.tf
@@ -151,6 +151,19 @@ variable "admin_cognito" {
   sensitive = true
 }
 
+variable "front_cognito" {
+  description = "Settings for the AWS Cognito to use for the admin interface."
+  type = object({
+    enabled                     = bool
+    id                          = string
+    user_pool_id                = string
+    user_pool_domain_name       = string
+    user_pool_client_secret     = string
+    user_pool_id_token_validity = string
+  })
+  sensitive = true
+}
+
 variable "tags" {
   type = object({
     business-unit          = string

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -22,7 +22,8 @@
         "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_non_production_admin_domain",
         "admin_cognito_client_supported_identity_providers": [
           "COGNITO"
-        ]
+        ],
+        "front_cognito_auth_enabled": false
       },
       "onelogin_client_id": "theClientId",
       "feature_flags": {
@@ -103,7 +104,8 @@
         "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_non_production_admin_domain",
         "admin_cognito_client_supported_identity_providers": [
           "COGNITO"
-        ]
+        ],
+        "front_cognito_auth_enabled": false
       },
       "onelogin_client_id": "14MNCO6niDuXKsvEzAAZlwShFnA",
       "feature_flags": {
@@ -184,7 +186,8 @@
         "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_non_production_admin_domain",
         "admin_cognito_client_supported_identity_providers": [
           "COGNITO"
-        ]
+        ],
+        "front_cognito_auth_enabled": false
       },
       "onelogin_client_id": "theClientId",
       "feature_flags": {
@@ -265,7 +268,8 @@
         "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_admin_domain",
         "admin_cognito_client_supported_identity_providers": [
           "EntraID"
-        ]
+        ],
+        "front_cognito_auth_enabled": false
       },
       "onelogin_client_id": "theClientId",
       "feature_flags": {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -16,6 +16,7 @@
       "log_retention_in_days": 7,
       "account_name_short": "dev",
       "associate_alb_with_waf_web_acl_enabled": true,
+      "public_access_enabled": false,
       "cognito": {
         "admin_cognito_auth_enabled": true,
         "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-non-production-admin",
@@ -98,6 +99,7 @@
       "log_retention_in_days": 7,
       "account_name_short": "dev",
       "associate_alb_with_waf_web_acl_enabled": true,
+      "public_access_enabled": false,
       "cognito": {
         "admin_cognito_auth_enabled": true,
         "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-non-production-admin",
@@ -180,6 +182,7 @@
       "log_retention_in_days": 7,
       "account_name_short": "dev",
       "associate_alb_with_waf_web_acl_enabled": true,
+      "public_access_enabled": false,
       "cognito": {
         "admin_cognito_auth_enabled": true,
         "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-non-production-admin",
@@ -262,6 +265,7 @@
       "log_retention_in_days": 7,
       "account_name_short": "pre",
       "associate_alb_with_waf_web_acl_enabled": true,
+      "public_access_enabled": false,
       "cognito": {
         "admin_cognito_auth_enabled": true,
         "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-non-production-admin",
@@ -344,6 +348,7 @@
       "log_retention_in_days": 120,
       "account_name_short": "prod",
       "associate_alb_with_waf_web_acl_enabled": true,
+      "public_access_enabled": true,
       "cognito": {
         "admin_cognito_auth_enabled": true,
         "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-admin",

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -164,6 +164,88 @@
         }
       }
     },
+    "ur": {
+      "dr_enabled": false,
+      "performance_platform_enabled": true,
+      "always_on": false,
+      "pagerduty_service_name": "Make a Lasting Power of Attorney Non-Production",
+      "account_id": "050256574573",
+      "account_name": "development",
+      "is_production": "false",
+      "sirius_api_gateway_endpoint": "https://demo.dev.lpa.api.opg.service.justice.gov.uk/v1/lpa-online-tool/lpas/",
+      "sirius_api_gateway_arn": "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/lpa-online-tool/*",
+      "sirius_api_healthcheck_arn": "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/healthcheck",
+      "telemetry_requests_sampled_fraction": "1.0",
+      "auth_token_ttl_secs": 4500,
+      "log_retention_in_days": 7,
+      "account_name_short": "dev",
+      "associate_alb_with_waf_web_acl_enabled": true,
+      "cognito": {
+        "admin_cognito_auth_enabled": true,
+        "admin_cognito_user_pool_name": "make-a-lasting-power-of-attorney-non-production-admin",
+        "admin_cognito_user_pool_domain_name": "make_a_lasting_power_of_attorney_non_production_admin_domain",
+        "admin_cognito_client_supported_identity_providers": [
+          "COGNITO"
+        ],
+        "front_cognito_auth_enabled": true
+      },
+      "onelogin_client_id": "14MNCO6niDuXKsvEzAAZlwShFnA",
+      "feature_flags": {
+        "onelogin_enabled": true,
+        "onelogin_use_mock": false,
+        "shared_spaces_enabled": true,
+        "cypress_fixtures_enabled": true
+      },
+      "database": {
+        "cluster_identifier": "api2",
+        "aurora_cross_region_backup_enabled": false,
+        "cross_account_backup_enabled": false,
+        "aurora_restore_testing_enabled": false,
+        "enable_backup_vault_lock":  false,
+        "daily_backup_deletion": 1,
+        "daily_backup_cold_storage": 0,
+        "monthly_backup_deletion": 0,
+        "monthly_backup_cold_storage": 0,
+        "aurora_enabled": true,
+        "aurora_instance_count": 1,
+        "aurora_serverless": true,
+        "deletion_protection": false,
+        "psql_engine_version": "14",
+        "psql_parameter_group_family": "postgres14",
+        "rds_instance_type": "db.t3.small",
+        "skip_final_snapshot": true
+      },
+      "autoscaling": {
+        "front": {
+          "minimum": 1,
+          "maximum": 5
+        },
+        "api": {
+          "minimum": 1,
+          "maximum": 5
+        },
+        "pdf": {
+          "minimum": 1,
+          "maximum": 5
+        },
+        "admin": {
+          "minimum": 1,
+          "maximum": 5
+        }
+      },
+      "regions": {
+        "eu-west-1": {
+          "region": "eu-west-1",
+          "enabled": true,
+          "is_primary": true
+        },
+        "eu-west-2": {
+          "region": "eu-west-2",
+          "enabled": false,
+          "is_primary": false
+        }
+      }
+    },
     "preproduction": {
       "dr_enabled": false,
       "performance_platform_enabled": false,

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -32,6 +32,7 @@ variable "environments" {
         admin_cognito_user_pool_name                      = string
         admin_cognito_user_pool_domain_name               = string
         admin_cognito_client_supported_identity_providers = list(string)
+        front_cognito_auth_enabled                        = bool
       })
       onelogin_client_id = string
       feature_flags = object({

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -27,6 +27,7 @@ variable "environments" {
       log_retention_in_days                  = number
       account_name_short                     = string
       associate_alb_with_waf_web_acl_enabled = bool
+      public_access_enabled                  = bool
       cognito = object({
         admin_cognito_auth_enabled                        = bool
         admin_cognito_user_pool_name                      = string


### PR DESCRIPTION
## Purpose

Require a login to access the ur environment (like basic auth)

Fixes LPAL-2408

## Approach

- define a ur environment
- add cognito client for ur environment front loadbalancer access
- require oidc authentication on front loadbalancer in the ur environment
- allow ur to be publicly accessible

When a user requests the ur environment, they will be prompted for a username and password. This will allow them to reach the home page.

Sessions will last an hour

Double checked and this doesn't impact production's availability
