### PR TITLE
Handle failed routes in CheckMemberStatusMiddleware

### DIFF
--- a/service-front/src/App/src/Middleware/CheckMemberStatusMiddleware.php
+++ b/service-front/src/App/src/Middleware/CheckMemberStatusMiddleware.php
@@ -46,6 +46,10 @@ class CheckMemberStatusMiddleware implements MiddlewareInterface
     private function inactiveSharedSpaceName(ServerRequestInterface $request): ?string
     {
         $routeName = $request->getAttribute(RouteResult::class)->getMatchedRouteName();
+        if (!$routeName) {
+            return null;
+        }
+
         if ($routeName !== 'shared-space' && !str_starts_with($routeName, 'shared-space.')) {
             return null;
         }

--- a/service-front/test/AppTest/Middleware/CheckMemberStatusMiddlewareTest.php
+++ b/service-front/test/AppTest/Middleware/CheckMemberStatusMiddlewareTest.php
@@ -84,6 +84,19 @@ class CheckMemberStatusMiddlewareTest extends TestCase
         $this->assertInstanceOf(HtmlResponse::class, $result);
     }
 
+    public function testProcessWhenNoRoute(): void
+    {
+        $identity = new User('1', '', 1, new DateTime(), sharedSpaceId: "1");
+        $routeResult = RouteResult::fromRouteFailure([]);
+
+        $request = new ServerRequest()
+            ->withAttribute(User::class, $identity)
+            ->withAttribute(RouteResult::class, $routeResult);
+
+        $result = $this->middleware->process($request, $this->handler());
+        $this->assertSame($this->emptyResponse, $result);
+    }
+
     #[DataProvider('nonSharedSpaceRouteProvider')]
     public function testProcessWhenNonMatchingRoute(string $routeName): void
     {


### PR DESCRIPTION
This means random URLs will return 404s instead of 500s.
