### PR TITLE
use boundaried ci role for workspace cleanup

### DIFF
--- a/.github/workflows/workflow_terraform_environment_cleanup.yml
+++ b/.github/workflows/workflow_terraform_environment_cleanup.yml
@@ -62,4 +62,4 @@ jobs:
         env:
           TF_VAR_pagerduty_token: ${{ secrets.PAGERDUTY_TOKEN }}
         run: |
-          ../../scripts/pipeline/workspace_cleanup/workspace_cleanup.sh $(terraform-workspace-manager -protected-workspaces=true -aws-account-id=050256574573 -aws-iam-role=opg-lpa-ci)
+          ../../scripts/pipeline/workspace_cleanup/workspace_cleanup.sh $(terraform-workspace-manager -protected-workspaces=true -aws-account-id=050256574573 -aws-iam-role=opg-lpa-ci-boundary)


### PR DESCRIPTION
## Purpose

Cleanup jobs has been failing for a little while since the removal of the old ci role.

## Approach

- use correct boundaried ci role for workspace cleanup script