### PR TITLE
LPAL-2428 - add nginx healthcheck

### DIFF
--- a/service-admin/docker/web/Dockerfile
+++ b/service-admin/docker/web/Dockerfile
@@ -14,7 +14,7 @@ RUN npm run build
 FROM nginx:1.31.3-alpine3.24@sha256:818f487daa916d5bad276afac9ec1b219cdad6fd3901c39aee0efaf150b14606
 
 # Remove unused packages
-RUN apk del freetype nginx-module-image-filter curl
+RUN apk del freetype nginx-module-image-filter
 
 # Upgrade vulnerable packages
 RUN apk upgrade --no-cache

--- a/service-admin/docker/web/etc/nginx/templates/default.conf.template
+++ b/service-admin/docker/web/etc/nginx/templates/default.conf.template
@@ -70,6 +70,11 @@ server {
     add_header X-Content-Type-Options "nosniff";
     add_header Strict-Transport-Security "max-age=3600; includeSubDomains";
 
+    # Simple health check for nginx containers
+    location /nginx-health {
+        access_log /dev/null;
+        return 200 "healthy\n";
+    }
 
     location / {
         try_files $uri /index.php$is_args$args;

--- a/service-api/docker/web/Dockerfile
+++ b/service-api/docker/web/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx:1.31.3-alpine3.24@sha256:818f487daa916d5bad276afac9ec1b219cdad6fd3901c39aee0efaf150b14606
 
 # Remove unused packages
-RUN apk del freetype nginx-module-image-filter curl
+RUN apk del freetype nginx-module-image-filter
 
 # Upgrade vulnerable packages
 RUN apk upgrade --no-cache

--- a/service-api/docker/web/Dockerfile
+++ b/service-api/docker/web/Dockerfile
@@ -7,6 +7,7 @@ RUN apk del freetype nginx-module-image-filter
 RUN apk upgrade --no-cache
 
 RUN chown -R nginx:nginx /etc/nginx/conf.d
+RUN exec 3<>/dev/tcp/localhost/8080/nginx-health
 
 USER nginx
 COPY --chown=nginx:nginx service-api/docker/web/etc /etc

--- a/service-api/docker/web/Dockerfile
+++ b/service-api/docker/web/Dockerfile
@@ -7,7 +7,6 @@ RUN apk del freetype nginx-module-image-filter
 RUN apk upgrade --no-cache
 
 RUN chown -R nginx:nginx /etc/nginx/conf.d
-RUN exec 3<>/dev/tcp/localhost/8080/nginx-health
 
 USER nginx
 COPY --chown=nginx:nginx service-api/docker/web/etc /etc

--- a/service-api/docker/web/etc/nginx/templates/default.conf.template
+++ b/service-api/docker/web/etc/nginx/templates/default.conf.template
@@ -65,6 +65,11 @@ server {
     add_header X-Content-Type-Options "nosniff";
     add_header Strict-Transport-Security "max-age=3600; includeSubDomains";
 
+    # Simple health check for nginx containers
+    location /nginx-health {
+        access_log /dev/null;
+        return 200 "healthy\n";
+    }
 
     location / {
         try_files $uri /index.php$is_args$args;

--- a/service-front/docker/web/Dockerfile
+++ b/service-front/docker/web/Dockerfile
@@ -1,7 +1,8 @@
 FROM nginx:1.31.3-alpine3.24@sha256:818f487daa916d5bad276afac9ec1b219cdad6fd3901c39aee0efaf150b14606
 
 # Remove unused packages
-RUN apk del freetype nginx-module-image-filter curl
+# RUN apk del freetype nginx-module-image-filter curl
+RUN apk del freetype nginx-module-image-filter
 
 # Upgrade vulnerable packages
 RUN apk upgrade --no-cache

--- a/service-front/docker/web/etc/nginx/templates/default.conf.template
+++ b/service-front/docker/web/etc/nginx/templates/default.conf.template
@@ -116,6 +116,12 @@ server {
     add_header Strict-Transport-Security $sts;
     add_header Referrer-Policy $rp;
 
+    # Simple health check for nginx containers
+    location /nginx-health {
+        access_log /dev/null;
+        return 200 "healthy\n";
+    }
+
     # block potentially sensitive files in case they were accidentally added to web root
     # using a 403 to match status returned by WAF for bad filenames
     location ~ "^/.*\.(zip|gz|lzh|tar|rar|7z|swp|bak|git|ht|exe|dll|py|msi|bin|sh|bat|xml|apk|jar|log|sql|conf|cfg|ini|tmp|doc|xls|rtf)" {

--- a/terraform/environment/modules/environment/ecs_admin.tf
+++ b/terraform/environment/modules/environment/ecs_admin.tf
@@ -169,6 +169,13 @@ locals {
           }
         ]
       },
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:8080/nginx-health || exit 1"],
+        startPeriod = 30,
+        interval    = 15,
+        timeout     = 10,
+        retries     = 3
+      },
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_api.tf
+++ b/terraform/environment/modules/environment/ecs_api.tf
@@ -222,6 +222,13 @@ locals {
           },
         ]
       },
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:8080/nginx-health || exit 1"],
+        startPeriod = 30,
+        interval    = 15,
+        timeout     = 10,
+        retries     = 3
+      },
       logConfiguration = {
         logDriver = "awslogs",
         options = {

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -178,6 +178,13 @@ locals {
         },
       ]
     },
