### PR TITLE
LPAL-2488 - ur environment should use mock onelogin

### DIFF
--- a/terraform/environment/modules/environment/rds.tf
+++ b/terraform/environment/modules/environment/rds.tf
@@ -18,13 +18,12 @@ data "aws_rds_cluster_parameter_group" "postgresql_aurora_params" {
 }
 
 module "api_aurora" {
-  auto_minor_version_upgrade = true
-  source                     = "./modules/aurora"
-  count                      = 1
-  aurora_serverless          = var.environment.database.aurora_serverless
-  account_id                 = data.aws_caller_identity.current.account_id
-  availability_zones         = [for az in data.aws_availability_zones.aws_zones.names : az if az != "eu-west-2d"]
-  # availability_zones              = data.aws_availability_zones.aws_zones.names
+  auto_minor_version_upgrade      = true
+  source                          = "./modules/aurora"
+  count                           = 1
+  aurora_serverless               = var.environment.database.aurora_serverless
+  account_id                      = data.aws_caller_identity.current.account_id
+  availability_zones              = [for az in data.aws_availability_zones.aws_zones.names : az if az != "eu-west-2d"]
   apply_immediately               = !var.environment.database.deletion_protection
   cluster_identifier              = var.environment.database.cluster_identifier
   db_subnet_group_name            = "data"

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -195,7 +195,7 @@
       "onelogin_client_id": "14MNCO6niDuXKsvEzAAZlwShFnA",
       "feature_flags": {
         "onelogin_enabled": true,
-        "onelogin_use_mock": false,
+        "onelogin_use_mock": true,
         "shared_spaces_enabled": true,
         "cypress_fixtures_enabled": true
       },


### PR DESCRIPTION
## Purpose

Use mock onelogin for user research instead of the integration environment

Fixes LPAL-2488

## Approach

- set `onelogin_use_mock` to `true`