### PR TITLE
LPAL-2409 - exclude the 4th london az from use when deploying aurora

### DIFF
--- a/terraform/environment/modules/environment/rds.tf
+++ b/terraform/environment/modules/environment/rds.tf
@@ -1,9 +1,7 @@
 data "aws_kms_key" "aurora_new_key" {
   key_id = "alias/opg-lpa-${var.account_name}-rds-encryption-key"
 }
-locals {
-  kms_key_id = data.aws_kms_key.aurora_new_key.arn
-}
+
 locals {
   psql_parameter_group_family_list = [
     "postgres13",
@@ -20,12 +18,13 @@ data "aws_rds_cluster_parameter_group" "postgresql_aurora_params" {
 }
 
 module "api_aurora" {
-  auto_minor_version_upgrade      = true
-  source                          = "./modules/aurora"
-  count                           = 1
-  aurora_serverless               = var.environment.database.aurora_serverless
-  account_id                      = data.aws_caller_identity.current.account_id
-  availability_zones              = data.aws_availability_zones.aws_zones.names
+  auto_minor_version_upgrade = true
+  source                     = "./modules/aurora"
+  count                      = 1
+  aurora_serverless          = var.environment.database.aurora_serverless
+  account_id                 = data.aws_caller_identity.current.account_id
+  availability_zones         = [for az in data.aws_availability_zones.aws_zones.names : az if az != "eu-west-2d"]
+  # availability_zones              = data.aws_availability_zones.aws_zones.names
   apply_immediately               = !var.environment.database.deletion_protection
   cluster_identifier              = var.environment.database.cluster_identifier
   db_subnet_group_name            = "data"
@@ -37,7 +36,7 @@ module "api_aurora" {
   master_password                 = data.aws_secretsmanager_secret_version.api_rds_password.secret_string
   instance_count                  = var.environment.database.aurora_instance_count
   instance_class                  = "db.t3.medium"
-  kms_key_id                      = local.kms_key_id
+  kms_key_id                      = data.aws_kms_key.aurora_new_key.arn
   replication_source_identifier   = ""
   skip_final_snapshot             = !var.environment.database.deletion_protection
   vpc_security_group_ids          = [aws_security_group.rds_api.id]


### PR DESCRIPTION
## Purpose

Don't use the 4th availability zone in London for Aurora

Fixes LPAL-2409

## Approach

- exclude the 4th london az from use when deploying aurora