### PR TITLE
LPAL-2436 | adding readonlyrootfilesystem to OTEL collector shared container definitions

### DIFF
--- a/terraform/environment/modules/environment/locals.tf
+++ b/terraform/environment/modules/environment/locals.tf
@@ -48,11 +48,12 @@ locals {
 
   aws_otel_collector = jsonencode(
     {
-      cpu         = 0,
-      essential   = true,
-      image       = "311462405659.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.48.0",
-      mountPoints = [],
-      name        = "aws-otel-collector",
+      cpu                    = 0,
+      essential              = true,
+      image                  = "311462405659.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/aws-otel-collector-public-ecr/aws-observability/aws-otel-collector:v0.48.0",
+      mountPoints            = [],
+      name                   = "aws-otel-collector",
+      readonlyRootFilesystem = true,
       command = [
         "--config=/etc/ecs/ecs-default-config.yaml"
       ],


### PR DESCRIPTION

## Purpose

Security hub finding failure due to OTEL collector not being compliant with readonlyrootfilestsystem config set to true. 

Fixes LPAL-2436

## Approach

Enabled on shared OTEL collector container definitions in locals - used by all services that require otel collector 

## Learning
<img width="734" height="382" alt="Screenshot 2026-09-08 at 15 37 52" src="https://github.com/user-attachments/assets/af86c8f0-434c-44b5-b822-d0505af6425b" />


_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the LPA service_