+    healthCheck = {
+      command     = ["CMD-SHELL", "curl -f http://localhost/nginx-health || exit 1"],
+      startPeriod = 30,
+      interval    = 15,
+      timeout     = 10,
+      retries     = 3
+    },
     logConfiguration = {
       logDriver = "awslogs",
       options = {

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -178,13 +178,13 @@ locals {
         },
       ]
     },
-    # healthCheck = {
-    #   command     = ["CMD-SHELL", "curl -f http://localhost:8080/nginx-health || exit 1"],
-    #   startPeriod = 30,
-    #   interval    = 15,
-    #   timeout     = 10,
-    #   retries     = 3
-    # },
+    healthCheck = {
+      command     = ["CMD-SHELL", "curl -f http://localhost:8080/nginx-health || exit 1"],
+      startPeriod = 30,
+      interval    = 15,
+      timeout     = 10,
+      retries     = 3
+    },
     logConfiguration = {
       logDriver = "awslogs",
       options = {

--- a/terraform/environment/modules/environment/ecs_front.tf
+++ b/terraform/environment/modules/environment/ecs_front.tf
@@ -37,8 +37,8 @@ resource "aws_ecs_service" "front" {
   }
 
   timeouts {
-    create = var.environment_name == "production" ? "20m" : "10m"
-    update = var.environment_name == "production" ? "20m" : "6m"
+    create = var.environment_name == "production" ? "20m" : "4m"
+    update = var.environment_name == "production" ? "20m" : "4m"
   }
 
   depends_on = [aws_lb.front]
@@ -178,13 +178,13 @@ locals {
         },
       ]
     },
-    healthCheck = {
-      command     = ["CMD-SHELL", "curl -f http://localhost/nginx-health || exit 1"],
-      startPeriod = 30,
-      interval    = 15,
-      timeout     = 10,
-      retries     = 3
-    },
+    # healthCheck = {
+    #   command     = ["CMD-SHELL", "curl -f http://localhost:8080/nginx-health || exit 1"],
+    #   startPeriod = 30,
+    #   interval    = 15,
+    #   timeout     = 10,
+    #   retries     = 3
+    # },
     logConfiguration = {
       logDriver = "awslogs",
       options = {


### PR DESCRIPTION
## Purpose

Ensure that the Nginx web container is ready before it starts serving requests

Fixes LPAL-2428

## Approach

- add a health check response to the nginx configuration
- set up the front-web ecs task to have a healthcheck
- add curl to the web container (or rather, stop removing curl from the container)

## Learning

based on opg-sirius and opg-sirius-infratructure
- https://github.com/ministryofjustice/opg-sirius-infrastructure/blob/f7549c3c14fbdd62f86f5d054734e34b8f1030e2/environment/modules/environment/api.tf#L182
- https://github.com/ministryofjustice/opg-sirius/blob/d0fc9b71684256069acf932f7958fb3c024a7e83/nginx/default.conf.template#L20
